### PR TITLE
fix(release-please): one PR per component + revert opencode bump

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,5 +3,5 @@
   "apps/plugin/.claude-plugin": "0.9.0",
   "apps/plugin/.codex-plugin": "0.9.0",
   "apps/plugin/.hermes-plugin": "0.9.0",
-  "apps/plugin/.opencode-plugin": "0.9.0"
+  "apps/plugin/.opencode-plugin": "0.8.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "separate-pull-requests": true,
   "packages": {
     "apps/server": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

Two related fixes after PR #62's first multi-component release produced a single bloated `server-v0.18.0` release whose body contained the concatenated changelogs of all five components, and tagged only the server.

- **Add `separate-pull-requests: true`** to `release-please-config.json`. From the next release cycle, release-please opens one PR per component with changes. Each merge cuts its own tag and a focused release body. Trade-off: more PRs in cycles that touch multiple components, but every release is clean and the docker-publish gate stays accurate.
- **Revert `apps/plugin/.opencode-plugin` to `0.8.0`** in `.release-please-manifest.json`. The aggregated run wrote `0.9.0` to the manifest but never updated `apps/plugin/.opencode-plugin/plugin.ts` (still at `// @rembric-plugin-version 0.8.0`) and never minted `opencode-plugin-v0.9.0`. Re-aligning the manifest with the file keeps release-please's internal state honest; the next opencode-plugin-scoped change will produce a real 0.9.0 release via the separate-PR flow.

## Test plan

- [x] `pnpm run typecheck` clean (hook ran on commit).
- [ ] After merge, observe that the next conventional commit touching a single component (e.g. `fix(plugin-hermes): ...`) opens **one** release-please PR scoped to that component only.
- [ ] Verify the docker-publish gate still fires only on `server`-component releases.

## Companion cleanup (handled separately by the operator, not in this PR)

- Edit the body of the existing `server-v0.18.0` GitHub Release to keep only the server section.
- Mint the three missing plugin tags+releases (`claude-code-plugin-v0.9.0`, `codex-plugin-v0.9.0`, `hermes-plugin-v0.9.0`) at commit `bda35bf` with clean per-component bodies. Those plugins are already at `0.9.0` in their manifest files; only the GitHub tag+release surfaces are missing.