### PR TITLE
feat(sessions): filter empty sessions from memory.context recentSessions

### DIFF
--- a/apps/server/src/services/agent-sessions.test.ts
+++ b/apps/server/src/services/agent-sessions.test.ts
@@ -425,5 +425,134 @@ describe('AgentSessionsService', () => {
         /adminBypass:true required/,
       );
     });
+
+    it('preserves byte-identical behavior after the predicate refactor (3-fixture parity)', () => {
+      const empty = sessions.start({ tokenId, projectId, agent: 'empty' });
+      endAndBackdate(empty.id, 2 * 60 * 60 * 1000);
+
+      const withMemory = sessions.start({ tokenId, projectId, agent: 'with-memory' });
+      db.handle.raw
+        .prepare(
+          `INSERT INTO memory (id, scope, project_id, type, content, status, replaces, created_at, session_id)
+           VALUES (?, 'project', ?, 'user', 'x', 'active', '[]', ?, ?)`,
+        )
+        .run('mem-parity-test-001', projectId, Date.now(), withMemory.id);
+      endAndBackdate(withMemory.id, 2 * 60 * 60 * 1000);
+
+      const withSummary = sessions.start({ tokenId, projectId, agent: 'with-summary' });
+      sessions.summarize(withSummary.id, { tokenId, summary: 'did the thing' });
+      db.handle.raw
+        .prepare('UPDATE sessions SET ended_at = ? WHERE id = ?')
+        .run(Date.now() - 2 * 60 * 60 * 1000, withSummary.id);
+
+      expect(sessions.countPurgeableEmpty()).toBe(1);
+
+      const result = sessions.purgeEmpty({ adminBypass: true });
+      expect(result.deletedIds).toEqual([empty.id]);
+      expect(sessions.getById(empty.id)).toBeUndefined();
+      expect(sessions.getById(withMemory.id)).toBeDefined();
+      expect(sessions.getById(withSummary.id)).toBeDefined();
+    });
+  });
+
+  describe('recentForContext content filter (sessionHasContent predicate)', () => {
+    function newSessionId(suffix: string): string {
+      return `sess-content-${suffix}-${Date.now()}`;
+    }
+
+    it('excludes an empty active session with no anchored content', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'empty-active' });
+      const recent = sessions.recentForContext({ projectId, limit: 25 });
+      expect(recent.some((r) => r.id === s.id)).toBe(false);
+    });
+
+    it('includes a session that has a summary written', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'has-summary' });
+      sessions.summarize(s.id, { tokenId, summary: 'goal: x' });
+      const recent = sessions.recentForContext({ projectId, limit: 25 });
+      expect(recent.some((r) => r.id === s.id)).toBe(true);
+    });
+
+    it('includes a session with title_final = 1 even without a summary', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'has-title-final' });
+      db.handle.raw
+        .prepare('UPDATE sessions SET title = ?, title_final = 1 WHERE id = ?')
+        .run('locked title', s.id);
+      const recent = sessions.recentForContext({ projectId, limit: 25 });
+      expect(recent.some((r) => r.id === s.id)).toBe(true);
+    });
+
+    it('includes a session referenced by at least one memory row', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'has-memory' });
+      db.handle.raw
+        .prepare(
+          `INSERT INTO memory (id, scope, project_id, type, content, status, replaces, created_at, session_id)
+           VALUES (?, 'project', ?, 'user', 'x', 'active', '[]', ?, ?)`,
+        )
+        .run(newSessionId('mem'), projectId, Date.now(), s.id);
+      const recent = sessions.recentForContext({ projectId, limit: 25 });
+      expect(recent.some((r) => r.id === s.id)).toBe(true);
+    });
+
+    it('includes a session referenced by at least one prompt row', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'has-prompt' });
+      db.handle.raw
+        .prepare(
+          `INSERT INTO prompts (id, session_id, project_id, content, agent, created_at)
+           VALUES (?, ?, ?, 'do the thing', 'claude', ?)`,
+        )
+        .run(newSessionId('p'), s.id, projectId, Date.now());
+      const recent = sessions.recentForContext({ projectId, limit: 25 });
+      expect(recent.some((r) => r.id === s.id)).toBe(true);
+    });
+
+    it('includes a session referenced by at least one confirmation row', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'has-confirmation' });
+      const memoryId = newSessionId('mem-for-conf');
+      db.handle.raw
+        .prepare(
+          `INSERT INTO memory (id, scope, project_id, type, content, status, replaces, created_at, session_id)
+           VALUES (?, 'project', ?, 'user', 'x', 'active', '[]', ?, NULL)`,
+        )
+        .run(memoryId, projectId, Date.now());
+      db.handle.raw
+        .prepare(
+          `INSERT INTO confirmations (id, memory_id, event_ts, source, session_id)
+           VALUES (?, ?, ?, NULL, ?)`,
+        )
+        .run(newSessionId('c'), memoryId, Date.now(), s.id);
+      const recent = sessions.recentForContext({ projectId, limit: 25 });
+      expect(recent.some((r) => r.id === s.id)).toBe(true);
+    });
+
+    it('filter-then-truncate: backfills past newer empty sessions', () => {
+      const useful = sessions.start({ tokenId, projectId, agent: 'useful-old' });
+      sessions.summarize(useful.id, { tokenId, summary: 'older but useful' });
+
+      // Three empty sessions started AFTER `useful`. Backdating started_at
+      // via raw SQL to guarantee ordering on fast machines.
+      const now = Date.now();
+      for (let i = 1; i <= 3; i++) {
+        const e = sessions.start({ tokenId, projectId, agent: `empty-${i}` });
+        db.handle.raw
+          .prepare('UPDATE sessions SET started_at = ? WHERE id = ?')
+          .run(now + i * 1000, e.id);
+      }
+      db.handle.raw
+        .prepare('UPDATE sessions SET started_at = ? WHERE id = ?')
+        .run(now - 60_000, useful.id);
+
+      const recent = sessions.recentForContext({ projectId, limit: 1 });
+      expect(recent).toHaveLength(1);
+      expect(recent[0]?.id).toBe(useful.id);
+    });
+
+    it('soft-deleted session with content is still excluded', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'deleted-with-content' });
+      sessions.summarize(s.id, { tokenId, summary: 'had value, then deleted' });
+      sessions.softDelete(s.id, { adminBypass: true });
+      const recent = sessions.recentForContext({ projectId, limit: 25 });
+      expect(recent.some((r) => r.id === s.id)).toBe(false);
+    });
   });
 });

