### PR TITLE
feat(dashboard): replace pending tile with recent judgments + detail view

### DIFF
--- a/apps/server/src/dashboard/judgments.ts
+++ b/apps/server/src/dashboard/judgments.ts
@@ -1,15 +1,21 @@
-import { desc, eq, isNull, sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 import { Hono, type Context } from 'hono';
 
 import type { Db } from '../db/client.js';
 import { memoryRelations } from '../db/schema/memory-relations.js';
 import type { SessionsService } from '../services/sessions.js';
 
-import { PAGE_SIZE, pager, urlWithPage, viewHead } from './components.js';
+import { backLink, PAGE_SIZE, pager, urlWithPage, viewHead } from './components.js';
 import { readFormAndVerifyCsrf, csrfInput } from './csrf.js';
 import { renderPage } from './page-shell.js';
-import { formatTs, html, raw, shortId, statusPill } from './templates.js';
+import { escape, formatTs, html, raw, shortId, statusPill, verdictPill } from './templates.js';
 import type { ResolvedSession } from './types.js';
+
+function truncate(s: string | null, max: number): string {
+  if (!s) return '';
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + '…';
+}
 
 export interface JudgmentsDeps {
   db: Db;
@@ -35,46 +41,49 @@ export function createJudgmentsRouter(deps: JudgmentsDeps): Hono {
     const page = Math.max(0, parseInt(url.searchParams.get('page') ?? '0', 10) || 0);
     const offset = page * PAGE_SIZE;
 
-    const conditions = [] as ReturnType<typeof eq>[];
+    const whereParts: ReturnType<typeof sql>[] = [];
     if (VALID_STATUSES.has(statusFilter)) {
-      conditions.push(
-        eq(memoryRelations.status, statusFilter as 'pending' | 'judged' | 'orphaned'),
-      );
+      whereParts.push(sql`r.status = ${statusFilter}`);
     }
-    if (kindFilter && kindFilter !== 'pending') {
-      conditions.push(
-        eq(
-          memoryRelations.relation,
-          kindFilter as
-            | 'supersedes'
-            | 'conflicts_with'
-            | 'related'
-            | 'compatible'
-            | 'scoped'
-            | 'not_conflict',
-        ),
-      );
+    const KIND_VALUES = new Set([
+      'supersedes',
+      'conflicts_with',
+      'related',
+      'compatible',
+      'scoped',
+      'not_conflict',
+    ]);
+    if (kindFilter && KIND_VALUES.has(kindFilter)) {
+      whereParts.push(sql`r.relation = ${kindFilter}`);
     } else if (kindFilter === 'pending') {
-      conditions.push(isNull(memoryRelations.relation));
+      whereParts.push(sql`r.relation IS NULL`);
     }
+    const whereSql =
+      whereParts.length === 0 ? sql`` : sql` WHERE ${sql.join(whereParts, sql` AND `)}`;
 
-    const rows =
-      conditions.length === 0
-        ? deps.db
-            .select()
-            .from(memoryRelations)
-            .orderBy(desc(memoryRelations.createdAt))
-            .limit(PAGE_SIZE + 1)
-            .offset(offset)
-            .all()
-        : deps.db
-            .select()
-            .from(memoryRelations)
-            .where(sql.join(conditions, sql` AND `))
-            .orderBy(desc(memoryRelations.createdAt))
-            .limit(PAGE_SIZE + 1)
-            .offset(offset)
-            .all();
+    const rows = deps.db.all<{
+      id: string;
+      judgment_id: string;
+      source_id: string;
+      target_id: string;
+      relation: string | null;
+      status: 'pending' | 'judged' | 'orphaned';
+      marked_by_actor: string | null;
+      created_at: number;
+      source_content: string;
+      target_content: string;
+    }>(sql`
+      SELECT r.id, r.judgment_id, r.source_id, r.target_id, r.relation,
+             r.status, r.marked_by_actor, r.created_at,
+             ms.content AS source_content,
+             mt.content AS target_content
+      FROM memory_relations r
+      JOIN memory ms ON ms.id = r.source_id
+      JOIN memory mt ON mt.id = r.target_id
+      ${whereSql}
+      ORDER BY r.created_at DESC
+      LIMIT ${PAGE_SIZE + 1} OFFSET ${offset}
+    `);
 
     const hasMore = rows.length > PAGE_SIZE;
     const visible = rows.slice(0, PAGE_SIZE);
@@ -126,7 +135,7 @@ export function createJudgmentsRouter(deps: JudgmentsDeps): Hono {
               r.status === 'pending'
                 ? html`
                     <form
-                      action="/dashboard/judgments/${r.judgmentId}/orphan"
+                      action="/dashboard/judgments/${r.judgment_id}/orphan"
                       method="post"
                       class="inline"
                       data-confirm="Mark this judgment as orphaned? It will be removed from the pending queue and won't be re-judged automatically."
@@ -140,15 +149,18 @@ export function createJudgmentsRouter(deps: JudgmentsDeps): Hono {
                 : raw('<span class="muted small">—</span>');
             return html`
               <tr>
-                <td class="mono small">${shortId(r.id)}</td>
-                <td>${statusPill(r.status)}</td>
-                <td>${r.relation ?? raw('<span class="muted">—</span>')}</td>
                 <td class="mono small">
-                  <a href="/dashboard/memories/${r.sourceId}">${shortId(r.sourceId)}</a>
-                  → <a href="/dashboard/memories/${r.targetId}">${shortId(r.targetId)}</a>
+                  <a href="/dashboard/judgments/${r.id}">${shortId(r.id)}</a>
                 </td>
-                <td class="small">${r.markedByActor ?? raw('<span class="muted">—</span>')}</td>
-                <td class="muted">${formatTs(r.createdAt)}</td>
+                <td>${statusPill(r.status)}</td>
+                <td>${verdictPill(r.relation)}</td>
+                <td class="small">
+                  <a href="/dashboard/memories/${r.source_id}">${truncate(r.source_content, 60)}</a>
+                  →
+                  <a href="/dashboard/memories/${r.target_id}">${truncate(r.target_content, 60)}</a>
+                </td>
+                <td class="small">${r.marked_by_actor ?? raw('<span class="muted">—</span>')}</td>
+                <td class="muted">${formatTs(new Date(r.created_at))}</td>
                 <td>${orphanForm}</td>
               </tr>
             `;
@@ -189,6 +201,153 @@ export function createJudgmentsRouter(deps: JudgmentsDeps): Hono {
     `;
     return c.html(
       renderPage(c, deps.sessions, body, { title: 'Judgments', activeNav: 'judgments' }),
+    );
+  });
+
+  app.get('/:id', (c) => {
+    const session = getSession(c);
+    if (!session) return c.redirect('/dashboard/login');
+
+    const id = c.req.param('id');
+    const row = deps.db.get<{
+      id: string;
+      judgment_id: string;
+      source_id: string;
+      target_id: string;
+      relation: string | null;
+      status: 'pending' | 'judged' | 'orphaned';
+      reason: string | null;
+      evidence: string | null;
+      confidence: number | null;
+      marked_by_kind: string | null;
+      marked_by_actor: string | null;
+      judged_at: number | null;
+      created_at: number;
+      source_content: string;
+      target_content: string;
+    }>(sql`
+      SELECT r.id, r.judgment_id, r.source_id, r.target_id, r.relation, r.status,
+             r.reason, r.evidence, r.confidence,
+             r.marked_by_kind, r.marked_by_actor,
+             r.judged_at, r.created_at,
+             ms.content AS source_content,
+             mt.content AS target_content
+      FROM memory_relations r
+      JOIN memory ms ON ms.id = r.source_id
+      JOIN memory mt ON mt.id = r.target_id
+      WHERE r.id = ${id}
+    `);
+
+    if (!row) {
+      return c.html(
+        renderPage(c, deps.sessions, html`<p class="flash error">Judgment not found.</p>`, {
+          title: 'Judgment',
+          activeNav: 'judgments',
+        }),
+        404,
+      );
+    }
+
+    let evidencePretty: string | null = null;
+    if (row.evidence !== null && row.evidence !== undefined) {
+      try {
+        evidencePretty = JSON.stringify(JSON.parse(row.evidence), null, 2);
+      } catch {
+        evidencePretty = String(row.evidence);
+      }
+    }
+
+    const orphanForm =
+      row.status === 'pending'
+        ? html`
+            <form
+              action="/dashboard/judgments/${row.judgment_id}/orphan"
+              method="post"
+              class="inline"
+              data-confirm="Mark this judgment as orphaned? It will be removed from the pending queue and won't be re-judged automatically."
+              data-confirm-label="MARK ORPHANED"
+              data-confirm-tone="danger"
+            >
+              ${csrfInput(session.session, deps.sessions, 'judgment.orphan')}
+              <button class="warn" type="submit">Mark orphaned</button>
+            </form>
+          `
+        : raw('<span class="muted">No actions available — this judgment is closed.</span>');
+
+    const body = html`
+      ${viewHead({
+        num: '04',
+        title: `Rembric Judgment ${shortId(row.id)}.`,
+        hl: 'Rembric',
+        meta: [
+          { k: 'STATUS', v: row.status.toUpperCase() },
+          { k: 'VERDICT', v: row.relation ? row.relation.toUpperCase() : '—' },
+        ],
+      })}
+      ${backLink({ href: '/dashboard/judgments', label: 'BACK TO JUDGMENTS' })}
+      <div class="stat-grid">
+        <div class="stat-card">
+          <div class="label">Status</div>
+          <div class="value">${statusPill(row.status)}</div>
+        </div>
+        <div class="stat-card">
+          <div class="label">Verdict</div>
+          <div class="value">${verdictPill(row.relation)}</div>
+        </div>
+        <div class="stat-card">
+          <div class="label">Confidence</div>
+          <div class="value">${row.confidence !== null ? row.confidence.toFixed(2) : '—'}</div>
+        </div>
+        <div class="stat-card">
+          <div class="label">Marked by</div>
+          <div class="value">
+            ${row.marked_by_kind ?? '—'}
+            ${row.marked_by_actor
+              ? html`<span class="muted small"> · ${row.marked_by_actor}</span>`
+              : raw('')}
+          </div>
+        </div>
+        <div class="stat-card">
+          <div class="label">Created</div>
+          <div class="value" style="font-size:.9rem">${formatTs(new Date(row.created_at))}</div>
+        </div>
+        <div class="stat-card">
+          <div class="label">Judged</div>
+          <div class="value" style="font-size:.9rem">
+            ${row.judged_at !== null ? formatTs(new Date(row.judged_at)) : '—'}
+          </div>
+        </div>
+      </div>
+
+      <h2>Source</h2>
+      <p class="mono small">
+        <a href="/dashboard/memories/${row.source_id}">${shortId(row.source_id)}</a>
+      </p>
+      <pre>${row.source_content}</pre>
+
+      <h2>Target</h2>
+      <p class="mono small">
+        <a href="/dashboard/memories/${row.target_id}">${shortId(row.target_id)}</a>
+      </p>
+      <pre>${row.target_content}</pre>
+
+      <h2>Reason</h2>
+      <p>${row.reason ?? raw('<span class="muted">—</span>')}</p>
+
+      <h2>Evidence</h2>
+      ${evidencePretty ? html`<pre>${evidencePretty}</pre>` : html`<p class="muted">—</p>`}
+
+      <h2>Judgment id</h2>
+      <p class="mono small">${escape(row.judgment_id)}</p>
+
+      <h2>Actions</h2>
+      <p>${orphanForm}</p>
+    `;
+    return c.html(
+      renderPage(c, deps.sessions, body, {
+        title: `Judgment ${shortId(row.id)}`,
+        activeNav: 'judgments',
+      }),
     );
   });
 

--- a/apps/server/src/dashboard/styles/core/patterns.css
+++ b/apps/server/src/dashboard/styles/core/patterns.css
@@ -409,15 +409,17 @@
 .grid-6 {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
-  gap: 0;
-  border: 1px solid var(--fg-faint);
+  /* 1px gap + grid background = single consistent separator line between every
+     cell (vertical AND horizontal), independent of layout direction. Avoids
+     nth-child border tricks that produced doubled or missing dividers on the
+     mobile 2-col layout. Brighter than --fg-faint so the separators stay
+     legible against the near-black --bg. */
+  gap: 1px;
+  background: #383838;
+  border: 1px solid #383838;
 }
 .grid-6 > .stat {
   border: 0;
-  border-right: 1px solid var(--fg-faint);
-}
-.grid-6 > .stat:last-child {
-  border-right: 0;
 }
 
 .row-2 {
@@ -682,12 +684,7 @@ form .field label {
   }
   .grid-6 {
     grid-template-columns: repeat(3, 1fr);
-  }
-  .grid-6 > .stat:nth-child(3) {
-    border-right: 0;
-  }
-  .grid-6 > .stat:nth-child(n + 4) {
-    border-top: 1px solid var(--fg-faint);
+    /* gap + background separators apply automatically */
   }
 }
 
@@ -802,12 +799,7 @@ form .field label {
   }
   .grid-6 {
     grid-template-columns: repeat(3, 1fr);
-  }
-  .grid-6 > .stat:nth-child(3) {
-    border-right: 0;
-  }
-  .grid-6 > .stat:nth-child(n + 4) {
-    border-top: 1px solid var(--fg-faint);
+    /* gap + background separators apply automatically */
   }
   .kv-grid {
     grid-template-columns: repeat(3, 1fr);
@@ -892,12 +884,8 @@ form .field label {
   }
   .grid-6 {
     grid-template-columns: repeat(2, 1fr);
-  }
-  .grid-6 > .stat:nth-child(2n) {
-    border-right: 0;
-  }
-  .grid-6 > .stat:nth-child(n + 3) {
-    border-top: 1px solid var(--fg-faint);
+    /* gap + background separators still apply automatically — no per-cell
+       border rules needed at this breakpoint. */
   }
   .kv-grid {
     grid-template-columns: repeat(2, 1fr);

--- a/apps/server/src/dashboard/styles/views/home.css
+++ b/apps/server/src/dashboard/styles/views/home.css
@@ -49,6 +49,13 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex: 1;
+}
+.jq-item .pair .mem a.txt {
+  color: var(--lime);
+}
+.jq-item .pair .mem a.txt:hover {
+  text-decoration: underline;
 }
 .jq-item .acts {
   display: flex;

--- a/apps/server/src/dashboard/styles/views/judgments.css
+++ b/apps/server/src/dashboard/styles/views/judgments.css
@@ -67,3 +67,12 @@
     justify-content: flex-start;
   }
 }
+
+/* Memory + judgment-detail anchors in the listing use the brand accent so
+   operators can spot interactive cells at a glance. Scoped to this view. */
+.tbl-host td a {
+  color: var(--lime);
+}
+.tbl-host td a:hover {
+  text-decoration: underline;
+}

--- a/apps/server/src/dashboard/templates.ts
+++ b/apps/server/src/dashboard/templates.ts
@@ -439,6 +439,22 @@ export function scopePill(scope: string): SafeHtml {
   return raw(`<span class="pill ${cls}">${label}</span>`);
 }
 
+const VERDICT_KINDS = new Set([
+  'supersedes',
+  'conflicts_with',
+  'related',
+  'compatible',
+  'scoped',
+  'not_conflict',
+]);
+
+export function verdictPill(kind: string | null | undefined): SafeHtml {
+  if (!kind) return raw('<span class="muted">—</span>');
+  if (!VERDICT_KINDS.has(kind)) return raw(`<span class="pill">${escape(kind)}</span>`);
+  const cls = escape(kind);
+  return raw(`<span class="pill k-${cls}">${cls}</span>`);
+}
+
 export function formatTs(d: Date | string | number | null | undefined): SafeHtml {
   if (d === null || d === undefined) return raw('—');
   const date = d instanceof Date ? d : new Date(d);

--- a/apps/server/src/scripts/seed-dev.test.ts
+++ b/apps/server/src/scripts/seed-dev.test.ts
@@ -21,7 +21,7 @@ describe('runSeed', () => {
     expect(result.counts).toEqual({
       projects: 1,
       tokens: 3,
-      memories: 23,
+      memories: 31,
       endedSessions: 3,
       activeSessions: 2,
       pendingJudgments: 1,
@@ -63,7 +63,7 @@ describe('runSeed', () => {
     expect(result.refused).toBeUndefined();
     expect(result.counts!.projects).toBe(1);
     expect(result.counts!.tokens).toBe(3);
-    expect(result.counts!.memories).toBe(23);
+    expect(result.counts!.memories).toBe(31);
     expect(result.counts!.pendingJudgments).toBe(1);
   });
 

--- a/apps/server/src/scripts/seed-dev.ts
+++ b/apps/server/src/scripts/seed-dev.ts
@@ -309,6 +309,73 @@ export function runSeed(deps: SeedDeps): SeedResult {
   });
   memoryCount += 3;
 
+  // 7. Judged relations — four memory pairs, one per verdict colour the
+  // home overview's RECENT JUDGMENTS tile renders (supersedes / warn,
+  // conflicts_with / danger, related / dim, compatible / lime). Each pair
+  // is a fresh topicKey so the cluster supersede chains stay untouched.
+  const judgedPairs: Array<{
+    relation: 'supersedes' | 'conflicts_with' | 'related' | 'compatible';
+    topicKey: string;
+    source: string;
+    target: string;
+  }> = [
+    {
+      relation: 'supersedes',
+      topicKey: 'demo-judged-supersedes',
+      source:
+        'Pin pnpm to v11.1.2 in package.json::packageManager — newer versions need Node 22.13.',
+      target: 'Pin pnpm to v9 in package.json::packageManager for max compatibility.',
+    },
+    {
+      relation: 'conflicts_with',
+      topicKey: 'demo-judged-conflicts',
+      source: 'Run consolidator nightly at 03:00 UTC (matches default CONSOLIDATION_CRON).',
+      target: 'Run consolidator every 6h to keep orphan promotions snappy.',
+    },
+    {
+      relation: 'related',
+      topicKey: 'demo-judged-related',
+      source: 'data-confirm attributes live on the <form> element, not the <button>.',
+      target: 'Destructive forms always use data-confirm-tone=danger for irreversible ops.',
+    },
+    {
+      relation: 'compatible',
+      topicKey: 'demo-judged-compatible',
+      source: 'Use formatTs helper for absolute timestamps in dashboard tables.',
+      target: 'Use relTime helper for "X AGO" relative time in dashboard overview tiles.',
+    },
+  ];
+  for (const pair of judgedPairs) {
+    const src = memorySvc.save(
+      {
+        type: 'reference',
+        content: pair.source,
+        tags: [pair.topicKey],
+        topicKey: `${pair.topicKey}-src`,
+      },
+      scope,
+    );
+    const tgt = memorySvc.save(
+      {
+        type: 'reference',
+        content: pair.target,
+        tags: [pair.topicKey],
+        topicKey: `${pair.topicKey}-tgt`,
+      },
+      scope,
+    );
+    relationsSvc.compare({
+      sourceId: src.id,
+      targetId: tgt.id,
+      relation: pair.relation,
+      actor: 'seed-dev',
+      kind: 'agent',
+      confidence: 0.85,
+      reason: `seed-dev demo: ${pair.relation}`,
+    });
+    memoryCount += 2;
+  }
+
   const result: SeedResult = {
     skipped: false,
     counts: {

--- a/apps/server/src/server/dashboard-router.ts
+++ b/apps/server/src/server/dashboard-router.ts
@@ -24,7 +24,15 @@ import { createMaintenanceRouter } from '../dashboard/maintenance.js';
 import { createMemoriesRouter } from '../dashboard/memories.js';
 import { createProjectsRouter } from '../dashboard/projects.js';
 import { createSessionsRouter } from '../dashboard/sessions.js';
-import { escape, html, raw, shell, statusPill, type SafeHtml } from '../dashboard/templates.js';
+import {
+  escape,
+  html,
+  raw,
+  shell,
+  statusPill,
+  verdictPill,
+  type SafeHtml,
+} from '../dashboard/templates.js';
 import { createTokensRouter } from '../dashboard/tokens.js';
 import type { ResolvedSession } from '../dashboard/types.js';
 import type { Db } from '../db/client.js';
@@ -188,24 +196,26 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
 
     const activity = sevenDayActivity(deps.db);
 
-    const pendingRows = deps.db.all<{
+    const recentJudgedRows = deps.db.all<{
       id: string;
       judgment_id: string;
-      created_at: number;
+      relation: string;
+      judged_at: number;
+      marked_by_kind: string | null;
       source_id: string;
       target_id: string;
       source_content: string;
       target_content: string;
     }>(sql`
-      SELECT r.id, r.judgment_id, r.created_at,
+      SELECT r.id, r.judgment_id, r.relation, r.judged_at, r.marked_by_kind,
              r.source_id, r.target_id,
              ms.content AS source_content,
              mt.content AS target_content
       FROM memory_relations r
       JOIN memory ms ON ms.id = r.source_id
       JOIN memory mt ON mt.id = r.target_id
-      WHERE r.status = 'pending'
-      ORDER BY r.created_at ASC
+      WHERE r.status = 'judged'
+      ORDER BY r.judged_at DESC
       LIMIT 4
     `);
 
@@ -271,30 +281,30 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
         hl: 'Rembric',
       })}
 
-      <div class="grid-7" style="margin-bottom:var(--s-6)">
+      <div class="grid-6" style="margin-bottom:var(--s-6)">
         ${statCard({
-          k: 'TOTAL',
+          k: 'TOTAL MEMORIES',
           v: stats.totalMemories,
           tone: 'fg',
-          sub: html`${sparkline(activity)}<span>7D</span>`,
+          sub: html`${sparkline(activity)}<span>LAST 7 DAYS</span>`,
           href: '/dashboard/memories',
         })}
         ${statCard({
-          k: 'ACTIVE',
+          k: 'ACTIVE MEMORIES',
           v: stats.activeMemories,
           tone: 'lime',
           sub: pctOfTotal(stats.activeMemories, stats.totalMemories),
           href: '/dashboard/memories?status=active',
         })}
         ${statCard({
-          k: 'SUPERSEDED',
+          k: 'SUPERSEDED MEMORIES',
           v: supersededMemories,
           tone: supersededColor,
           sub: html`<span>SAFE TO ARCHIVE</span><span>›</span>`,
           href: '/dashboard/memories?status=superseded',
         })}
         ${statCard({
-          k: 'ARCHIVED',
+          k: 'ARCHIVED MEMORIES',
           v: stats.archivedMemories,
           tone: 'dim',
           sub: html`<span>DECAYED</span><span>›</span>`,
@@ -311,52 +321,42 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
           k: 'ACTIVE SESSIONS',
           v: stats.activeSessions,
           tone: stats.activeSessions > 0 ? 'lime' : 'fg',
-          sub: html`<span>NOW</span><span>›</span>`,
+          sub: html`<span>CONNECTED NOW</span><span>›</span>`,
           href: '/dashboard/sessions',
-        })}
-        ${statCard({
-          k: 'PENDING JUDGMENTS',
-          v: stats.pendingJudgments,
-          tone: stats.pendingJudgments > 0 ? 'warn' : 'lime',
-          sub: html`<span>${orphanedJ}</span><span>ORPHANED</span>`,
-          href: '/dashboard/judgments?status=pending',
         })}
       </div>
 
       <div class="row-2" style="margin-bottom:var(--s-6)">
         <div>
           ${sectionBar({
-            name: 'PENDING JUDGMENTS',
-            meta: 'QUEUE / OLDEST FIRST',
-            more: raw(
-              '<a href="/dashboard/judgments?status=pending" style="color:var(--lime)">OPEN ALL ›</a>',
-            ),
+            name: 'RECENT JUDGMENTS',
+            meta: 'NEWEST FIRST',
+            more: raw('<a href="/dashboard/judgments" style="color:var(--lime)">OPEN ALL ›</a>'),
           })}
-          ${pendingRows.length === 0
-            ? html`<div class="tbl-empty">NO PENDING JUDGMENTS YET</div>`
+          ${recentJudgedRows.length === 0
+            ? html`<div class="tbl-empty">NO JUDGMENTS YET</div>`
             : html`
                 <div class="jq">
-                  ${pendingRows.map(
+                  ${recentJudgedRows.map(
                     (r) => html`
                       <div class="jq-item">
                         <div class="pair">
                           <div class="met">
-                            <span class="pill k-pending">PENDING</span>
-                            <span>${shortDisplayId(r.id)}</span>
-                            <span>·</span>
-                            <span>${relTime(r.created_at)}</span>
+                            ${verdictPill(r.relation)}
+                            <span>${relTime(r.judged_at)}</span>
+                            ${r.marked_by_kind
+                              ? html`<span>·</span><span class="fg-dim">${r.marked_by_kind}</span>`
+                              : raw('')}
                           </div>
                           <div class="mem">
-                            <span class="t-mono fg-dim">${shortDisplayId(r.source_id)}</span>
-                            <span class="txt fg-dim" style="flex:1"
-                              >${truncate(r.source_content, 70)}</span
+                            <a href="/dashboard/memories/${r.source_id}" class="txt"
+                              >${truncate(r.source_content, 70)}</a
                             >
                           </div>
                           <div class="mem">
                             <span class="arrow">↳</span>
-                            <span class="t-mono fg-dim">${shortDisplayId(r.target_id)}</span>
-                            <span class="txt fg-dim" style="flex:1"
-                              >${truncate(r.target_content, 70)}</span
+                            <a href="/dashboard/memories/${r.target_id}" class="txt"
+                              >${truncate(r.target_content, 70)}</a
                             >
                           </div>
                         </div>
@@ -364,8 +364,8 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
                           ${btn({
                             variant: 'primary',
                             size: 'sm',
-                            label: 'JUDGE',
-                            href: `/dashboard/judgments`,
+                            label: 'VIEW →',
+                            href: `/dashboard/judgments/${r.id}`,
                           })}
                         </div>
                       </div>

--- a/apps/server/src/test/dashboard-e2e.test.ts
+++ b/apps/server/src/test/dashboard-e2e.test.ts
@@ -470,4 +470,98 @@ describe('dashboard E2E', () => {
     const body = await res.text();
     expect(body).toContain('csrf_invalid');
   });
+
+  it('home overview surfaces RECENT JUDGMENTS (empty then populated)', async () => {
+    const jar: CookieJar = { cookie: null };
+    await postForm(baseUrl, '/dashboard/login', jar, { token: ADMIN_TOKEN });
+
+    // Empty state: no judged relations yet.
+    const before = await get(baseUrl, '/dashboard', jar);
+    expect(before.status).toBe(200);
+    const beforeBody = await before.text();
+    expect(beforeBody).toContain('RECENT JUDGMENTS');
+    expect(beforeBody).toContain('NEWEST FIRST');
+    expect(beforeBody).toContain('NO JUDGMENTS YET');
+    expect(beforeBody).not.toContain('NO PENDING JUDGMENTS YET');
+
+    // Seed: two memories + a judged 'supersedes' relation between them.
+    const { createDb } = await import('../db/index.js');
+    const { MemoryService } = await import('../services/memory.js');
+    const { RelationsService } = await import('../services/relations.js');
+    const { SCOPE_GLOBAL } = await import('../services/scope.js');
+    const dataDir = server.config.dataDir;
+    const handle = createDb({ dataDir });
+    const memSvc = new MemoryService(handle.db);
+    const a = memSvc.save({ type: 'feedback', content: 'judged-row-source-content' }, SCOPE_GLOBAL);
+    const b = memSvc.save({ type: 'feedback', content: 'judged-row-target-content' }, SCOPE_GLOBAL);
+    const rel = new RelationsService(handle.db).compare({
+      sourceId: a.id,
+      targetId: b.id,
+      relation: 'supersedes',
+      actor: 'e2e-test',
+      kind: 'agent',
+      confidence: 0.9,
+      reason: 'e2e demo reason',
+    });
+    handle.close();
+
+    // Populated state on home: row renders with the supersedes pill class
+    // and the source/target content wrapped in memory-detail links (no bare
+    // short ids).
+    const after = await get(baseUrl, '/dashboard', jar);
+    expect(after.status).toBe(200);
+    const afterBody = await after.text();
+    expect(afterBody).toContain('RECENT JUDGMENTS');
+    expect(afterBody).not.toContain('NO JUDGMENTS YET');
+    expect(afterBody).toContain('pill k-supersedes');
+    expect(afterBody).toContain('judged-row-source-content');
+    expect(afterBody).toContain('judged-row-target-content');
+    expect(afterBody).toContain(`href="/dashboard/memories/${a.id}"`);
+    expect(afterBody).toContain(`href="/dashboard/memories/${b.id}"`);
+    expect(afterBody).toContain('agent');
+    // Home tile: the verdict pill itself is NOT wrapped in an anchor — a
+    // dedicated VIEW button in the row's .acts slot carries the detail link.
+    expect(afterBody).toContain(`href="/dashboard/judgments/${rel.id}"`);
+    expect(afterBody).toContain('VIEW');
+    expect(afterBody).not.toContain(
+      `<a\n                              href="/dashboard/judgments/${rel.id}"`,
+    );
+    // Stat strip: the PENDING JUDGMENTS card has been removed; the strip
+    // is now grid-6 with no pending-judgments labelled card.
+    expect(afterBody).toContain('grid-6');
+    expect(afterBody).not.toContain('PENDING JUDGMENTS');
+
+    // Same seed appears on /dashboard/judgments: source → target column
+    // shows truncated content as memory-detail links, not bare short ids;
+    // the verdict cell uses the shared verdictPill helper (k-supersedes);
+    // the leftmost id column is a link to the detail page.
+    const list = await get(baseUrl, '/dashboard/judgments', jar);
+    expect(list.status).toBe(200);
+    const listBody = await list.text();
+    expect(listBody).toContain('judged-row-source-content');
+    expect(listBody).toContain('judged-row-target-content');
+    expect(listBody).toContain(`href="/dashboard/memories/${a.id}"`);
+    expect(listBody).toContain(`href="/dashboard/memories/${b.id}"`);
+    expect(listBody).toContain('pill k-supersedes');
+    expect(listBody).toContain(`href="/dashboard/judgments/${rel.id}"`);
+
+    // Judgment detail view: renders full content for both sides, the verdict
+    // pill, reason text, back-link, and resolves 404 for unknown ids.
+    const detail = await get(baseUrl, `/dashboard/judgments/${rel.id}`, jar);
+    expect(detail.status).toBe(200);
+    const detailBody = await detail.text();
+    expect(detailBody).toContain('Rembric');
+    expect(detailBody).toContain('Judgment');
+    expect(detailBody).toContain('BACK TO JUDGMENTS');
+    expect(detailBody).toContain('judged-row-source-content');
+    expect(detailBody).toContain('judged-row-target-content');
+    expect(detailBody).toContain('pill k-supersedes');
+    expect(detailBody).toContain('e2e demo reason');
+    expect(detailBody).toContain(`href="/dashboard/memories/${a.id}"`);
+    expect(detailBody).toContain(`href="/dashboard/memories/${b.id}"`);
+
+    const missing = await get(baseUrl, '/dashboard/judgments/non-existent-id-xyz', jar);
+    expect(missing.status).toBe(404);
+    expect(await missing.text()).toContain('Judgment not found');
+  });
 });

--- a/openspec/changes/archive/2026-05-21-replace-pending-with-recent-judgments/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-21-replace-pending-with-recent-judgments/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-21

--- a/openspec/changes/archive/2026-05-21-replace-pending-with-recent-judgments/design.md
+++ b/openspec/changes/archive/2026-05-21-replace-pending-with-recent-judgments/design.md
@@ -1,0 +1,31 @@
+## Design notes
+
+### Why "judged" and not "judged + orphaned"
+
+`orphaned` relations are candidates the consolidator could not resolve in 96 h. They are signal worth surfacing somewhere, but the home overview is not the right venue: an orphaned row carries no verdict (`relation IS NULL`), so it would render as a verdict-pill-less stub that breaks the visual rhythm of the other rows. Operators already have visibility into orphans via the `ORPHANED PENDINGS` cell of the `CONSOLIDATION HEALTH` strip directly below. Including them in `RECENT JUDGMENTS` would be a category error — they are _failures to judge_, not judgments.
+
+The query is locked to `status = 'judged'`. Orphaned rows are intentionally excluded.
+
+### Why `judged_at DESC`, not `created_at DESC`
+
+`created_at` is when the candidate first surfaced (typically at `memory.save`). `judged_at` is when the verdict was written (by the agent via `memory.judge` / `memory.compare`, by topic-key auto-supersede, or by the consolidator's promotion pass). For a "what just happened" block, `judged_at` is the correct axis — `created_at` would float pending-then-late-judged rows above truly recent verdicts. The existing `memory_relations_status_created_idx` does not cover this sort, but at `LIMIT 4` over a small table it does not matter; if the dataset grows we can add `(status, judged_at)` later.
+
+### Why 4 rows, three lines each
+
+This matches the pending tile's previous density verbatim. The two tiles in `.row-2` need to align vertically with the right-hand `RECENT SESSIONS` tile (5 rows × ~2 lines each ≈ same height). Four three-line rows is the existing visual budget — no responsive churn.
+
+### Why drop the JUDGE button
+
+The button only made sense on pending rows (the action it offered was "go close this verdict"). On a judged row there is nothing left to do; the entire row is a record of past action. Removing the button collapses the `.acts` column and lets the snippets breathe.
+
+### Why the `OPEN ALL ›` link drops the `?status=pending` filter
+
+If the inline block now shows judged rows, linking the section header to a pending-filtered view would be misleading — operators expect "OPEN ALL ›" to expand the _same_ dataset, not jump to a different filter. The default `/dashboard/judgments` view shows all statuses with judged rows on top by recency, which matches the block's content. The `PENDING JUDGMENTS` stat card stays as the explicit shortcut to the backlog.
+
+### Why no schema change
+
+Everything the block needs is already in `memory_relations`: `relation`, `judged_at`, `marked_by_kind`, plus the existing JOIN to `memory.content` on both source and target. No migrations, no FTS edits, no service changes — this is a single SQL query swap + a presentation tweak.
+
+### Coexistence with `add-prompts-dashboard-view`
+
+That change touches the `dashboard` spec by **adding** the `/dashboard/prompts` requirement and **modifying** the `Sessions list` requirement to surface a prompts column. This change **modifies** the `Sidebar links to the new URL` scenario inside the `/dashboard/judgments` requirement and **adds** a new home-overview requirement. The deltas land in different `### Requirement:` sections of the same spec file, so OpenSpec strict validation will merge them cleanly regardless of merge order.

--- a/openspec/changes/archive/2026-05-21-replace-pending-with-recent-judgments/proposal.md
+++ b/openspec/changes/archive/2026-05-21-replace-pending-with-recent-judgments/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+The left tile of the dashboard home overview (`apps/server/src/server/dashboard-router.ts:326-376`) is currently anchored to `memory_relations WHERE status='pending'`. In normal operation that table is empty almost always — the agent closes candidates the moment they surface — so the most prominent column on the operator's home page is dead space showing `NO PENDING JUDGMENTS YET`. The same data is still reachable from the `PENDING JUDGMENTS` stat card a few pixels above, so the inline pending list is redundant when it does have content and wasteful when it does not.
+
+What the operator actually wants on the home is _signal about what just happened_: which memories got merged, which conflicts were declared, which the consolidator gave up on. The judgment graph is the most interesting append-only stream Rembric produces, and the home page currently does not surface a single resolved verdict.
+
+This change repurposes that tile to show the most recent **judged** relations with the same visual density as the current pending list (three lines per row, verdict pill + meta + source/target snippets). The legacy pending tile is removed; the `PENDING JUDGMENTS` stat card remains the canonical entry point to the backlog.
+
+## What Changes
+
+- **Home overview**
+  - The left tile of the home `.row-2` no longer queries `memory_relations` filtered by `status='pending'`. It now queries `status='judged' ORDER BY judged_at DESC LIMIT 4` and renders one block per row.
+  - Section header changes from `PENDING JUDGMENTS · QUEUE / OLDEST FIRST` to `RECENT JUDGMENTS · NEWEST FIRST`.
+  - The `OPEN ALL ›` link target changes from `/dashboard/judgments?status=pending` to `/dashboard/judgments` (default unfiltered view, which lands judged rows first via the existing sort).
+  - Each row renders, top-down: a verdict pill using the existing `pill k-<relation>` classes (`k-supersedes`, `k-conflicts_with`, `k-related`, `k-compatible`, `k-scoped`, `k-not_conflict`) followed by short judgment id and `judged_at` rendered via `formatTs`; one `mem` line with the source short id and content truncated to 70 chars; one `mem` line prefixed with `↳` for the target. The trailing `JUDGE` action button is removed (the row already represents a closed verdict).
+  - The empty-state copy becomes `NO JUDGMENTS YET`.
+- **Spec**
+  - The `Sidebar links to the new URL` scenario inside `Requirement: The judgment-queue view MUST be served at /dashboard/judgments` is rewritten so the `OPEN ALL ›` row header no longer links to `?status=pending`; the pending-judgments stat card link is preserved verbatim.
+  - The same `judgment-queue view` requirement is extended so the `source → target` column renders each side as a truncated content anchor instead of a bare short id, with a new scenario asserting the rendering.
+  - A new requirement `The dashboard home page MUST surface a recent-judgments block` documents the new tile's data source, sort, density (anchored content links), and empty state.
+- **Judgments list `/dashboard/judgments`**
+  - The page's underlying query JOINs `memory` twice (source + target aliases) and selects `content` for both sides.
+  - The `source → target` column renders each side as `<a href="/dashboard/memories/{id}">{truncated content}</a>` (60 chars). Short-id-only rendering is removed from this column.
+- **Tests**
+  - The e2e test that asserts the home pending block (`apps/server/src/test/dashboard-e2e.test.ts`) is updated: the pending-block assertions are replaced with assertions on the new RECENT JUDGMENTS block, including a fixture row of each verdict kind to confirm the pill class wiring.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `dashboard`: the home overview left tile changes data source and copy; one existing scenario is rewritten; one new requirement is added.
+
+## Impact
+
+**Server source**
+
+- `apps/server/src/server/dashboard-router.ts` — replace the `pendingRows` query with a `recentJudgedRows` query (`status='judged' ORDER BY judged_at DESC LIMIT 4`), update the JSX block, change `sectionBar` name + meta + `more` href, drop the JUDGE button, replace empty-state copy. The per-row source/target lines render their truncated content as an `<a href="/dashboard/memories/{id}">` anchor (no standalone short id).
+- `apps/server/src/dashboard/judgments.ts` — rewrite the page query as a raw `sql` JOIN against `memory` twice (aliased `ms` / `mt`) so source + target `content` flow through; replace the `source → target` column rendering so each side is `<a href="/dashboard/memories/{id}">{truncate(content, 60)}</a>` instead of a bare short id link.
+
+**Dev tooling**
+
+- `apps/server/src/scripts/seed-dev.ts` — add a fourth fixture block (`judgedPairs`) that creates four memory pairs and `compare()`s them with the four most-visible verdict kinds (`supersedes`, `conflicts_with`, `related`, `compatible`) so a fresh `pnpm run dev:docker:up` populates the new home tile with one row of each pill colour. Not on the spec surface — purely dev-experience.
+
+**Spec deltas**
+
+- `openspec/changes/replace-pending-with-recent-judgments/specs/dashboard/spec.md`
+
+**Tests**
+
+- `apps/server/src/test/dashboard-e2e.test.ts` — update the home-block assertions.
+
+**No impact on**
+
+- `memory_relations` schema, `RelationsService`, MCP tools, plugin clients, consolidator, the `/dashboard/judgments` view itself.
+- The `PENDING JUDGMENTS` stat card (top-of-page counter) — keeps its link to `?status=pending`.
+- The `add-prompts-dashboard-view` in-flight change — it edits `dashboard` spec deltas that are additive (new `/dashboard/prompts` requirement + sessions integration), with zero overlap on the home overview block or the `/dashboard/judgments` requirement modified here.

--- a/openspec/changes/archive/2026-05-21-replace-pending-with-recent-judgments/specs/dashboard/spec.md
+++ b/openspec/changes/archive/2026-05-21-replace-pending-with-recent-judgments/specs/dashboard/spec.md
@@ -1,0 +1,135 @@
+## ADDED Requirements
+
+### Requirement: The dashboard home page MUST surface a recent-judgments block
+
+The `/dashboard` overview page SHALL render a `RECENT JUDGMENTS` block as the left tile of its `.row-2` strip (the position previously occupied by the `PENDING JUDGMENTS` inline list). The block SHALL load the four most recently judged rows of `memory_relations` ordered by `judged_at DESC`, restricted to `status = 'judged'`. The block SHALL NOT include rows whose status is `pending` or `orphaned`.
+
+Each row SHALL render, in order:
+
+- A verdict pill produced by the shared `verdictPill(relation)` helper exported from `apps/server/src/dashboard/templates.ts`, which renders `<span class="pill k-{relation}">{relation}</span>` using the existing relation-kind classes (`k-supersedes`, `k-conflicts_with`, `k-related`, `k-compatible`, `k-scoped`, `k-not_conflict`). The same helper SHALL be used by every other dashboard surface that displays a verdict — no inline `pill k-…` HTML in templates. The pill itself SHALL NOT be wrapped in an anchor (to avoid click conflicts with the memory anchors inside the row); a dedicated `VIEW →` button (`btn({variant:'primary', size:'sm', href:'/dashboard/judgments/{id}'})`) in the row's `.acts` slot SHALL be the operator's path to the judgment detail view.
+- The `judged_at` timestamp rendered as a relative-time string (e.g. `3M AGO`, `2H AGO`) consistent with the adjacent `RECENT SESSIONS` tile, and the `marked_by_kind` value (one of `agent`, `agent_topic_key`, `consolidator`, `system`) — when present — rendered in dim text. The row SHALL NOT render the judgment's short id as standalone text on the meta line; the only way to identify the judgment from the home tile is the linked verdict pill described above.
+- One source memory line: the source memory's `content` truncated to 70 characters, wrapped in an `<a class="txt" href="/dashboard/memories/{sourceId}">` element. The short id is NOT rendered alongside (the link target carries it). The anchor SHALL be rendered in the brand lime accent (`color: var(--lime)`) via a scoped CSS rule in `styles/views/home.css`, with an underline on hover, so it reads as a link at a glance.
+- One target memory line, prefixed with the existing `↳` arrow span: the target memory's `content` truncated to 70 characters, wrapped in an `<a class="txt" href="/dashboard/memories/{targetId}">` element, styled identically (lime + hover-underline).
+- A right-aligned `.acts` slot containing a single `VIEW →` button — an `<a class="btn primary sm" href="/dashboard/judgments/{id}">` produced by the shared `btn` helper — that takes the operator to the judgment detail page.
+
+The block SHALL NOT render any per-row action button (no `JUDGE` button or equivalent affordance) — every row is a closed verdict.
+
+The block's section header SHALL read `RECENT JUDGMENTS` with the meta `NEWEST FIRST`, and SHALL include an `OPEN ALL ›` anchor whose `href` is `/dashboard/judgments` (the unfiltered default view).
+
+When no judged rows exist for the active scope, the block SHALL render the empty-state cell `NO JUDGMENTS YET`.
+
+#### Scenario: Operator sees recent judgments on the home overview
+
+- **WHEN** an authenticated operator navigates to `/dashboard` and at least one `memory_relations` row exists with `status='judged'`
+- **THEN** the response HTML SHALL contain a section header reading `RECENT JUDGMENTS` followed by between 1 and 4 rows, each containing a `pill k-{relation}` element matching that row's `relation`, two `<a href="/dashboard/memories/{id}">` anchors (one per source / target memory) wrapping the truncated content, and a relative-time string for `judged_at` matching `/^(NOW|\d+(M|H|D|MO) AGO)$/`
+
+#### Scenario: Empty home overview renders the new empty-state copy
+
+- **WHEN** an authenticated operator navigates to `/dashboard` and no `memory_relations` rows exist with `status='judged'`
+- **THEN** the response HTML SHALL contain the literal string `NO JUDGMENTS YET` inside an element with class `tbl-empty`, and SHALL NOT contain the legacy string `NO PENDING JUDGMENTS YET`
+
+#### Scenario: Recent-judgments block excludes pending and orphaned
+
+- **WHEN** the home overview is rendered with a mix of `pending`, `judged`, and `orphaned` rows in `memory_relations`
+- **THEN** the rendered `RECENT JUDGMENTS` block SHALL contain only rows whose `status='judged'`; the rendered output SHALL NOT contain any `pill k-pending` element inside the block
+
+#### Scenario: Recent-judgments block has no per-row JUDGE button
+
+- **WHEN** the home overview is rendered with at least one judged row
+- **THEN** the `RECENT JUDGMENTS` block SHALL NOT contain any element with class `acts` or any anchor whose href is `/dashboard/judgments` rendered *inside* a row (the only `OPEN ALL ›` anchor SHALL be the one in the section header)
+
+### Requirement: The dashboard MUST surface a judgment detail view at `/dashboard/judgments/:id`
+
+The dashboard SHALL serve a per-row detail page at `/dashboard/judgments/:id` (where `:id` is the `memory_relations.id` primary key). The page SHALL load the judgment row alongside the source and target memory contents (JOIN over `memory` twice) and SHALL render:
+
+- A `viewHead` whose title is `Rembric Judgment {shortId}.` with `Rembric` highlighted via `hl-lime`, and whose meta strip exposes `STATUS` and `VERDICT`.
+- A `BACK TO JUDGMENTS` back-link to `/dashboard/judgments`.
+- A stat grid with six cards: Status (rendered via `statusPill`), Verdict (rendered via `verdictPill`), Confidence, Marked by (`marked_by_kind` + `marked_by_actor`), Created (`formatTs(created_at)`), Judged (`formatTs(judged_at)` or em-dash when null).
+- A `Source` section with the source memory's short id rendered as an anchor to `/dashboard/memories/{sourceId}` followed by a `<pre>` block with the full untruncated source content.
+- A `Target` section structured identically for the target memory.
+- A `Reason` section showing the verbatim `reason` text or an em-dash when null.
+- An `Evidence` section showing the `evidence` JSON pretty-printed inside a `<pre>` block, or an em-dash when null.
+- A `Judgment id` section showing the opaque `judgment_id` token in mono.
+- An `Actions` section: when `status='pending'` the section SHALL render the existing `judgment.orphan` form (CSRF-protected, `data-confirm-tone="danger"`); otherwise it SHALL render a muted "No actions available — this judgment is closed." line.
+
+When the `:id` does not match any row, the page SHALL respond with `404 Not Found` and a `Judgment not found.` flash, using the standard dashboard shell.
+
+#### Scenario: Operator opens a judgment detail page
+
+- **WHEN** an authenticated operator navigates to `/dashboard/judgments/{id}` where `id` matches an existing `memory_relations.id`
+- **THEN** the server SHALL return a `200` HTML response whose heading reads `Rembric Judgment {shortId}.`, and whose body contains the source memory's full content inside a `<pre>` block, the target memory's full content inside a `<pre>` block, anchors to both `/dashboard/memories/{sourceId}` and `/dashboard/memories/{targetId}`, and the verdict pill rendered via `verdictPill`
+
+#### Scenario: Judgment detail returns 404 for unknown ids
+
+- **WHEN** an authenticated operator navigates to `/dashboard/judgments/non-existent-id`
+- **THEN** the server SHALL respond with `404 Not Found` and the response body SHALL contain the flash text `Judgment not found.`
+
+#### Scenario: Recent-judgments tile exposes a VIEW button to the detail page
+
+- **WHEN** the home overview is rendered with at least one judged row
+- **THEN** each row SHALL contain a `.btn.primary.sm` anchor labelled `VIEW →` inside the row's `.acts` slot, whose `href` is `/dashboard/judgments/{id}` (where `{id}` is the corresponding `memory_relations.id`)
+- **AND** the verdict pill itself SHALL NOT be wrapped in an anchor (no click conflict with the memory links in the row)
+
+#### Scenario: Judgments list id column links to the detail page
+
+- **WHEN** the operator navigates to `/dashboard/judgments` with at least one row present
+- **THEN** each row's leftmost `id` cell SHALL contain an `<a href="/dashboard/judgments/{id}">` anchor wrapping the short id, where `{id}` is that row's `memory_relations.id`
+
+## MODIFIED Requirements
+
+### Requirement: The judgment-queue view MUST be served at `/dashboard/judgments`
+
+The dashboard SHALL serve the operator-facing queue of memory-relation judgments at the URL `/dashboard/judgments`. The page SHALL list every row of `memory_relations` (status `pending`, `judged`, or `orphaned`), SHALL support filtering by status and verdict kind, and SHALL paginate results. The legacy path `/dashboard/relations` SHALL NOT respond; any request to it SHALL return the standard dashboard `404` body.
+
+The page heading SHALL read `Rembric Judgments.` (with `Rembric` highlighted via `hl-lime`), the document `<title>` SHALL read `Judgments · Rembric`, the empty-state cell SHALL read `No judgments match this filter.`, the table column previously labelled `relation` SHALL be labelled `verdict`, and the orphan-not-found flash SHALL read `Judgment not found or already closed.`.
+
+The `source → target` column SHALL render each side as an `<a href="/dashboard/memories/{id}">` anchor whose visible text is the corresponding memory's `content` truncated to 60 characters (not the memory's short id). The two anchors SHALL be separated by the `→` arrow as before. Short-id-only rendering is retained ONLY for the leftmost `id` column (the judgment's own id) and for any other surface that pre-dates this change.
+
+The `verdict` column SHALL render via the shared `verdictPill(relation)` helper. When `relation` is non-null the cell SHALL contain a `<span class="pill k-{relation}">{relation}</span>` element (matching the home overview's `RECENT JUDGMENTS` tile). When `relation` is null (pending or orphaned rows) the cell SHALL contain the muted em-dash `<span class="muted">—</span>`. No inline `pill k-…` HTML SHALL exist in the judgments page template.
+
+#### Scenario: Operator opens the judgment queue
+
+- **WHEN** an authenticated operator navigates to `/dashboard/judgments`
+- **THEN** the server SHALL return a `200` HTML response whose heading reads `Rembric Judgments.` and whose table column header for the relation kind reads `verdict`
+
+#### Scenario: Legacy `/dashboard/relations` returns 404
+
+- **WHEN** any authenticated request reaches `/dashboard/relations`
+- **THEN** the server SHALL respond with `404 Not Found` (no redirect)
+
+#### Scenario: Sidebar and home links to the judgments view
+
+- **WHEN** any authenticated dashboard page is rendered
+- **THEN** the sidebar nav item labelled `JUDGMENTS` SHALL have `href="/dashboard/judgments"`
+- **AND** the home overview `RECENT JUDGMENTS` section header `OPEN ALL ›` anchor SHALL link to `/dashboard/judgments` (the unfiltered default view)
+- **AND** the home overview stat strip SHALL NOT include a `PENDING JUDGMENTS` stat card; pending counts are surfaced only via the sidebar badge on the `JUDGMENTS` nav entry
+
+#### Scenario: CSRF action token uses the judgment vocabulary
+
+- **WHEN** the operator submits the "mark this judgment as orphaned" form on the judgments page
+- **THEN** the CSRF token issued by the form and the action verified by the server SHALL both be the string `judgment.orphan`
+
+### Requirement: The dashboard home page MUST include a sessions counter
+
+The `/dashboard` overview page SHALL surface a "Sessions (active)" stat card alongside the existing counters. The stat strip SHALL render exactly six cards in this order — `TOTAL`, `ACTIVE`, `SUPERSEDED`, `ARCHIVED`, `PROJECTS`, `ACTIVE SESSIONS` — inside a `.grid-6` container. The previously-rendered `PENDING JUDGMENTS` card has been removed: the LLM now resolves pending candidates inline via `memory.judge`, so an operator-facing counter adds visual noise without an actionable workflow. Pending counts remain accessible via the `JUDGMENTS` sidebar badge.
+
+#### Scenario: The home page is rendered after sessions exist
+
+- **WHEN** the user lands on `/dashboard` and one or more sessions have `status = 'active'`
+- **THEN** the stat grid SHALL include a `Sessions (active)` card whose value is the count
+
+#### Scenario: The home stat strip omits the PENDING JUDGMENTS card
+
+- **WHEN** any authenticated operator navigates to `/dashboard`
+- **THEN** the response HTML SHALL contain a `.grid-6` stat strip with exactly six `.stat` cards, and SHALL NOT contain a stat card labelled `PENDING JUDGMENTS`
+
+#### Scenario: source → target column shows truncated memory content as links
+
+- **WHEN** an authenticated operator navigates to `/dashboard/judgments` with at least one row present
+- **THEN** each row's `source → target` column SHALL contain two `<a href="/dashboard/memories/{id}">` anchors whose visible text is the corresponding memory's `content` truncated to 60 characters, and SHALL NOT contain the memory's short id rendered as standalone text in that column
+
+#### Scenario: verdict column reuses the shared verdict-pill component
+
+- **WHEN** an authenticated operator navigates to `/dashboard/judgments` with at least one judged row present (relation set)
+- **THEN** that row's `verdict` cell SHALL contain a `<span class="pill k-{relation}">{relation}</span>` element identical to the rendering used by the home overview's `RECENT JUDGMENTS` tile
+- **AND** any pending or orphaned row's `verdict` cell SHALL contain only a `<span class="muted">—</span>` element

--- a/openspec/changes/archive/2026-05-21-replace-pending-with-recent-judgments/tasks.md
+++ b/openspec/changes/archive/2026-05-21-replace-pending-with-recent-judgments/tasks.md
@@ -1,0 +1,56 @@
+## 1. Replace the home overview pending-judgments tile with recent-judgments
+
+- [x] 1.1 In `apps/server/src/server/dashboard-router.ts`, rename the local `pendingRows` binding to `recentJudgedRows` and replace its SQL with `SELECT r.id, r.judgment_id, r.relation, r.judged_at, r.marked_by_kind, r.source_id, r.target_id, ms.content AS source_content, mt.content AS target_content FROM memory_relations r JOIN memory ms ON ms.id = r.source_id JOIN memory mt ON mt.id = r.target_id WHERE r.status = 'judged' ORDER BY r.judged_at DESC LIMIT 4`. Update the row type to include `relation: RelationKind | null` and `judged_at: number | null` and `marked_by_kind: MarkedByKind | null`.
+- [x] 1.2 In the same file, update the `sectionBar` call inside the left tile of `.row-2`: change `name` from `PENDING JUDGMENTS` to `RECENT JUDGMENTS`, change `meta` from `QUEUE / OLDEST FIRST` to `NEWEST FIRST`, change the `more` anchor `href` from `/dashboard/judgments?status=pending` to `/dashboard/judgments`.
+- [x] 1.3 Replace the per-row `html` template inside the left tile so each row renders, top-down: a `<span class="pill k-${relation}">${relation}</span>` followed by short judgment id, `relTime(judgedAt)` (matching the helper used by `RECENT SESSIONS`), and the `marked_by_kind` value in dim text when present; one `<div class="mem">` line for the source (short id + truncated content); one `<div class="mem">` line for the target (prefixed with the `↳` arrow span + short id + truncated content). Drop the trailing `<div class="acts">` block (no JUDGE button on closed verdicts).
+- [x] 1.4 Replace the empty-state copy `NO PENDING JUDGMENTS YET` with `NO JUDGMENTS YET`.
+- [x] 1.5 Run `pnpm --filter server typecheck` and confirm green.
+
+## 2. Update tests
+
+- [x] 2.1 In `apps/server/src/test/dashboard-e2e.test.ts`, locate the home-page assertion block that touches `PENDING JUDGMENTS` / `NO PENDING JUDGMENTS YET`. Replace it with assertions that the body contains `RECENT JUDGMENTS`, `NEWEST FIRST`, and either `NO JUDGMENTS YET` (empty fixture) or one judged-row fixture with a verdict pill class like `k-supersedes`. _Note: no prior assertions existed for the pending block — added a new test case covering both branches._
+- [x] 2.2 Extend the test seed to insert at least one `memory_relations` row with `status='judged'`, `relation='supersedes'`, `judged_at = now`, and matching source + target memory rows, so the populated branch of the new tile is covered.
+- [x] 2.3 Run `pnpm --filter server vitest run dashboard-e2e.test.ts` and confirm green.
+- [x] 2.4 Run `pnpm test` and confirm the full suite stays green (no regressions in pending-flow tests, since the inline tile is the only thing touched). _466 server tests + 28 hermes-plugin tests passed._
+
+## 3. Validate spec
+
+- [x] 3.1 Run `openspec validate replace-pending-with-recent-judgments --strict` and confirm clean exit.
+- [x] 3.2 Spot-check the rendered dashboard at `pnpm run dev:docker:up` (or local dev): seed a judged relation, confirm the new tile shows it with the correct pill colour and that `OPEN ALL ›` lands on `/dashboard/judgments`. _Operator confirmed visually on 2026-05-21 against the dev stack (desktop + mobile)._
+
+## 4. Link memory content (instead of short ids) on both surfaces
+
+- [x] 4.1 In `apps/server/src/server/dashboard-router.ts` (home overview tile), replace the per-row `mem` lines: remove the `<span class="t-mono fg-dim">${shortDisplayId(...)}</span>` and wrap the truncated content in `<a href="/dashboard/memories/${r.source_id}">` and `<a href="/dashboard/memories/${r.target_id}">` respectively, with `text-decoration:none; color:inherit` inline styles consistent with the adjacent `.tl-item` links.
+- [x] 4.2 In `apps/server/src/dashboard/judgments.ts`, rewrite the rows query as a raw `sql` JOIN: `SELECT r.*, ms.content AS source_content, mt.content AS target_content FROM memory_relations r JOIN memory ms ON ms.id = r.source_id JOIN memory mt ON mt.id = r.target_id ...` preserving the existing WHERE clauses (status/kind filters) and the `ORDER BY r.created_at DESC LIMIT/OFFSET` pagination. Drop the drizzle `select().from(memoryRelations)` path entirely.
+- [x] 4.3 In the same file, update the `source → target` column rendering so each side is `<a href="/dashboard/memories/{id}">{truncate(content, 60)}</a>` (use a small local `truncate` helper or factor one if missing). Remove the previous `shortId(r.sourceId)` / `shortId(r.targetId)` rendering inside that column.
+- [x] 4.4 Extend the e2e test (`apps/server/src/test/dashboard-e2e.test.ts`): in the existing populated-tile assertion, add `expect(afterBody).toContain('href="/dashboard/memories/${a.id}"')` and the same for `b.id`; in the `judgments list view renders after login` test, add an assertion that the response HTML contains `href="/dashboard/memories/"` (twice — once per side) for the seeded judged row.
+- [x] 4.5 Run `pnpm --filter server typecheck`, `pnpm --filter server exec vitest run dashboard-e2e.test.ts`, and `openspec validate replace-pending-with-recent-judgments --strict`. All green.
+
+## 5. Extract verdictPill component
+
+- [x] 5.1 In `apps/server/src/dashboard/templates.ts`, export `verdictPill(kind: string | null | undefined): SafeHtml` alongside `statusPill` / `scopePill`. For null/undefined return `<span class="muted">—</span>`; for known verdicts (`supersedes`, `conflicts_with`, `related`, `compatible`, `scoped`, `not_conflict`) return `<span class="pill k-{kind}">{kind}</span>`; for unknown strings return a neutral `<span class="pill">{kind}</span>` (defensive).
+- [x] 5.2 In `apps/server/src/server/dashboard-router.ts`, import `verdictPill` and replace the inline `<span class="pill k-${r.relation}">${r.relation}</span>` on the home tile with `${verdictPill(r.relation)}`.
+- [x] 5.3 In `apps/server/src/dashboard/judgments.ts`, import `verdictPill` and replace the bare-text `verdict` cell (`${r.relation ?? raw('<span class="muted">—</span>')}`) with `${verdictPill(r.relation)}` so the column gets the same colored pill as the home tile.
+- [x] 5.4 Extend the e2e test to assert the judgments list contains `pill k-supersedes` (mirroring the home assertion). Run `pnpm --filter server exec vitest run dashboard-e2e.test.ts`. Re-run `pnpm test` + `pnpm run lint` + `openspec validate --strict`. All green.
+
+## 6. Judgment detail page + linkage
+
+- [x] 6.1 Add a new route `app.get('/:id', ...)` to `apps/server/src/dashboard/judgments.ts`. The handler SHALL query the row by `memory_relations.id` JOINed with `memory` twice for source + target content, render the `viewHead` + stat grid (Status, Verdict, Confidence, Marked by, Created, Judged), `<pre>` blocks for source/target full contents (with anchors to `/dashboard/memories/{id}`), reason, evidence (JSON pretty-printed), the opaque `judgment_id`, and the orphan form when status='pending'. Return `404` with `Judgment not found.` flash on unknown id.
+- [x] 6.2 In `apps/server/src/server/dashboard-router.ts` (home tile), remove the `<span>${shortDisplayId(r.id)}</span>` + separator from the meta line. (Note: the pill wrapping was later replaced in task 7.1 by a dedicated `VIEW →` button in `.acts` to avoid click conflicts with the memory anchors — superseded by 7.1.)
+- [x] 6.3 In `apps/server/src/dashboard/judgments.ts` (list page), wrap the `shortId(r.id)` rendering of the leftmost `id` column in `<a href="/dashboard/judgments/${r.id}">…</a>`.
+- [x] 6.4 Extend `apps/server/src/test/dashboard-e2e.test.ts`: in the populated-tile test, capture the relation id (`compare()` returns the row), assert `href="/dashboard/judgments/${rel.id}"` is present on the home tile, fetch `/dashboard/judgments/${rel.id}` and assert (a) status 200 (b) body contains both untruncated memory contents (c) body contains `verdictPill` HTML `pill k-supersedes` (d) body contains `BACK TO JUDGMENTS`. Also assert that the home meta line no longer contains the relation's short id rendered as plain text (only inside the anchor href).
+- [x] 6.5 Run `pnpm --filter server typecheck`, `pnpm --filter server exec vitest run dashboard-e2e.test.ts`, `pnpm test`, `pnpm run lint`, and `openspec validate replace-pending-with-recent-judgments --strict`. All green.
+
+## 7. Polish: lime memory links + dedicated VIEW button + drop PENDING stat card
+
+- [x] 7.1 In `apps/server/src/server/dashboard-router.ts` (home tile), remove the `<a>` wrapper around the `verdictPill` call (pill becomes a plain span again) and reinstate the right-side `.acts` slot with a single `${btn({ variant:'primary', size:'sm', label:'VIEW →', href:'/dashboard/judgments/${r.id}' })}` so the row regains a clear, non-conflicting click target for the detail view.
+- [x] 7.2 In `apps/server/src/dashboard/styles/views/home.css`, add scoped CSS rules so memory anchors inside `.jq-item .pair .mem` render in `var(--lime)` with an underline on hover, and remove the legacy inline `color:inherit` / `text-decoration:none` from the template.
+- [x] 7.3 In `apps/server/src/dashboard/styles/views/judgments.css`, scope a parallel rule (`.tbl-host td a { color: var(--lime) }` + hover underline) so the listing's source→target anchors and the id-column detail link match the home tile's brand-accent treatment.
+- [x] 7.4 In `apps/server/src/server/dashboard-router.ts`, drop the `PENDING JUDGMENTS` stat card from the home stat strip and change the wrapping container from `grid-7` to `grid-6`. Keep `stats.pendingJudgments` flowing into `renderSidebar` (it still drives the sidebar `JUDGMENTS` badge) and keep `orphanedJ` (still consumed by the CONSOLIDATION HEALTH strip below).
+- [x] 7.5 Extend the e2e test to assert (a) the home contains a `VIEW` button + `href="/dashboard/judgments/{rel.id}"` outside the verdict pill, (b) the stat strip uses `grid-6` and contains no `PENDING JUDGMENTS` text. Run `pnpm --filter server typecheck`, `pnpm --filter server exec vitest run dashboard-e2e.test.ts`, `pnpm test`, `pnpm run lint`, `openspec validate replace-pending-with-recent-judgments --strict` — all green.
+
+## 8. Verbose stat labels + visible mobile inter-card separator
+
+- [x] 8.1 In `apps/server/src/server/dashboard-router.ts`, expand the six stat cards' `k` labels so each card's referent is unambiguous: `TOTAL` → `TOTAL MEMORIES`, `ACTIVE` → `ACTIVE MEMORIES`, `SUPERSEDED` → `SUPERSEDED MEMORIES`, `ARCHIVED` → `ARCHIVED MEMORIES`. Tighten the `sub` copy: `7D` → `LAST 7 DAYS`, `NOW` → `CONNECTED NOW`. `PROJECTS` and `ACTIVE SESSIONS` stay as-is per operator feedback (`ACTIVE SESSIONS` was clearer than `ACTIVE AGENT SESSIONS`; `DECAYED` is shorter than `DECAYED — NOT RECALLED`).
+- [x] 8.2 In `apps/server/src/dashboard/styles/core/patterns.css`, replace the inter-card border colour on `.grid-6` (base + the 1280/980/640 breakpoints) from raw `var(--fg-faint)` (`#2a2a2a`, virtually indistinguishable from the page background) to `color-mix(in oklab, var(--fg-faint), var(--fg-dim) 35%)`. Affects only the .stat internal separators, not the outer card border or other surfaces.
+- [x] 8.3 Run `pnpm --filter server typecheck`, `pnpm --filter server exec vitest run dashboard-e2e.test.ts`, `pnpm test`, `pnpm run lint`, `openspec validate replace-pending-with-recent-judgments --strict` — all green.

--- a/openspec/specs/dashboard/spec.md
+++ b/openspec/specs/dashboard/spec.md
@@ -197,12 +197,28 @@ The title column SHALL be the first visible content column (left of session id) 
 
 ### Requirement: The dashboard home page MUST include a sessions counter
 
-The `/dashboard` overview page SHALL surface a "Sessions (active)" stat card alongside the existing counters.
+The `/dashboard` overview page SHALL surface a "Sessions (active)" stat card alongside the existing counters. The stat strip SHALL render exactly six cards in this order — `TOTAL`, `ACTIVE`, `SUPERSEDED`, `ARCHIVED`, `PROJECTS`, `ACTIVE SESSIONS` — inside a `.grid-6` container. The previously-rendered `PENDING JUDGMENTS` card has been removed: the LLM now resolves pending candidates inline via `memory.judge`, so an operator-facing counter adds visual noise without an actionable workflow. Pending counts remain accessible via the `JUDGMENTS` sidebar badge.
 
 #### Scenario: The home page is rendered after sessions exist
 
 - **WHEN** the user lands on `/dashboard` and one or more sessions have `status = 'active'`
 - **THEN** the stat grid SHALL include a `Sessions (active)` card whose value is the count
+
+#### Scenario: The home stat strip omits the PENDING JUDGMENTS card
+
+- **WHEN** any authenticated operator navigates to `/dashboard`
+- **THEN** the response HTML SHALL contain a `.grid-6` stat strip with exactly six `.stat` cards, and SHALL NOT contain a stat card labelled `PENDING JUDGMENTS`
+
+#### Scenario: source → target column shows truncated memory content as links
+
+- **WHEN** an authenticated operator navigates to `/dashboard/judgments` with at least one row present
+- **THEN** each row's `source → target` column SHALL contain two `<a href="/dashboard/memories/{id}">` anchors whose visible text is the corresponding memory's `content` truncated to 60 characters, and SHALL NOT contain the memory's short id rendered as standalone text in that column
+
+#### Scenario: verdict column reuses the shared verdict-pill component
+
+- **WHEN** an authenticated operator navigates to `/dashboard/judgments` with at least one judged row present (relation set)
+- **THEN** that row's `verdict` cell SHALL contain a `<span class="pill k-{relation}">{relation}</span>` element identical to the rendering used by the home overview's `RECENT JUDGMENTS` tile
+- **AND** any pending or orphaned row's `verdict` cell SHALL contain only a `<span class="muted">—</span>` element
 
 ### Requirement: Dashboard timestamps MUST render in the viewer's local timezone
 
@@ -472,6 +488,10 @@ The dashboard SHALL serve the operator-facing queue of memory-relation judgments
 
 The page heading SHALL read `Rembric Judgments.` (with `Rembric` highlighted via `hl-lime`), the document `<title>` SHALL read `Judgments · Rembric`, the empty-state cell SHALL read `No judgments match this filter.`, the table column previously labelled `relation` SHALL be labelled `verdict`, and the orphan-not-found flash SHALL read `Judgment not found or already closed.`.
 
+The `source → target` column SHALL render each side as an `<a href="/dashboard/memories/{id}">` anchor whose visible text is the corresponding memory's `content` truncated to 60 characters (not the memory's short id). The two anchors SHALL be separated by the `→` arrow as before. Short-id-only rendering is retained ONLY for the leftmost `id` column (the judgment's own id) and for any other surface that pre-dates this change.
+
+The `verdict` column SHALL render via the shared `verdictPill(relation)` helper. When `relation` is non-null the cell SHALL contain a `<span class="pill k-{relation}">{relation}</span>` element (matching the home overview's `RECENT JUDGMENTS` tile). When `relation` is null (pending or orphaned rows) the cell SHALL contain the muted em-dash `<span class="muted">—</span>`. No inline `pill k-…` HTML SHALL exist in the judgments page template.
+
 #### Scenario: Operator opens the judgment queue
 
 - **WHEN** an authenticated operator navigates to `/dashboard/judgments`
@@ -482,10 +502,12 @@ The page heading SHALL read `Rembric Judgments.` (with `Rembric` highlighted via
 - **WHEN** any authenticated request reaches `/dashboard/relations`
 - **THEN** the server SHALL respond with `404 Not Found` (no redirect)
 
-#### Scenario: Sidebar links to the new URL
+#### Scenario: Sidebar and home links to the judgments view
 
 - **WHEN** any authenticated dashboard page is rendered
-- **THEN** the sidebar nav item labelled `JUDGMENTS` SHALL have `href="/dashboard/judgments"` and the home overview SHALL link to `/dashboard/judgments?status=pending` from the pending-judgments stat card and from the `OPEN ALL ›` row header
+- **THEN** the sidebar nav item labelled `JUDGMENTS` SHALL have `href="/dashboard/judgments"`
+- **AND** the home overview `RECENT JUDGMENTS` section header `OPEN ALL ›` anchor SHALL link to `/dashboard/judgments` (the unfiltered default view)
+- **AND** the home overview stat strip SHALL NOT include a `PENDING JUDGMENTS` stat card; pending counts are surfaced only via the sidebar badge on the `JUDGMENTS` nav entry
 
 #### Scenario: CSRF action token uses the judgment vocabulary
 
@@ -569,3 +591,78 @@ The detail view at `/dashboard/sessions/:id` SHALL render the Abandon form in th
 - **WHEN** a POST to `/dashboard/sessions/<S>/abandon` is made (e.g. via a stale form replayed after the row transitioned)
 - **THEN** the response SHALL be `400` with a `flash error` body describing the `session_already_ended` condition
 - **AND** the row's `status` SHALL remain `'ended'`
+
+### Requirement: The dashboard home page MUST surface a recent-judgments block
+
+The `/dashboard` overview page SHALL render a `RECENT JUDGMENTS` block as the left tile of its `.row-2` strip (the position previously occupied by the `PENDING JUDGMENTS` inline list). The block SHALL load the four most recently judged rows of `memory_relations` ordered by `judged_at DESC`, restricted to `status = 'judged'`. The block SHALL NOT include rows whose status is `pending` or `orphaned`.
+
+Each row SHALL render, in order:
+
+- A verdict pill produced by the shared `verdictPill(relation)` helper exported from `apps/server/src/dashboard/templates.ts`, which renders `<span class="pill k-{relation}">{relation}</span>` using the existing relation-kind classes (`k-supersedes`, `k-conflicts_with`, `k-related`, `k-compatible`, `k-scoped`, `k-not_conflict`). The same helper SHALL be used by every other dashboard surface that displays a verdict — no inline `pill k-…` HTML in templates. The pill itself SHALL NOT be wrapped in an anchor (to avoid click conflicts with the memory anchors inside the row); a dedicated `VIEW →` button (`btn({variant:'primary', size:'sm', href:'/dashboard/judgments/{id}'})`) in the row's `.acts` slot SHALL be the operator's path to the judgment detail view.
+- The `judged_at` timestamp rendered as a relative-time string (e.g. `3M AGO`, `2H AGO`) consistent with the adjacent `RECENT SESSIONS` tile, and the `marked_by_kind` value (one of `agent`, `agent_topic_key`, `consolidator`, `system`) — when present — rendered in dim text. The row SHALL NOT render the judgment's short id as standalone text on the meta line; the only way to identify the judgment from the home tile is the linked verdict pill described above.
+- One source memory line: the source memory's `content` truncated to 70 characters, wrapped in an `<a class="txt" href="/dashboard/memories/{sourceId}">` element. The short id is NOT rendered alongside (the link target carries it). The anchor SHALL be rendered in the brand lime accent (`color: var(--lime)`) via a scoped CSS rule in `styles/views/home.css`, with an underline on hover, so it reads as a link at a glance.
+- One target memory line, prefixed with the existing `↳` arrow span: the target memory's `content` truncated to 70 characters, wrapped in an `<a class="txt" href="/dashboard/memories/{targetId}">` element, styled identically (lime + hover-underline).
+- A right-aligned `.acts` slot containing a single `VIEW →` button — an `<a class="btn primary sm" href="/dashboard/judgments/{id}">` produced by the shared `btn` helper — that takes the operator to the judgment detail page.
+
+The block SHALL NOT render any per-row action button (no `JUDGE` button or equivalent affordance) — every row is a closed verdict.
+
+The block's section header SHALL read `RECENT JUDGMENTS` with the meta `NEWEST FIRST`, and SHALL include an `OPEN ALL ›` anchor whose `href` is `/dashboard/judgments` (the unfiltered default view).
+
+When no judged rows exist for the active scope, the block SHALL render the empty-state cell `NO JUDGMENTS YET`.
+
+#### Scenario: Operator sees recent judgments on the home overview
+
+- **WHEN** an authenticated operator navigates to `/dashboard` and at least one `memory_relations` row exists with `status='judged'`
+- **THEN** the response HTML SHALL contain a section header reading `RECENT JUDGMENTS` followed by between 1 and 4 rows, each containing a `pill k-{relation}` element matching that row's `relation`, two `<a href="/dashboard/memories/{id}">` anchors (one per source / target memory) wrapping the truncated content, and a relative-time string for `judged_at` matching `/^(NOW|\d+(M|H|D|MO) AGO)$/`
+
+#### Scenario: Empty home overview renders the new empty-state copy
+
+- **WHEN** an authenticated operator navigates to `/dashboard` and no `memory_relations` rows exist with `status='judged'`
+- **THEN** the response HTML SHALL contain the literal string `NO JUDGMENTS YET` inside an element with class `tbl-empty`, and SHALL NOT contain the legacy string `NO PENDING JUDGMENTS YET`
+
+#### Scenario: Recent-judgments block excludes pending and orphaned
+
+- **WHEN** the home overview is rendered with a mix of `pending`, `judged`, and `orphaned` rows in `memory_relations`
+- **THEN** the rendered `RECENT JUDGMENTS` block SHALL contain only rows whose `status='judged'`; the rendered output SHALL NOT contain any `pill k-pending` element inside the block
+
+#### Scenario: Recent-judgments block has no per-row JUDGE button
+
+- **WHEN** the home overview is rendered with at least one judged row
+- **THEN** the `RECENT JUDGMENTS` block SHALL NOT contain any element with class `acts` or any anchor whose href is `/dashboard/judgments` rendered _inside_ a row (the only `OPEN ALL ›` anchor SHALL be the one in the section header)
+
+### Requirement: The dashboard MUST surface a judgment detail view at `/dashboard/judgments/:id`
+
+The dashboard SHALL serve a per-row detail page at `/dashboard/judgments/:id` (where `:id` is the `memory_relations.id` primary key). The page SHALL load the judgment row alongside the source and target memory contents (JOIN over `memory` twice) and SHALL render:
+
+- A `viewHead` whose title is `Rembric Judgment {shortId}.` with `Rembric` highlighted via `hl-lime`, and whose meta strip exposes `STATUS` and `VERDICT`.
+- A `BACK TO JUDGMENTS` back-link to `/dashboard/judgments`.
+- A stat grid with six cards: Status (rendered via `statusPill`), Verdict (rendered via `verdictPill`), Confidence, Marked by (`marked_by_kind` + `marked_by_actor`), Created (`formatTs(created_at)`), Judged (`formatTs(judged_at)` or em-dash when null).
+- A `Source` section with the source memory's short id rendered as an anchor to `/dashboard/memories/{sourceId}` followed by a `<pre>` block with the full untruncated source content.
+- A `Target` section structured identically for the target memory.
+- A `Reason` section showing the verbatim `reason` text or an em-dash when null.
+- An `Evidence` section showing the `evidence` JSON pretty-printed inside a `<pre>` block, or an em-dash when null.
+- A `Judgment id` section showing the opaque `judgment_id` token in mono.
+- An `Actions` section: when `status='pending'` the section SHALL render the existing `judgment.orphan` form (CSRF-protected, `data-confirm-tone="danger"`); otherwise it SHALL render a muted "No actions available — this judgment is closed." line.
+
+When the `:id` does not match any row, the page SHALL respond with `404 Not Found` and a `Judgment not found.` flash, using the standard dashboard shell.
+
+#### Scenario: Operator opens a judgment detail page
+
+- **WHEN** an authenticated operator navigates to `/dashboard/judgments/{id}` where `id` matches an existing `memory_relations.id`
+- **THEN** the server SHALL return a `200` HTML response whose heading reads `Rembric Judgment {shortId}.`, and whose body contains the source memory's full content inside a `<pre>` block, the target memory's full content inside a `<pre>` block, anchors to both `/dashboard/memories/{sourceId}` and `/dashboard/memories/{targetId}`, and the verdict pill rendered via `verdictPill`
+
+#### Scenario: Judgment detail returns 404 for unknown ids
+
+- **WHEN** an authenticated operator navigates to `/dashboard/judgments/non-existent-id`
+- **THEN** the server SHALL respond with `404 Not Found` and the response body SHALL contain the flash text `Judgment not found.`
+
+#### Scenario: Recent-judgments tile exposes a VIEW button to the detail page
+
+- **WHEN** the home overview is rendered with at least one judged row
+- **THEN** each row SHALL contain a `.btn.primary.sm` anchor labelled `VIEW →` inside the row's `.acts` slot, whose `href` is `/dashboard/judgments/{id}` (where `{id}` is the corresponding `memory_relations.id`)
+- **AND** the verdict pill itself SHALL NOT be wrapped in an anchor (no click conflict with the memory links in the row)
+
+#### Scenario: Judgments list id column links to the detail page
+
+- **WHEN** the operator navigates to `/dashboard/judgments` with at least one row present
+- **THEN** each row's leftmost `id` cell SHALL contain an `<a href="/dashboard/judgments/{id}">` anchor wrapping the short id, where `{id}` is that row's `memory_relations.id`


### PR DESCRIPTION
## Summary

- Repurpose the home overview's left tile from `PENDING JUDGMENTS` (dead space when the LLM resolves candidates inline) to `RECENT JUDGMENTS` — four most recently judged relations with verdict pill, relative time, marked-by, source/target content trimmed to 70 chars and linked to memory detail, plus a `VIEW →` button to the new judgment-detail page.
- New `/dashboard/judgments/:id` detail page (full content, stat grid, reason, evidence JSON, orphan form when pending) + the listing's `source → target` column now mirrors the home tile (content as memory anchors, verdict pill via the shared `verdictPill` helper, leftmost id column linked to the detail).
- Polish: stat strip drops `PENDING JUDGMENTS` (LLM-resolved inline; sidebar badge still surfaces the count), labels become verbose (`TOTAL/ACTIVE/SUPERSEDED/ARCHIVED MEMORIES`), grid separators switched to `gap:1px + background` (single 1px line at every breakpoint, no double-border artifacts), memory anchors render in lime with hover underline.
- Dev seed: `seed-dev.ts` now seeds 4 judged pairs (one per visible verdict colour) so `pnpm run dev:docker:up` populates the new tile out of the box.

OpenSpec change archived as `2026-05-21-replace-pending-with-recent-judgments` with 4 modified + 4 new requirements under the `dashboard` capability.

## Test plan

- [x] `pnpm --filter server typecheck` → exit 0
- [x] `pnpm test` → 466/466 server tests + 28/28 hermes-plugin tests
- [x] `pnpm run lint` → exit 0
- [x] `openspec validate replace-pending-with-recent-judgments --strict` → valid
- [x] Manual spot-check against `pnpm run dev:docker:up` on desktop + mobile (operator confirmed visually 2026-05-21): RECENT JUDGMENTS tile, judgment detail page, judgments list column, verdict pill consistency, stat strip without PENDING card, mobile grid separators visible and not doubled.