### PR TITLE
fix(docker): use pnpm deploy for runtime image to resolve workspace deps

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -30,18 +30,13 @@ COPY apps/server ./apps/server
 
 # Build inside the server workspace.
 WORKDIR /app/apps/server
-
-# --ignore-scripts is redundant given .npmrc, kept as defense in depth.
-# The explicit `pnpm rebuild` below runs the postinstall for the
-# allowlisted native modules (better-sqlite3, sqlite-vec) under the controlled
-# allowlist in pnpm-workspace.yaml.
 RUN pnpm run build
 
+# pnpm deploy ships a flat node_modules to /prod-out (no symlinks into the workspace store).
 WORKDIR /app
-
-RUN rm -rf node_modules apps/server/node_modules \
-    && pnpm install --frozen-lockfile --prod --ignore-scripts --filter @rembric/server... \
-    && pnpm rebuild --filter @rembric/server better-sqlite3 sqlite-vec
+RUN pnpm deploy --filter=@rembric/server --prod --legacy /prod-out \
+    && cd /prod-out \
+    && pnpm rebuild better-sqlite3 sqlite-vec
 
 
 FROM node:22-bookworm-slim AS dev
@@ -94,9 +89,9 @@ RUN useradd -r -u 10001 -m rembric
 
 WORKDIR /app
 
-COPY --from=builder --chown=rembric:rembric /app/apps/server/dist          ./dist
-COPY --from=builder --chown=rembric:rembric /app/apps/server/node_modules  ./node_modules
-COPY --from=builder --chown=rembric:rembric /app/apps/server/package.json  ./
+COPY --from=builder --chown=rembric:rembric /prod-out/dist          ./dist
+COPY --from=builder --chown=rembric:rembric /prod-out/node_modules  ./node_modules
+COPY --from=builder --chown=rembric:rembric /prod-out/package.json  ./
 
 USER rembric
 


### PR DESCRIPTION
## Summary
- After the `apps/+packages` restructure (#62), the runtime stage copied `/app/apps/server/node_modules`, whose entries are symlinks into the workspace pnpm store at `/app/node_modules/.pnpm/`. The root `node_modules` was never copied, so every symlink was dead in the published image and the container crash-looped with `ERR_MODULE_NOT_FOUND: Cannot find package 'drizzle-orm'`.
- Replace the manual prod-install + `node_modules` copy with `pnpm deploy --legacy /prod-out`, which produces a flat, self-contained `node_modules` outside the workspace. The runtime stage now ships from `/prod-out`.
- Native modules (`better-sqlite3`, `sqlite-vec`) are rebuilt explicitly inside `/prod-out` since `.npmrc::ignore-scripts=true` blocks postinstall.

## Test plan
- [x] `docker build -t rembric:fix-test -f apps/server/Dockerfile --target runtime .` succeeds.
- [x] `docker run --rm rembric:fix-test` reaches the config validator (Zod) instead of crashing on module resolution — the entire bootstrap import chain (`drizzle-orm`, `hono`, `better-sqlite3`, `sqlite-vec`, `@modelcontextprotocol/sdk`, …) resolves.
- [x] Once merged: `docker-publish.yml` republishes `ghcr.io/susomejias/rembric:latest`; verify on the selfhost box with `docker compose pull && docker compose up -d`.