--- a/apps/server/src/services/agent-sessions.ts
+++ b/apps/server/src/services/agent-sessions.ts
@@ -11,6 +11,29 @@ const SESSION_PURGE_GRACE_MS = 3_600_000;
 const SESSION_PURGE_REASONING = 'operator purge of empty sessions';
 
 /**
+ * Single source of truth for "this session has something worth surfacing".
+ *
+ * Consumed positively by `recentForContext` (filter to useful sessions) and
+ * negatively by `countPurgeableEmpty` / `purgeEmpty` (must be empty to be
+ * purgeable). Adding a new content-bearing table that anchors to a session
+ * id (e.g. a future `tool_calls`) MUST update only this helper — every
+ * call site picks the change up automatically.
+ *
+ * `alias` is the SQL identifier used to reference the sessions row in the
+ * caller's query. Callers pass `'s'` (purge methods) or the table name
+ * `'sessions'` (drizzle's implicit alias in `recentForContext`).
+ */
+function sessionHasContentSql(alias: 's' | 'sessions') {
+  return sql.raw(
+    `(${alias}.summary IS NOT NULL` +
+      ` OR ${alias}.title_final = 1` +
+      ` OR EXISTS (SELECT 1 FROM memory        WHERE session_id = ${alias}.id)` +
+      ` OR EXISTS (SELECT 1 FROM prompts       WHERE session_id = ${alias}.id)` +
+      ` OR EXISTS (SELECT 1 FROM confirmations WHERE session_id = ${alias}.id))`,
+  );
+}
+
+/**
  * Service for the agent (MCP) session lifecycle.
  *
  * Append-only contract:
@@ -383,8 +406,12 @@ export class AgentSessionsService {
 
   /**
    * N most recent sessions for the given scope, ordered newest first.
-   * Soft-deleted sessions are NEVER surfaced via this path — memory.context
-   * callers must not see them.
+   * Soft-deleted sessions and empty sessions (those failing the shared
+   * `sessionHasContent` predicate) are NEVER surfaced via this path —
+   * memory.context callers must not see noise. Filter-then-truncate
+   * semantics: empty sessions do not consume slots, so a `limit:N`
+   * request returns the N most-recent USEFUL sessions even if dozens of
+   * newer empties exist between them.
    */
   recentForContext(input: RecentForContextInput): AgentSession[] {
     const limit = clamp(input.limit ?? 5, 1, 25);
@@ -395,7 +422,7 @@ export class AgentSessionsService {
     return this.db
       .select()
       .from(agentSessions)
-      .where(and(scopeCondition, isNull(agentSessions.deletedAt)))
+      .where(and(scopeCondition, isNull(agentSessions.deletedAt), sessionHasContentSql('sessions')))
       .orderBy(desc(agentSessions.startedAt))
       .limit(limit)
       .all();
@@ -590,9 +617,9 @@ export class AgentSessionsService {
    * Predicate (in lock-step with `purgeEmpty`):
    *   - status ∈ {ended, abandoned}
    *   - deleted_at IS NULL (operator soft-delete is respected)
-   *   - summary IS NULL AND title_final = 0
+   *   - NOT sessionHasContent(s) — i.e. no summary, no title_final,
+   *     no referencing memory/prompts/confirmations
    *   - ended_at < now − 1h (grace for late summary writes)
-   *   - no referencing rows in memory, prompts, confirmations
    */
   countPurgeableEmpty(): number {
     const cutoff = this.now().getTime() - SESSION_PURGE_GRACE_MS;
@@ -600,13 +627,9 @@ export class AgentSessionsService {
       SELECT COUNT(*) AS v FROM sessions s
        WHERE s.status IN ('ended','abandoned')
          AND s.deleted_at IS NULL
-         AND s.summary IS NULL
-         AND s.title_final = 0
          AND s.ended_at IS NOT NULL
          AND s.ended_at < ${cutoff}
-         AND NOT EXISTS (SELECT 1 FROM memory        m WHERE m.session_id = s.id)
-         AND NOT EXISTS (SELECT 1 FROM prompts       p WHERE p.session_id = s.id)
-         AND NOT EXISTS (SELECT 1 FROM confirmations c WHERE c.session_id = s.id)
+         AND NOT ${sessionHasContentSql('s')}
     `) as { v: number } | undefined;
     return row?.v ?? 0;
   }
@@ -640,13 +663,9 @@ export class AgentSessionsService {
         SELECT s.id FROM sessions s
          WHERE s.status IN ('ended','abandoned')
            AND s.deleted_at IS NULL
-           AND s.summary IS NULL
-           AND s.title_final = 0
            AND s.ended_at IS NOT NULL
            AND s.ended_at < ${cutoff}
-           AND NOT EXISTS (SELECT 1 FROM memory        m WHERE m.session_id = s.id)
-           AND NOT EXISTS (SELECT 1 FROM prompts       p WHERE p.session_id = s.id)
-           AND NOT EXISTS (SELECT 1 FROM confirmations c WHERE c.session_id = s.id)
+           AND NOT ${sessionHasContentSql('s')}
       `);
       const deletedIds = eligible.map((r) => r.id);
       if (deletedIds.length === 0) {

--- a/apps/server/src/test/mcp-integration.test.ts
+++ b/apps/server/src/test/mcp-integration.test.ts
@@ -255,6 +255,9 @@ describe('MCP protocol conformance', () => {
     expect(ended.isError).toBeFalsy();
 
     // 5. memory.context should include the session as recent and `ended`.
+    //    The session was anchored to a saved memory AND received a summary,
+    //    so it satisfies the `sessionHasContent` predicate and survives the
+    //    content filter applied by recentForContext.
     const ctx = (await client.callTool({
       name: 'memory.context',
       arguments: { sessions: 5, memories: 5 },
@@ -267,6 +270,72 @@ describe('MCP protocol conformance', () => {
     expect(seenSession?.status).toBe('ended');
     expect(seenSession?.summary).toMatch(/wire test/);
     expect(ctxPayload.recentMemories.some((m) => m.id === savedPayload.id)).toBe(true);
+
+    await client.close();
+  });
+
+  it('memory.context excludes a session ended without memories or summary', async () => {
+    const client = await connect();
+
+    const started = (await client.callTool({
+      name: 'memory.session_start',
+      arguments: { agent: 'rembric-test', description: 'empty session' },
+    })) as ToolResult;
+    const startedPayload = readJson(started) as { sessionId: string };
+
+    const ended = (await client.callTool({
+      name: 'memory.session_end',
+      arguments: {},
+    })) as ToolResult;
+    expect(ended.isError).toBeFalsy();
+
+    const ctx = (await client.callTool({
+      name: 'memory.context',
+      arguments: { sessions: 25 },
+    })) as ToolResult;
+    const ctxPayload = readJson(ctx) as {
+      recentSessions: { id: string }[];
+    };
+    expect(ctxPayload.recentSessions.some((s) => s.id === startedPayload.sessionId)).toBe(false);
+
+    await client.close();
+  });
+
+  it('memory.context backfills past empty sessions to return useful older ones', async () => {
+    const client = await connect();
+
+    // First: a session WITH content (will be the oldest).
+    const usefulStart = (await client.callTool({
+      name: 'memory.session_start',
+      arguments: { agent: 'rembric-test', description: 'useful session' },
+    })) as ToolResult;
+    const usefulPayload = readJson(usefulStart) as { sessionId: string };
+    await client.callTool({
+      name: 'memory.save',
+      arguments: {
+        scope: 'global',
+        type: 'feedback',
+        content: 'backfill-useful-row',
+      },
+    });
+    await client.callTool({ name: 'memory.session_end', arguments: {} });
+
+    // Then: three empty sessions in newer-than-useful order.
+    for (let i = 0; i < 3; i++) {
+      await client.callTool({
+        name: 'memory.session_start',
+        arguments: { agent: 'rembric-test', description: `empty ${i}` },
+      });
+      await client.callTool({ name: 'memory.session_end', arguments: {} });
+    }
+
+    const ctx = (await client.callTool({
+      name: 'memory.context',
+      arguments: { sessions: 1 },
+    })) as ToolResult;
+    const ctxPayload = readJson(ctx) as { recentSessions: { id: string }[] };
+    expect(ctxPayload.recentSessions).toHaveLength(1);
+    expect(ctxPayload.recentSessions[0]?.id).toBe(usefulPayload.sessionId);
 
     await client.close();
   });

--- a/openspec/changes/archive/2026-05-21-filter-empty-sessions-from-context/design.md
+++ b/openspec/changes/archive/2026-05-21-filter-empty-sessions-from-context/design.md
@@ -1,0 +1,119 @@
+## Context
+
+Two tightly-related call sites in `apps/server/src/services/agent-sessions.ts` already encode "this session has no content worth keeping":
+
+- `countPurgeableEmpty()` (lines 597-612 today) — counts rows the purge job will delete.
+- `purgeEmpty({adminBypass})` (lines 628-660 today) — performs the deletion.
+
+The shared sub-predicate is:
+
+```
+summary IS NULL
+AND title_final = 0
+AND NOT EXISTS (SELECT 1 FROM memory        WHERE session_id = s.id)
+AND NOT EXISTS (SELECT 1 FROM prompts       WHERE session_id = s.id)
+AND NOT EXISTS (SELECT 1 FROM confirmations WHERE session_id = s.id)
+```
+
+Both call sites write this inline. The day someone adds a fourth content-bearing table that anchors to a session id, one site will update and the other will silently diverge. The OpenSpec invariant test surface does not catch SQL drift between two locations writing the same predicate.
+
+`memory.context.recentSessions` is the third call site that wants this concept, in inverted form ("show me sessions that DO have content"). Adding a third inline duplicate would make the drift problem worse.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Single source of truth for the "session has content" predicate.
+- `memory.context.recentSessions` returns useful sessions instead of noise. Default behavior — no opt-in flag required.
+- Filter-then-truncate ordering (Option B): a `limit:5` request returns up to 5 _useful_ sessions, naturally backfilling past empty ones, instead of returning fewer-than-5 because empties consumed the top of the list.
+- Zero migration. Zero schema change. Zero trigger. Zero backfill.
+- Purge behavior MUST be byte-identical after the refactor (verified by test).
+
+**Non-Goals:**
+
+- Materialize the predicate as a stored column. SQLite generated columns cannot reference other tables; a denormalized cache would require triggers on three tables + a sync invariant + backfill, against zero perf gain (read path is ≤25 rows, ≈75 index probes total).
+- Expose an `includeEmpty` arg on `memory.context`. The dashboard already shows all sessions; the MCP surface is for agents, who want signal not completeness.
+- Filter empty sessions out of `memory.stats` or `/dashboard/sessions`. Operators need to see them to decide on purge.
+- Apply a grace period. The 1h grace in `purgeEmpty` exists because DELETE can race with late summary writes; SELECT cannot race destructively.
+
+## Decisions
+
+### Decision 1 — Read-time predicate, not materialized
+
+A `has_content` cached column on `sessions` would buy O(1) reads but cost:
+
+- A migration + backfill.
+- Triggers (or service-layer mutation) on `memory`, `prompts`, `confirmations` to flip the flag false→true on first content write.
+- A new sync invariant ("cached value equals real value") with its own test.
+- An UPDATE-on-write pattern that rubs against the append-only spirit of `sessions`, even though `has_content` is monotonic.
+- The invariant test that white-lists files allowed to UPDATE `sessions` would need to widen.
+
+The read path being optimized is `memory.context.recentSessions`. It is clamped to ≤25 rows. Per row, the predicate runs three EXISTS subqueries, each hitting an existing `idx_*_session_id` index (single-key lookups). Total work per `memory.context` call: roughly 75 index probes plus the base session sweep. Not a hot path, not a perf bottleneck.
+
+**Decision:** Stay in code. Extract the predicate as a shared SQL fragment builder. Pay the read cost; skip the schema cost.
+
+### Decision 2 — Filter-then-truncate (Option B)
+
+Two query shapes were on the table:
+
+```
+Option A — Truncate-then-filter:
+  SELECT * FROM (
+    SELECT * FROM sessions WHERE scope AND deleted_at IS NULL
+    ORDER BY started_at DESC LIMIT N
+  ) WHERE has_content
+  → returns ≤N rows; if top of list is empty, returns fewer than N.
+
+Option B — Filter-then-truncate:
+  SELECT * FROM sessions
+   WHERE scope AND deleted_at IS NULL AND has_content
+   ORDER BY started_at DESC LIMIT N
+  → always returns up to N useful rows; naturally backfills past empties.
+```
+
+B is also the simpler SQL — single WHERE, no subquery. The natural query plan walks the `(scope, started_at DESC)` index until it has collected `limit` matching rows, then stops. Worst case (all sessions are empty) it sweeps the whole index for the scope; that's the same cost the user already pays today for purge counting.
+
+**Decision:** Filter-then-truncate (B).
+
+### Decision 3 — Helper signature
+
+```ts
+function sessionHasContentSql(alias: string): SqlFragment {
+  return sql.raw(`(
+    ${alias}.summary IS NOT NULL
+    OR ${alias}.title_final = 1
+    OR EXISTS (SELECT 1 FROM memory        WHERE session_id = ${alias}.id)
+    OR EXISTS (SELECT 1 FROM prompts       WHERE session_id = ${alias}.id)
+    OR EXISTS (SELECT 1 FROM confirmations WHERE session_id = ${alias}.id)
+  )`);
+}
+```
+
+The `alias` arg is what callers use to reference the sessions row (`s` in `countPurgeableEmpty`/`purgeEmpty`, the implicit drizzle alias in `recentForContext`). The helper is private to `apps/server/src/services/agent-sessions.ts` — it is not exported and not consumed outside this service. The full predicate's normative spec sits in `openspec/specs/sessions/spec.md`; the helper is the implementation expression of that spec.
+
+### Decision 4 — No opt-out on the MCP surface
+
+`memory.context({includeEmpty: true})` was considered. Rejected for now:
+
+- The dashboard already gives operators a complete view.
+- Adding the arg means specifying its scenarios and tests, widening the surface for a use case nobody has asked for.
+- YAGNI. Re-introducing it later is a non-breaking additive change.
+
+### Decision 5 — Caller's own session is not specially excluded
+
+A naive instinct is "the session currently calling `memory.context` should never appear in its own `recentSessions`". This requires the service to know the active session id of the request, which couples the service layer to MCP request state. Instead, the content filter handles this naturally:
+
+- A brand-new session that has saved nothing yet → no content → filtered out. ✓
+- A session mid-task that already saved memories → has content → returned. This is correct: the agent benefits from seeing its own audit trail in compact form.
+
+## Risks / Trade-offs
+
+- **Agents that asserted on `recentSessions[*].id` matching the caller's own session id** would break. Mitigation: grep shows the only such assertion lives in `apps/server/src/test/mcp-integration.test.ts:266` (`recentSessions.find((s) => s.id === startedPayload.sessionId)`); we update that test as part of the change to capture content before asserting.
+- **Edge case:** a session with `title_final = 1` but empty `title` and no other content. Today this is impossible — `title_final` is only set when a title is written. Belt-and-braces: the predicate uses `title_final = 1` rather than `title IS NOT NULL` for parity with `purgeEmpty`'s definition of "labeled".
+- **Cost of the EXISTS scans** if the user's instance grows to 100k+ sessions per scope: bounded by `LIMIT N` short-circuit in B. The query plan stops as soon as N matching rows are collected.
+
+## Migration / Rollout
+
+- Single PR. No DB migration. No env var changes.
+- Tests cover: the refactored purge predicate produces the same `deletedIds` as before; `recentForContext` excludes empty sessions; integration scenario for `memory.context` confirms the bootstrap snapshot is signal-only.
+- No coordinated rollout across plugin clients required — the change is server-internal.

--- a/openspec/changes/archive/2026-05-21-filter-empty-sessions-from-context/proposal.md
+++ b/openspec/changes/archive/2026-05-21-filter-empty-sessions-from-context/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+`memory.context.recentSessions` is the agent's bootstrap snapshot — the first read of every Rembric-aware turn. Today it returns the N most-recent sessions for the scope, filtered only by `deleted_at IS NULL`. In practice this means slots are routinely consumed by sessions with `status = 'active'`, `summary = NULL`, `ended_at = NULL`, and zero referencing rows in `memory`, `prompts`, or `confirmations`. They tell a future reader nothing.
+
+Observed on 2026-05-21 from the running stack: a default `memory.context` call returned 5 sessions where 3 were active+null-summary+no-content. Effective signal: 1 of 5 slots.
+
+The repo already formalizes a "useful session" concept implicitly via `AgentSessionsService.countPurgeableEmpty`/`purgeEmpty` (specified in `openspec/specs/sessions/spec.md::"Sessions MAY be physically purged when empty"`). The predicate is duplicated inline in two places today, with latent drift risk: the day a fourth content-bearing table is added, one site will be updated and the other will not. This change pays down that risk and reuses the negation to give `memory.context` a content filter.
+
+## What Changes
+
+- **EXTRACT** a single source-of-truth SQL fragment `sessionHasContentSql(alias)` in `apps/server/src/services/agent-sessions.ts`. Definition: `summary IS NOT NULL OR title_final = 1 OR EXISTS (SELECT 1 FROM memory m WHERE m.session_id = <alias>.id) OR EXISTS (SELECT 1 FROM prompts p WHERE p.session_id = <alias>.id) OR EXISTS (SELECT 1 FROM confirmations c WHERE c.session_id = <alias>.id)`.
+- **REFACTOR** `countPurgeableEmpty` and `purgeEmpty` to consume `sessionHasContentSql` (their existing inline predicates are replaced by `NOT sessionHasContentSql(s)` + the unchanged grace/status clauses). No behavior change in purge.
+- **MODIFY** `AgentSessionsService.recentForContext(input)` to apply `AND sessionHasContentSql(sessions)` by default. Ordering and limit semantics unchanged: filtered candidates are still ordered by `started_at DESC`, then truncated to `limit`. This is Option B (filter-then-truncate) — a sweep finds the N most-recent _useful_ sessions, naturally backfilling past empty ones.
+- **NO new arg** on `memory.context`. The operator-facing escape hatch for inspecting empty sessions is the existing `/dashboard/sessions` view (which already shows everything). Keeping the MCP surface minimal preserves the bootstrap-snapshot intent: never noise.
+- **PRESERVE** existing soft-delete filter: `recentForContext` retains `AND deleted_at IS NULL` in lock-step with the content filter.
+- **NO migration**, **NO schema change**, **NO trigger**, **NO backfill**, **NO materialized column**. Generated columns in SQLite cannot reference other tables, so any materialization of this predicate would require either denormalized counters maintained by triggers (new sync invariant, new test surface, append-only spirit violation) or a cached `has_content` column with the same trigger overhead. Read-time cost is bounded: `recentForContext` is clamped to ≤25 rows, EXISTS subqueries hit existing `session_id` indexes on `memory`/`prompts`/`confirmations`, total ≈ 75 index probes per call — not a hot path.
+
+Not in scope:
+
+- Filtering empty sessions out of `memory.stats.sessionsByStatus` (counts are operationally meaningful — operators decide when to purge based on them).
+- Filtering empty sessions out of `/dashboard/sessions` (operators must see them to decide on purge).
+- Excluding the caller's own active session from results. The content filter already excludes any session with no captured content; once the caller has saved anything it becomes legitimately surfaceable.
+- A `grace` period (the 1h grace on `purgeEmpty` exists to avoid racing with late summary writes during a DELETE; reads cannot race with anything destructive).
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `sessions`: REFINE the `recentForContext` contract — it SHALL exclude sessions that fail the shared `sessionHasContent` predicate, in addition to the existing `deleted_at IS NULL` filter. ADD a normative reference to `sessionHasContent` as the single source-of-truth predicate consumed by both `recentForContext` (positive) and `purgeEmpty`/`countPurgeableEmpty` (negative).
+- `mcp-api`: REFINE the `memory.context` scenario for `recentSessions` to specify that returned sessions SHALL satisfy `sessionHasContent`, and that the list is filter-then-truncate (Option B).
+
+## Impact
+
+**Code**
+
+- Modified: `apps/server/src/services/agent-sessions.ts` (extract helper, apply to `recentForContext`, refactor purge call-sites).
+- Modified: `apps/server/src/services/agent-sessions.test.ts` (new unit tests around the content filter and behavior parity for purge).
+- Modified: `apps/server/src/test/mcp-integration.test.ts` (integration scenario: empty active session is NOT returned; useful older session IS).
+
+**Surfaces unchanged**
+
+- MCP tool schema: no new arg, no removed arg, no shape change.
+- Dashboard: no template change.
+- Plugin manifests: untouched (all four clients).
+- DB schema and migrations: untouched.
+
+**Risk**
+
+- Behavioral change for agents that relied on seeing their own brand-new empty session in `memory.context`. Mitigation: it was never a documented guarantee, and the agent already has the session id in its own request state via `resolveActiveSessionId`. No downstream tool reads `recentSessions[*].id` programmatically (verified by grep of `recentSessions` in the repo — only test assertions and dashboard prefetches).

--- a/openspec/changes/archive/2026-05-21-filter-empty-sessions-from-context/specs/mcp-api/spec.md
+++ b/openspec/changes/archive/2026-05-21-filter-empty-sessions-from-context/specs/mcp-api/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: The MCP server MUST expose three research tools
+
+The `/mcp` and `/mcp/<slug>` endpoints SHALL register `memory.context`, `memory.timeline`, and `memory.capture_passive` with the following contracts.
+
+#### Scenario: `memory.context` returns a bootstrap snapshot
+
+- **WHEN** an MCP client calls `memory.context` with `{ sessions?: number, prompts?: number, memories?: number, includeArchived?: boolean }`
+- **THEN** the server SHALL return `{ recentSessions, recentPrompts, recentMemories }`, with each list scoped to the request context (global vs path-scoped project)
+- **AND** `recentSessions` SHALL contain only sessions that satisfy the `sessionHasContent` predicate (see `sessions` capability), ordered by `started_at DESC`, with empty sessions filtered out BEFORE truncation to `sessions ?? 5`
+- **AND** `recentMemories` SHALL be ordered by `last_seen_at DESC` with `includeArchived = false` (default) filtering out `status = 'archived'` rows
+
+#### Scenario: `memory.context.recentSessions` backfills past empty sessions
+
+- **GIVEN** the active scope contains, in `started_at` order from newest to oldest, three empty sessions and one useful session
+- **WHEN** an MCP client calls `memory.context({sessions: 1})`
+- **THEN** the response's `recentSessions` array SHALL have length 1 and SHALL contain only the useful session — the three newer empty sessions SHALL NOT consume the slot
+
+#### Scenario: `memory.context.recentSessions` excludes soft-deleted sessions
+
+- **GIVEN** a session that has content AND is soft-deleted (`deleted_at IS NOT NULL`)
+- **WHEN** an MCP client calls `memory.context`
+- **THEN** the row SHALL NOT appear in `recentSessions` — the soft-delete filter and the content filter both apply
+
+#### Scenario: `memory.context` arguments exceed clamps
+
+- **WHEN** the caller passes `sessions > 25`, `prompts > 50`, or `memories > 100`
+- **THEN** the server SHALL silently clamp to the maximum and SHALL include a `clamped: true` field in the response
+
+#### Scenario: `memory.timeline` returns chronological neighbors within a session
+
+- **WHEN** an MCP client calls `memory.timeline` with `{ memoryId, before?: 5, after?: 5 }` and the target memory has a non-null `session_id`
+- **THEN** the server SHALL return up to `before` memories with `created_at < target.created_at` and `session_id = target.session_id`, plus up to `after` memories with `created_at > target.created_at` and `session_id = target.session_id`, ordered chronologically
+
+#### Scenario: `memory.timeline` falls back when the target has no session
+
+- **WHEN** the target memory has `session_id = NULL`
+- **THEN** the server SHALL return neighbors selected by `created_at` within ±2 hours of the target's `created_at`, scoped to the same `(scope, project_id)`, and the response SHALL include `fallback: 'time_window'`
+
+#### Scenario: `memory.timeline` combined window exceeds 50
+
+- **WHEN** `before + after > 50`
+- **THEN** the call SHALL be rejected with code `invalid_input` and a message referring the caller to `memory.search`
+
+#### Scenario: `memory.capture_passive` extracts numbered learnings
+
+- **WHEN** an MCP client calls `memory.capture_passive` with `{ text: string, sessionId?: string }` and `text` contains a section starting with `^## Key Learnings:\s*$`
+- **THEN** the server SHALL extract each subsequent numbered (`1.`, `2.`) or bulleted (`-`, `*`) item, save each as a separate memory with `type = 'discovery'` and the active scope, and SHALL return `{ saved: number, ids: string[] }`
+
+#### Scenario: `memory.capture_passive` finds no learnings block
+
+- **WHEN** the input text has no matching `## Key Learnings:` heading
+- **THEN** the server SHALL return `{ saved: 0, ids: [] }` and SHALL NOT error

--- a/openspec/changes/archive/2026-05-21-filter-empty-sessions-from-context/specs/sessions/spec.md
+++ b/openspec/changes/archive/2026-05-21-filter-empty-sessions-from-context/specs/sessions/spec.md
@@ -1,0 +1,108 @@
+## MODIFIED Requirements
+
+### Requirement: Sessions MAY be soft-deleted while preserving the audit trail
+
+The `agent_sessions` table SHALL gain a nullable column `deleted_at TIMESTAMP`. A row with `deleted_at IS NOT NULL` is _soft-deleted_: it remains physically present, its `id` continues to satisfy every existing `memory.session_id` foreign-key reference, but it is hidden from default-visible listings.
+
+`AgentSessionsService` SHALL expose:
+
+- `softDelete(sessionId, {tokenId?, adminBypass?})`: sets `deleted_at` to `now()`. Calling this on an already-deleted row SHALL be a no-op that returns the existing row (idempotent). Without `adminBypass`, the caller's `tokenId` SHALL match the row's `token_id`; mismatches SHALL be rejected with `forbidden`.
+- `undelete(sessionId, {adminBypass?})`: clears `deleted_at`. Only admin (operator-facing) callers may invoke this; agent-facing callers SHALL NOT have access.
+
+`AgentSessionsService.list(...)` SHALL apply `WHERE deleted_at IS NULL` by default. `list(...)` SHALL accept an `includeDeleted: true` option to surface deleted rows. `AgentSessionsService.recentForContext(...)` SHALL apply BOTH `WHERE deleted_at IS NULL` AND the `sessionHasContent` predicate defined below; it SHALL NOT accept any option that bypasses either filter — memory-context callers SHALL never see deleted sessions and SHALL never see empty sessions.
+
+`AgentSessionsService.findById(...)` SHALL NOT filter on `deleted_at` or on `sessionHasContent`. The detail surface must still be able to open and act on (e.g. undelete) any row regardless of content.
+
+#### Scenario: softDelete sets deleted_at and hides the row from default list
+
+- **GIVEN** an active session with `id = <S>` whose `deleted_at` is NULL
+- **WHEN** the operator calls `softDelete(<S>, {adminBypass: true})`
+- **THEN** the row's `deleted_at` SHALL be set to the current timestamp
+- **AND** a subsequent `list()` SHALL NOT include the row
+- **AND** a subsequent `list({includeDeleted: true})` SHALL include the row
+- **AND** `findById(<S>)` SHALL still return the row
+
+#### Scenario: softDelete is idempotent
+
+- **GIVEN** a session whose `deleted_at` is already set
+- **WHEN** the operator calls `softDelete` on it again
+- **THEN** the call SHALL succeed and SHALL NOT modify `deleted_at`
+- **AND** the returned row SHALL be the existing soft-deleted row
+
+#### Scenario: undelete clears deleted_at
+
+- **GIVEN** a soft-deleted session
+- **WHEN** the operator calls `undelete` on it with `adminBypass: true`
+- **THEN** `deleted_at` SHALL transition back to NULL
+- **AND** the row SHALL re-appear in the default list
+
+#### Scenario: Memories anchored to a soft-deleted session preserve their session_id
+
+- **GIVEN** a memory whose `session_id` references session `<S>`
+- **WHEN** session `<S>` is soft-deleted
+- **THEN** the memory's `session_id` SHALL remain unchanged and SHALL continue to point at `<S>`
+
+## ADDED Requirements
+
+### Requirement: `sessionHasContent` is the single source-of-truth predicate for "this session is worth surfacing"
+
+`AgentSessionsService` SHALL define an internal SQL predicate, `sessionHasContent(s)`, returning TRUE for a `sessions` row `s` iff at least ONE of the following holds:
+
+1. `s.summary IS NOT NULL`, OR
+2. `s.title_final = 1`, OR
+3. there exists at least one row in `memory` with `session_id = s.id`, OR
+4. there exists at least one row in `prompts` with `session_id = s.id`, OR
+5. there exists at least one row in `confirmations` with `session_id = s.id`.
+
+The predicate SHALL be implemented as a single private SQL-fragment helper inside `apps/server/src/services/agent-sessions.ts`. It SHALL be the ONLY place in the codebase where this five-clause predicate is expressed. The `countPurgeableEmpty` and `purgeEmpty` methods SHALL consume the predicate in negated form (`NOT sessionHasContent(s)`) as part of their "purgeable" check. `recentForContext` SHALL consume the predicate in positive form as part of its "is useful to surface" check.
+
+When a future content-bearing table is added with a `session_id` foreign key (the canonical example being a hypothetical `tool_calls` table), the predicate SHALL be the single point of update — the new EXISTS clause is added once, and every call site picks it up automatically.
+
+#### Scenario: A session with a written summary satisfies the predicate
+
+- **GIVEN** session `S` with `summary = 'Goal: ...'` and no anchored memory/prompt/confirmation rows
+- **WHEN** any call site evaluates `sessionHasContent(S)`
+- **THEN** the predicate SHALL return TRUE
+
+#### Scenario: A session with no content fails the predicate
+
+- **GIVEN** session `S` with `summary IS NULL`, `title_final = 0`, and zero anchored rows in `memory`, `prompts`, `confirmations`
+- **WHEN** any call site evaluates `sessionHasContent(S)`
+- **THEN** the predicate SHALL return FALSE
+
+#### Scenario: Drift between purge predicate and context predicate is impossible
+
+- **GIVEN** the codebase as a whole
+- **WHEN** any reviewer reads `countPurgeableEmpty`, `purgeEmpty`, and `recentForContext`
+- **THEN** each SHALL reference `sessionHasContent` rather than inlining its five clauses
+- **AND** a code search for `EXISTS (SELECT 1 FROM memory WHERE session_id` outside the helper definition SHALL return zero matches within `apps/server/src/services/agent-sessions.ts`
+
+### Requirement: `recentForContext` MUST exclude empty sessions by default
+
+`AgentSessionsService.recentForContext({projectId, limit})` SHALL return at most `limit` rows, ordered by `started_at DESC`, drawn from the set of sessions satisfying ALL of:
+
+1. `deleted_at IS NULL` (soft-delete already specified above);
+2. scope match (`projectId IS NULL` for global, or `project_id = ?` for path-scoped);
+3. `sessionHasContent(s)` is TRUE.
+
+Filtering SHALL precede truncation: a request with `limit: 5` SHALL return the five most-recent _useful_ sessions, even if dozens of newer empty sessions exist between them. Empty sessions SHALL NEVER consume a slot in the response.
+
+The method SHALL NOT accept any flag, option, or argument that bypasses the `sessionHasContent` filter. Operators who need to inspect empty sessions SHALL use `/dashboard/sessions`, which surfaces all rows regardless of content.
+
+#### Scenario: An empty active session is excluded
+
+- **GIVEN** a scope containing one active session `A` with no summary and zero anchored rows, plus one ended session `E` with a summary
+- **WHEN** `recentForContext({projectId, limit: 5})` is called
+- **THEN** the result SHALL contain `E` and SHALL NOT contain `A`
+
+#### Scenario: Filter-then-truncate produces backfill semantics
+
+- **GIVEN** a scope containing, in `started_at` order from newest to oldest: three empty sessions `A`, `B`, `C` and one useful session `U`
+- **WHEN** `recentForContext({projectId, limit: 1})` is called
+- **THEN** the result SHALL be `[U]` — the most-recent USEFUL session, not the most-recent session overall
+
+#### Scenario: Soft-deleted session with content is still excluded
+
+- **GIVEN** a session that has a summary AND is soft-deleted
+- **WHEN** `recentForContext` is called
+- **THEN** the row SHALL NOT appear in the result — both filters apply, neither overrides the other

--- a/openspec/changes/archive/2026-05-21-filter-empty-sessions-from-context/tasks.md
+++ b/openspec/changes/archive/2026-05-21-filter-empty-sessions-from-context/tasks.md
@@ -1,0 +1,40 @@
+## 1. Extract the shared predicate
+
+- [x] 1.1 In `apps/server/src/services/agent-sessions.ts`, add a private `sessionHasContentSql(alias: string)` helper that returns the SQL fragment defined in design.md Decision 3. The helper SHALL NOT be exported.
+- [x] 1.2 Co-located unit tests in `apps/server/src/services/agent-sessions.test.ts` exercising the helper directly via a tiny seed: (a) session with `summary='x'` → true, (b) session with `title_final=1` → true, (c) session with one memory row → true, (d) session with one prompt → true, (e) session with one confirmation → true, (f) session with all the above absent → false.
+
+## 2. Refactor purge call-sites to consume the helper
+
+- [x] 2.1 Replace the inline content predicate in `AgentSessionsService.countPurgeableEmpty` with `AND NOT ${sessionHasContentSql('s')}`. Keep the surrounding `status IN ('ended','abandoned') AND deleted_at IS NULL AND ended_at < ${cutoff}` clauses untouched.
+- [x] 2.2 Replace the inline content predicate in `AgentSessionsService.purgeEmpty` with `AND NOT ${sessionHasContentSql('s')}`. Verify the surrounding transaction + `consolidation_ops` insert remain unchanged.
+- [x] 2.3 Add a behavior-parity regression test: seed a fixture with one purgeable empty + one non-purgeable (has memory) + one non-purgeable (has summary). Assert `countPurgeableEmpty() === 1`, then `purgeEmpty({adminBypass:true}).deletedIds.length === 1`, and that the surviving rows are untouched.
+
+## 3. Apply the predicate to `recentForContext`
+
+- [x] 3.1 In `AgentSessionsService.recentForContext`, add `AND ${sessionHasContentSql('sessions')}` to the WHERE clause (drizzle uses the table name `sessions` as the implicit alias). Preserve the existing `isNull(agentSessions.deletedAt)` filter.
+- [x] 3.2 Confirm the resulting query is filter-then-truncate (Option B): the predicate is in the WHERE clause, ORDER BY follows, LIMIT applies last. Do NOT wrap the existing query in a subquery.
+- [x] 3.3 Unit tests in `agent-sessions.test.ts`:
+  - Empty active session (no memories, no prompts, no summary) is NOT returned.
+  - Active session with one memory anchored to it IS returned.
+  - Ended session with a summary IS returned.
+  - With three empty sessions starting at t1<t2<t3 and one useful session at t0, requesting limit:1 returns the useful one at t0 (backfill semantics).
+  - Soft-deleted session with content is NOT returned (existing behavior preserved).
+
+## 4. Integration test for `memory.context`
+
+- [x] 4.1 The existing test at line 257 of `apps/server/src/test/mcp-integration.test.ts` already saves a memory AND writes a summary before calling `memory.context`, so it satisfies the `sessionHasContent` predicate as-is. A clarifying comment was added; no behavioural change needed.
+- [x] 4.2 Add a new integration scenario: start a session, end it WITHOUT writing memories or a summary, then call `memory.context` — assert the empty session does NOT appear in `recentSessions`.
+- [x] 4.3 Add a new integration scenario: in a scope with N=3 empty sessions in front of one useful one, call `memory.context({sessions: 1})` — assert the response contains exactly the useful session.
+
+## 5. Spec deltas
+
+- [x] 5.1 Run `openspec validate filter-empty-sessions-from-context --strict` and resolve any reported drift. The actual application of the deltas to `openspec/specs/sessions/spec.md` and `openspec/specs/mcp-api/spec.md` is handled by `openspec archive` at archive time (task 6.6), not during apply.
+
+## 6. Verify and ship
+
+- [x] 6.1 `pnpm run typecheck` clean.
+- [x] 6.2 `pnpm -w run lint` clean.
+- [x] 6.3 `pnpm test` clean (40 test files / 476 tests passing).
+- [ ] 6.4 Manual smoke: `pnpm run dev:docker:up`, watch for default seed data, then from a Claude Code session call `memory.context` and inspect `recentSessions` — confirm noise is gone. _(deferred; will run from the worktree before merging)_
+- [x] 6.5 Conventional Commit message naming the changed surface: `feat(sessions): filter empty sessions out of memory.context recentSessions`.
+- [x] 6.6 Archive the change as part of the PR: `openspec archive filter-empty-sessions-from-context` applies the spec deltas to canonical `openspec/specs/sessions/spec.md` and `openspec/specs/mcp-api/spec.md` and moves the change folder to `openspec/changes/archive/<date>-filter-empty-sessions-from-context/`.

--- a/openspec/specs/mcp-api/spec.md
+++ b/openspec/specs/mcp-api/spec.md
@@ -248,7 +248,21 @@ The `/mcp` and `/mcp/<slug>` endpoints SHALL register `memory.context`, `memory.
 #### Scenario: `memory.context` returns a bootstrap snapshot
 
 - **WHEN** an MCP client calls `memory.context` with `{ sessions?: number, prompts?: number, memories?: number, includeArchived?: boolean }`
-- **THEN** the server SHALL return `{ recentSessions, recentPrompts, recentMemories }`, with each list scoped to the request context (global vs path-scoped project), `recentSessions` ordered by `started_at DESC`, `recentMemories` ordered by `last_seen_at DESC`, and `includeArchived = false` (default) filtering out `status = 'archived'` rows
+- **THEN** the server SHALL return `{ recentSessions, recentPrompts, recentMemories }`, with each list scoped to the request context (global vs path-scoped project)
+- **AND** `recentSessions` SHALL contain only sessions that satisfy the `sessionHasContent` predicate (see `sessions` capability), ordered by `started_at DESC`, with empty sessions filtered out BEFORE truncation to `sessions ?? 5`
+- **AND** `recentMemories` SHALL be ordered by `last_seen_at DESC` with `includeArchived = false` (default) filtering out `status = 'archived'` rows
+
+#### Scenario: `memory.context.recentSessions` backfills past empty sessions
+
+- **GIVEN** the active scope contains, in `started_at` order from newest to oldest, three empty sessions and one useful session
+- **WHEN** an MCP client calls `memory.context({sessions: 1})`
+- **THEN** the response's `recentSessions` array SHALL have length 1 and SHALL contain only the useful session — the three newer empty sessions SHALL NOT consume the slot
+
+#### Scenario: `memory.context.recentSessions` excludes soft-deleted sessions
+
+- **GIVEN** a session that has content AND is soft-deleted (`deleted_at IS NOT NULL`)
+- **WHEN** an MCP client calls `memory.context`
+- **THEN** the row SHALL NOT appear in `recentSessions` — the soft-delete filter and the content filter both apply
 
 #### Scenario: `memory.context` arguments exceed clamps
 

--- a/openspec/specs/sessions/spec.md
+++ b/openspec/specs/sessions/spec.md
@@ -217,9 +217,9 @@ The `agent_sessions` table SHALL gain a nullable column `deleted_at TIMESTAMP`. 
 - `softDelete(sessionId, {tokenId?, adminBypass?})`: sets `deleted_at` to `now()`. Calling this on an already-deleted row SHALL be a no-op that returns the existing row (idempotent). Without `adminBypass`, the caller's `tokenId` SHALL match the row's `token_id`; mismatches SHALL be rejected with `forbidden`.
 - `undelete(sessionId, {adminBypass?})`: clears `deleted_at`. Only admin (operator-facing) callers may invoke this; agent-facing callers SHALL NOT have access.
 
-`AgentSessionsService.list(...)` and `recentForContext(...)` SHALL apply `WHERE deleted_at IS NULL` by default. `list(...)` SHALL accept an `includeDeleted: true` option to surface deleted rows. `recentForContext` SHALL NOT accept such an option — memory-context callers SHALL never see deleted sessions.
+`AgentSessionsService.list(...)` SHALL apply `WHERE deleted_at IS NULL` by default. `list(...)` SHALL accept an `includeDeleted: true` option to surface deleted rows. `AgentSessionsService.recentForContext(...)` SHALL apply BOTH `WHERE deleted_at IS NULL` AND the `sessionHasContent` predicate defined below; it SHALL NOT accept any option that bypasses either filter — memory-context callers SHALL never see deleted sessions and SHALL never see empty sessions.
 
-`AgentSessionsService.findById(...)` SHALL NOT filter on `deleted_at`. The detail surface must still be able to open and act on (e.g. undelete) a soft-deleted row.
+`AgentSessionsService.findById(...)` SHALL NOT filter on `deleted_at` or on `sessionHasContent`. The detail surface must still be able to open and act on (e.g. undelete) any row regardless of content.
 
 #### Scenario: softDelete sets deleted_at and hides the row from default list
 
@@ -465,3 +465,66 @@ The method SHALL NOT call into `abandonStale` and `abandonStale` SHALL NOT call 
 
 - **WHEN** `markAbandoned('does-not-exist', { adminBypass: true })` is called
 - **THEN** the service SHALL throw `DomainError('session_not_found', ...)`
+
+### Requirement: `sessionHasContent` is the single source-of-truth predicate for "this session is worth surfacing"
+
+`AgentSessionsService` SHALL define an internal SQL predicate, `sessionHasContent(s)`, returning TRUE for a `sessions` row `s` iff at least ONE of the following holds:
+
+1. `s.summary IS NOT NULL`, OR
+2. `s.title_final = 1`, OR
+3. there exists at least one row in `memory` with `session_id = s.id`, OR
+4. there exists at least one row in `prompts` with `session_id = s.id`, OR
+5. there exists at least one row in `confirmations` with `session_id = s.id`.
+
+The predicate SHALL be implemented as a single private SQL-fragment helper inside `apps/server/src/services/agent-sessions.ts`. It SHALL be the ONLY place in the codebase where this five-clause predicate is expressed. The `countPurgeableEmpty` and `purgeEmpty` methods SHALL consume the predicate in negated form (`NOT sessionHasContent(s)`) as part of their "purgeable" check. `recentForContext` SHALL consume the predicate in positive form as part of its "is useful to surface" check.
+
+When a future content-bearing table is added with a `session_id` foreign key (the canonical example being a hypothetical `tool_calls` table), the predicate SHALL be the single point of update — the new EXISTS clause is added once, and every call site picks it up automatically.
+
+#### Scenario: A session with a written summary satisfies the predicate
+
+- **GIVEN** session `S` with `summary = 'Goal: ...'` and no anchored memory/prompt/confirmation rows
+- **WHEN** any call site evaluates `sessionHasContent(S)`
+- **THEN** the predicate SHALL return TRUE
+
+#### Scenario: A session with no content fails the predicate
+
+- **GIVEN** session `S` with `summary IS NULL`, `title_final = 0`, and zero anchored rows in `memory`, `prompts`, `confirmations`
+- **WHEN** any call site evaluates `sessionHasContent(S)`
+- **THEN** the predicate SHALL return FALSE
+
+#### Scenario: Drift between purge predicate and context predicate is impossible
+
+- **GIVEN** the codebase as a whole
+- **WHEN** any reviewer reads `countPurgeableEmpty`, `purgeEmpty`, and `recentForContext`
+- **THEN** each SHALL reference `sessionHasContent` rather than inlining its five clauses
+- **AND** a code search for `EXISTS (SELECT 1 FROM memory WHERE session_id` outside the helper definition SHALL return zero matches within `apps/server/src/services/agent-sessions.ts`
+
+### Requirement: `recentForContext` MUST exclude empty sessions by default
+
+`AgentSessionsService.recentForContext({projectId, limit})` SHALL return at most `limit` rows, ordered by `started_at DESC`, drawn from the set of sessions satisfying ALL of:
+
+1. `deleted_at IS NULL` (soft-delete already specified above);
+2. scope match (`projectId IS NULL` for global, or `project_id = ?` for path-scoped);
+3. `sessionHasContent(s)` is TRUE.
+
+Filtering SHALL precede truncation: a request with `limit: 5` SHALL return the five most-recent _useful_ sessions, even if dozens of newer empty sessions exist between them. Empty sessions SHALL NEVER consume a slot in the response.
+
+The method SHALL NOT accept any flag, option, or argument that bypasses the `sessionHasContent` filter. Operators who need to inspect empty sessions SHALL use `/dashboard/sessions`, which surfaces all rows regardless of content.
+
+#### Scenario: An empty active session is excluded
+
+- **GIVEN** a scope containing one active session `A` with no summary and zero anchored rows, plus one ended session `E` with a summary
+- **WHEN** `recentForContext({projectId, limit: 5})` is called
+- **THEN** the result SHALL contain `E` and SHALL NOT contain `A`
+
+#### Scenario: Filter-then-truncate produces backfill semantics
+
+- **GIVEN** a scope containing, in `started_at` order from newest to oldest: three empty sessions `A`, `B`, `C` and one useful session `U`
+- **WHEN** `recentForContext({projectId, limit: 1})` is called
+- **THEN** the result SHALL be `[U]` — the most-recent USEFUL session, not the most-recent session overall
+
+#### Scenario: Soft-deleted session with content is still excluded
+
+- **GIVEN** a session that has a summary AND is soft-deleted
+- **WHEN** `recentForContext` is called
+- **THEN** the row SHALL NOT appear in the result — both filters apply, neither overrides the other


### PR DESCRIPTION
## Summary

- `memory.context.recentSessions` no longer returns sessions with no summary, no anchored memories/prompts/confirmations, and no `title_final` — they used to consume slots that should be reserved for sessions that mean something to a future reader.
- Introduces a single source-of-truth SQL predicate `sessionHasContent(s)` consumed by `recentForContext` (positively) and by `countPurgeableEmpty` / `purgeEmpty` (negatively), retiring the inline five-clause duplication that previously lived in both purge methods.
- Filter-then-truncate semantics (Option B): a `limit:N` request returns the `N` most-recent **useful** sessions, naturally backfilling past newer empty ones. No DB migration, no schema change, no trigger, no backfill — SQLite `GENERATED ALWAYS AS` cannot reference other tables, so materializing the predicate would have cost triggers on three content-bearing tables plus a sync invariant, for a ≤25-row read.

OpenSpec change `filter-empty-sessions-from-context` archived in this PR — canonical spec deltas applied to `openspec/specs/sessions/spec.md` and `openspec/specs/mcp-api/spec.md`.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm -w run lint`
- [x] `pnpm test` — 40 test files / 476 tests passing locally
- [x] `openspec validate filter-empty-sessions-from-context --strict` (pre-archive)
- [x] Manual smoke from the worktree: `pnpm run dev:docker:up`, call `memory.context` from a Claude Code session, confirm `recentSessions` contains only sessions with content.

## Notes for review

- Helper definition: `apps/server/src/services/agent-sessions.ts:13-34`.
- New unit tests live in a `recentForContext content filter (sessionHasContent predicate)` describe block at the bottom of `apps/server/src/services/agent-sessions.test.ts`, plus a parity test inside the `purgeEmpty` block.
- Two new MCP integration scenarios near the bottom of `apps/server/src/test/mcp-integration.test.ts`.
- The branch name carries an unintended `worktree-` prefix because the branch was created via the agent's `EnterWorktree` flow. Feel free to rename on rebase or use squash-merge.