### PR TITLE
docs: replace git clone with curl in Docker Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,10 @@ See [docs/relations.md](./docs/relations.md) for the relation taxonomy.
 Docker is the canonical install path. The image bundles Node 22 and the native modules (`better-sqlite3`, `sqlite-vec`) pre-built for `linux/amd64` and `linux/arm64`, so the only requirement on your host is Docker.
 
 ```bash
-git clone https://github.com/susomejias/rembric.git && cd rembric
+mkdir rembric && cd rembric
+curl -fsSLO https://raw.githubusercontent.com/susomejias/rembric/main/docker-compose.yml
+curl -fsSL  https://raw.githubusercontent.com/susomejias/rembric/main/.env.example -o .env
 
-cp .env.example .env
 # edit .env:  set REMBRIC_ADMIN_TOKEN (e.g. `openssl rand -hex 32`)
 #             confirm OPENAI_BASE_URL / OPENAI_API_KEY / OPENAI_MODEL
 


### PR DESCRIPTION
## Summary

Replace `git clone … && cd rembric` in the Docker Quickstart with two `curl` calls that fetch `docker-compose.yml` and `.env.example` from `raw.githubusercontent.com/.../main/`. Operators no longer pull the whole repo (and its history) just to run the image, and the canonical files stay the single source of truth — README doesn't duplicate their contents, so they can't drift.

## OpenSpec change

- Change name: N/A — docs only

## Test plan

- [ ] Visual: read the updated Quickstart in the rendered README on this PR.
- [ ] Manual smoke: in an empty dir, run the three new commands (`mkdir`, two `curl`s) against this branch's raw URLs and confirm both files land with the expected contents.
- [ ] `docker compose up -d` from that dir still boots the container against the fetched compose file.

## Checklist

- [x] Commit messages follow Conventional Commits (`docs:`).
- [x] Changes are scoped: one conceptual change per PR.
- [x] No new tests required — docs-only change.
- [x] No new dependency added.
- [x] `plugin/` not touched.
- [x] No tokens, API keys, private hostnames, LAN IPs, or maintainer home-directory paths committed.