### PR TITLE
feat(server): split session predicate, harden HTTP final, auto-curate at terminal

### DIFF
--- a/apps/server/src/server/api-router.test.ts
+++ b/apps/server/src/server/api-router.test.ts
@@ -206,7 +206,7 @@ describe('createApiRouter', () => {
       expect(row?.summaryFinal).toBe(false);
     });
 
-    it('persists title alongside summary with final:true precedence', async () => {
+    it('persists title alongside summary (always final:false on HTTP path)', async () => {
       const app = makeApp();
       await call(app, 'POST', `/${projectSlug}/sessions`, {
         token: adminToken.plaintext,
@@ -214,13 +214,33 @@ describe('createApiRouter', () => {
       });
       const r = await call(app, 'POST', `/${projectSlug}/sessions/sess-sum-title/summary`, {
         token: adminToken.plaintext,
-        body: { summary: 'Goal', title: 'Fix bug', final: true },
+        body: { summary: 'Goal', title: 'Fix bug' },
       });
       expect(r.status).toBe(200);
       const row = agentSessions.getById('sess-sum-title');
+      expect(row?.summary).toBe('Goal');
       expect(row?.title).toBe('Fix bug');
-      expect(row?.summaryFinal).toBe(true);
-      expect(row?.titleFinal).toBe(true);
+      // HTTP path never lifts `_final` — only memory.session_summary (MCP) can.
+      expect(row?.summaryFinal).toBe(false);
+      expect(row?.titleFinal).toBe(false);
+    });
+
+    it('HTTP body `final:true` is silently ignored on /summary', async () => {
+      const app = makeApp();
+      await call(app, 'POST', `/${projectSlug}/sessions`, {
+        token: adminToken.plaintext,
+        body: { id: 'sess-final-ignored' },
+      });
+      const r = await call(app, 'POST', `/${projectSlug}/sessions/sess-final-ignored/summary`, {
+        token: adminToken.plaintext,
+        // A misbehaving plugin tries to lift the curated flag via HTTP.
+        body: { summary: 'raw transcript', title: 'fake curated', final: true },
+      });
+      expect(r.status).toBe(200);
+      const row = agentSessions.getById('sess-final-ignored');
+      // zod strips `final`; handler hard-codes false; flags stay 0.
+      expect(row?.summaryFinal).toBe(false);
+      expect(row?.titleFinal).toBe(false);
     });
 
     it('400 on empty summary', async () => {
@@ -260,23 +280,28 @@ describe('createApiRouter', () => {
       expect(r.body.code).toBe('session_not_found');
     });
 
-    it('non-final write is silently blocked when summary_final is true', async () => {
+    it('HTTP write is silently blocked when summary_final is already true', async () => {
       const app = makeApp();
       await call(app, 'POST', `/${projectSlug}/sessions`, {
         token: adminToken.plaintext,
         body: { id: 'sess-twice' },
       });
-      await call(app, 'POST', `/${projectSlug}/sessions/sess-twice/summary`, {
-        token: adminToken.plaintext,
-        body: { summary: 'final-first', final: true },
+      // Simulate a prior memory.session_summary (MCP) call that set final=1.
+      // The HTTP path can never lift that flag itself, so we set it via the
+      // service layer (the only legitimate path).
+      agentSessions.writeSummary('sess-twice', {
+        tokenId: adminToken.id,
+        summary: 'final-first',
+        final: true,
       });
+      // Now a HTTP-path Stop hook tries to overwrite (final defaults to false).
       const r = await call(app, 'POST', `/${projectSlug}/sessions/sess-twice/summary`, {
         token: adminToken.plaintext,
-        body: { summary: 'non-final-second', final: false },
+        body: { summary: 'non-final-second' },
       });
       expect(r.status).toBe(200);
       const row = agentSessions.getById('sess-twice');
-      // First (final:true) write wins; non-final overwrite is ignored.
+      // Curated value wins; HTTP overwrite is ignored.
       expect(row?.summary).toBe('final-first');
       expect(row?.summaryFinal).toBe(true);
     });
@@ -349,7 +374,7 @@ describe('createApiRouter', () => {
       expect(r.body.endedAt).toBe(firstEnd);
     });
 
-    it('end accepts summary and title atomically (final:false precedence)', async () => {
+    it('end accepts summary and title atomically (always final:false on HTTP path)', async () => {
       const app = makeApp();
       await call(app, 'POST', `/${projectSlug}/sessions`, {
         token: adminToken.plaintext,
@@ -357,7 +382,7 @@ describe('createApiRouter', () => {
       });
       const r = await call(app, 'POST', `/${projectSlug}/sessions/sess-end-with-summary/end`, {
         token: adminToken.plaintext,
-        body: { summary: 'transcript dump', title: 'Bug fix', final: false },
+        body: { summary: 'transcript dump', title: 'Bug fix' },
       });
       expect(r.status).toBe(200);
       const row = agentSessions.getById('sess-end-with-summary');
@@ -365,26 +390,46 @@ describe('createApiRouter', () => {
       expect(row?.summary).toBe('transcript dump');
       expect(row?.title).toBe('Bug fix');
       expect(row?.summaryFinal).toBe(false);
+      expect(row?.titleFinal).toBe(false);
     });
 
-    it('end on already-ended session preserves final summary against non-final overwrite', async () => {
+    it('HTTP body `final:true` is silently ignored on /end', async () => {
+      const app = makeApp();
+      await call(app, 'POST', `/${projectSlug}/sessions`, {
+        token: adminToken.plaintext,
+        body: { id: 'sess-end-final-ignored' },
+      });
+      const r = await call(app, 'POST', `/${projectSlug}/sessions/sess-end-final-ignored/end`, {
+        token: adminToken.plaintext,
+        body: { summary: 'transcript', title: 'fallback', final: true },
+      });
+      expect(r.status).toBe(200);
+      const row = agentSessions.getById('sess-end-final-ignored');
+      expect(row?.status).toBe('ended');
+      expect(row?.summaryFinal).toBe(false);
+      expect(row?.titleFinal).toBe(false);
+    });
+
+    it('end on already-ended session preserves curated summary against HTTP overwrite', async () => {
       const app = makeApp();
       await call(app, 'POST', `/${projectSlug}/sessions`, {
         token: adminToken.plaintext,
         body: { id: 'sess-end-protected' },
       });
-      // Model writes a final summary first.
-      await call(app, 'POST', `/${projectSlug}/sessions/sess-end-protected/summary`, {
-        token: adminToken.plaintext,
-        body: { summary: 'model wrote', title: 'Real title', final: true },
+      // Simulate a prior memory.session_summary (MCP) call that curated.
+      agentSessions.writeSummary('sess-end-protected', {
+        tokenId: adminToken.id,
+        summary: 'model wrote',
+        title: 'Real title',
+        final: true,
       });
-      // Bash hook then ends with a non-final fallback.
+      // Bash hook then ends with the HTTP fallback (which is always final:false).
       await call(app, 'POST', `/${projectSlug}/sessions/sess-end-protected/end`, {
         token: adminToken.plaintext,
-        body: { summary: 'raw transcript', title: 'fallback title', final: false },
+        body: { summary: 'raw transcript', title: 'fallback title' },
       });
       const row = agentSessions.getById('sess-end-protected');
-      // Model values preserved through the end transition.
+      // Curated values preserved through the end transition.
       expect(row?.status).toBe('ended');
       expect(row?.summary).toBe('model wrote');
       expect(row?.title).toBe('Real title');

--- a/apps/server/src/server/api-router.ts
+++ b/apps/server/src/server/api-router.ts
@@ -42,16 +42,19 @@ const sessionPostSchema = z.object({
   description: z.string().max(2000).optional(),
 });
 
+// HTTP path body schemas. `final` is NOT accepted — the only writer that
+// can lift `summary_final` / `title_final` is the MCP tool
+// `memory.session_summary`, which hard-codes `final: true` server-side.
+// HTTP-path callers (plugin Stop/idle/end hooks) are structurally
+// restricted to `final: false` writes regardless of what they send.
 const sessionSummarySchema = z.object({
   summary: z.string().min(1).max(20_000),
   title: z.string().min(1).max(100).optional(),
-  final: z.boolean().optional(),
 });
 
 const sessionEndSchema = z.object({
   summary: z.string().min(1).max(20_000).optional(),
   title: z.string().min(1).max(100).optional(),
-  final: z.boolean().optional(),
 });
 
 export function createApiRouter(deps: ApiRouterDeps): Hono<ApiEnv> {
@@ -119,7 +122,7 @@ export function createApiRouter(deps: ApiRouterDeps): Hono<ApiEnv> {
         tokenId: ctx.token.id,
         summary: parsed.data.summary,
         title: parsed.data.title,
-        final: parsed.data.final,
+        final: false,
       });
       return c.json({
         ok: true,
@@ -154,7 +157,7 @@ export function createApiRouter(deps: ApiRouterDeps): Hono<ApiEnv> {
         tokenId: ctx.token.id,
         summary: parsed.data.summary,
         title: parsed.data.title,
-        final: parsed.data.final,
+        final: false,
       });
       return c.json({
         ok: true,

--- a/apps/server/src/services/agent-sessions.test.ts
+++ b/apps/server/src/services/agent-sessions.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { tokens as tokensSchema } from '../db/schema/tokens.js';
 import { createTestDb, type TestDb } from '../test/index.js';
 
-import { AgentSessionsService } from './agent-sessions.js';
+import { AgentSessionsService, composeDerivedSummary } from './agent-sessions.js';
 import { ProjectsService } from './projects.js';
 import { TokensService } from './tokens.js';
 
@@ -455,7 +455,7 @@ describe('AgentSessionsService', () => {
     });
   });
 
-  describe('recentForContext content filter (sessionHasContent predicate)', () => {
+  describe('recentForContext content filter (sessionIsContextWorthy predicate)', () => {
     function newSessionId(suffix: string): string {
       return `sess-content-${suffix}-${Date.now()}`;
     }
@@ -466,9 +466,16 @@ describe('AgentSessionsService', () => {
       expect(recent.some((r) => r.id === s.id)).toBe(false);
     });
 
-    it('includes a session that has a summary written', () => {
+    it('includes a session that has a curated summary written', () => {
       const s = sessions.start({ tokenId, projectId, agent: 'has-summary' });
       sessions.summarize(s.id, { tokenId, summary: 'goal: x' });
+      const recent = sessions.recentForContext({ projectId, limit: 25 });
+      expect(recent.some((r) => r.id === s.id)).toBe(true);
+    });
+
+    it('includes a session with curated summary via writeSummary({final:true})', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'has-curated' });
+      sessions.writeSummary(s.id, { tokenId, summary: 'Goal: x', final: true });
       const recent = sessions.recentForContext({ projectId, limit: 25 });
       expect(recent.some((r) => r.id === s.id)).toBe(true);
     });
@@ -482,7 +489,14 @@ describe('AgentSessionsService', () => {
       expect(recent.some((r) => r.id === s.id)).toBe(true);
     });
 
-    it('includes a session referenced by at least one memory row', () => {
+    it('excludes a session whose only summary write was final:false (transcript fallback)', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'transcript-only' });
+      sessions.writeSummary(s.id, { tokenId, summary: 'raw transcript', final: false });
+      const recent = sessions.recentForContext({ projectId, limit: 25 });
+      expect(recent.some((r) => r.id === s.id)).toBe(false);
+    });
+
+    it('excludes a session referenced ONLY by a memory row (memory still surfaces via recentMemories[])', () => {
       const s = sessions.start({ tokenId, projectId, agent: 'has-memory' });
       db.handle.raw
         .prepare(
@@ -491,10 +505,10 @@ describe('AgentSessionsService', () => {
         )
         .run(newSessionId('mem'), projectId, Date.now(), s.id);
       const recent = sessions.recentForContext({ projectId, limit: 25 });
-      expect(recent.some((r) => r.id === s.id)).toBe(true);
+      expect(recent.some((r) => r.id === s.id)).toBe(false);
     });
 
-    it('includes a session referenced by at least one prompt row', () => {
+    it('excludes a session referenced ONLY by a prompt row', () => {
       const s = sessions.start({ tokenId, projectId, agent: 'has-prompt' });
       db.handle.raw
         .prepare(
@@ -503,10 +517,10 @@ describe('AgentSessionsService', () => {
         )
         .run(newSessionId('p'), s.id, projectId, Date.now());
       const recent = sessions.recentForContext({ projectId, limit: 25 });
-      expect(recent.some((r) => r.id === s.id)).toBe(true);
+      expect(recent.some((r) => r.id === s.id)).toBe(false);
     });
 
-    it('includes a session referenced by at least one confirmation row', () => {
+    it('excludes a session referenced ONLY by a confirmation row', () => {
       const s = sessions.start({ tokenId, projectId, agent: 'has-confirmation' });
       const memoryId = newSessionId('mem-for-conf');
       db.handle.raw
@@ -522,15 +536,13 @@ describe('AgentSessionsService', () => {
         )
         .run(newSessionId('c'), memoryId, Date.now(), s.id);
       const recent = sessions.recentForContext({ projectId, limit: 25 });
-      expect(recent.some((r) => r.id === s.id)).toBe(true);
+      expect(recent.some((r) => r.id === s.id)).toBe(false);
     });
 
-    it('filter-then-truncate: backfills past newer empty sessions', () => {
+    it('filter-then-truncate: backfills past newer non-curated sessions', () => {
       const useful = sessions.start({ tokenId, projectId, agent: 'useful-old' });
       sessions.summarize(useful.id, { tokenId, summary: 'older but useful' });
 
-      // Three empty sessions started AFTER `useful`. Backdating started_at
-      // via raw SQL to guarantee ordering on fast machines.
       const now = Date.now();
       for (let i = 1; i <= 3; i++) {
         const e = sessions.start({ tokenId, projectId, agent: `empty-${i}` });
@@ -547,12 +559,254 @@ describe('AgentSessionsService', () => {
       expect(recent[0]?.id).toBe(useful.id);
     });
 
-    it('soft-deleted session with content is still excluded', () => {
+    it('soft-deleted session with curated summary is still excluded', () => {
       const s = sessions.start({ tokenId, projectId, agent: 'deleted-with-content' });
       sessions.summarize(s.id, { tokenId, summary: 'had value, then deleted' });
       sessions.softDelete(s.id, { adminBypass: true });
       const recent = sessions.recentForContext({ projectId, limit: 25 });
       expect(recent.some((r) => r.id === s.id)).toBe(false);
+    });
+  });
+
+  describe('purge protection vs surfacing asymmetry', () => {
+    function newId(suffix: string): string {
+      return `asym-${suffix}-${Date.now()}`;
+    }
+
+    it('a session with anchored memory but no curated summary surfaces via auto-curate AND stays purge-protected', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'asym' });
+      db.handle.raw
+        .prepare(
+          `INSERT INTO memory (id, scope, project_id, type, content, status, replaces, created_at, session_id)
+           VALUES (?, 'project', ?, 'user', 'memory anchored to uncurated session', 'active', '[]', ?, ?)`,
+        )
+        .run(newId('mem'), projectId, Date.now(), s.id);
+
+      // Before end(): session is active, summary_final=0, NOT context-worthy yet.
+      const recentBefore = sessions.recentForContext({ projectId, limit: 25 });
+      expect(recentBefore.some((r) => r.id === s.id)).toBe(false);
+
+      // End the session — auto-curate fires (EXISTS memory).
+      sessions.end(s.id, { tokenId });
+
+      // After end(): row now has summary_final=1 with derived summary.
+      const after = sessions.getById(s.id);
+      expect(after?.summaryFinal).toBe(true);
+      expect(after?.summary).toMatch(/^\[auto\] 1 memorias/);
+
+      // (a) Surfacing: NOW context-worthy → IS in recentForContext.
+      const recentAfter = sessions.recentForContext({ projectId, limit: 25 });
+      expect(recentAfter.some((r) => r.id === s.id)).toBe(true);
+
+      // (b) Purge protection: content-bearing (EXISTS memory) → NOT purgeable
+      // even after backdating ended_at past the 1h grace.
+      const tenHoursAgo = Date.now() - 10 * 3_600_000;
+      db.handle.raw.prepare('UPDATE sessions SET ended_at = ? WHERE id = ?').run(tenHoursAgo, s.id);
+      expect(sessions.countPurgeableEmpty()).toBe(0);
+    });
+  });
+
+  describe('auto-curate at terminal transition', () => {
+    function newId(suffix: string): string {
+      return `autocur-${suffix}-${Date.now()}`;
+    }
+
+    it('end() auto-curates a session with anchored memory and no prior curation', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'autocur-memory' });
+      db.handle.raw
+        .prepare(
+          `INSERT INTO memory (id, scope, project_id, type, content, status, replaces, created_at, session_id)
+           VALUES (?, 'project', ?, 'user', 'Fixed null check in handler', 'active', '[]', ?, ?)`,
+        )
+        .run(newId('m'), projectId, Date.now(), s.id);
+
+      sessions.end(s.id, { tokenId });
+
+      const row = sessions.getById(s.id);
+      expect(row?.status).toBe('ended');
+      expect(row?.summaryFinal).toBe(true);
+      expect(row?.summary).toBe("[auto] 1 memorias — última: 'Fixed null check in handler'");
+    });
+
+    it('end() does NOT auto-curate if summary_final is already true', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'autocur-curated' });
+      db.handle.raw
+        .prepare(
+          `INSERT INTO memory (id, scope, project_id, type, content, status, replaces, created_at, session_id)
+           VALUES (?, 'project', ?, 'user', 'should not appear', 'active', '[]', ?, ?)`,
+        )
+        .run(newId('m'), projectId, Date.now(), s.id);
+      sessions.writeSummary(s.id, {
+        tokenId,
+        summary: 'Curated by agent',
+        final: true,
+      });
+
+      sessions.end(s.id, { tokenId });
+
+      const row = sessions.getById(s.id);
+      expect(row?.summary).toBe('Curated by agent');
+      expect(row?.summaryFinal).toBe(true);
+    });
+
+    it('end() does NOT auto-curate if no anchored content exists', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'autocur-empty' });
+      sessions.end(s.id, { tokenId });
+      const row = sessions.getById(s.id);
+      expect(row?.summary).toBeNull();
+      expect(row?.summaryFinal).toBe(false);
+    });
+
+    it('end() auto-curate counts memories and shows last memory snippet', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'autocur-multi' });
+      const baseTs = Date.now();
+      for (let i = 0; i < 3; i++) {
+        db.handle.raw
+          .prepare(
+            `INSERT INTO memory (id, scope, project_id, type, content, status, replaces, created_at, session_id)
+             VALUES (?, 'project', ?, 'user', ?, 'active', '[]', ?, ?)`,
+          )
+          .run(newId(`m-${i}`), projectId, `memory ${i}`, baseTs + i, s.id);
+      }
+      sessions.end(s.id, { tokenId });
+      const row = sessions.getById(s.id);
+      expect(row?.summary).toBe("[auto] 3 memorias — última: 'memory 2'");
+    });
+
+    it('end() with prompts only generates prompt-based summary', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'autocur-prompts' });
+      db.handle.raw
+        .prepare(
+          `INSERT INTO prompts (id, session_id, project_id, content, title, agent, created_at)
+           VALUES (?, ?, ?, 'do the thing', 'do the thing', 'claude', ?)`,
+        )
+        .run(newId('p'), s.id, projectId, Date.now());
+      sessions.end(s.id, { tokenId });
+      const row = sessions.getById(s.id);
+      expect(row?.summary).toBe('[auto] 1 prompts');
+      expect(row?.summaryFinal).toBe(true);
+    });
+
+    it('end() ignores soft-deleted prompts in auto-curate counts', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'autocur-soft' });
+      db.handle.raw
+        .prepare(
+          `INSERT INTO prompts (id, session_id, project_id, content, title, agent, created_at, deleted_at)
+           VALUES (?, ?, ?, 'deleted', 'deleted', 'claude', ?, ?)`,
+        )
+        .run(newId('p'), s.id, projectId, Date.now(), Date.now());
+      sessions.end(s.id, { tokenId });
+      const row = sessions.getById(s.id);
+      expect(row?.summary).toBeNull();
+      expect(row?.summaryFinal).toBe(false);
+    });
+
+    it('abandonStale() auto-curates each transitioned session that has anchored content', () => {
+      const s1 = sessions.start({ tokenId, projectId, agent: 'autocur-stale-1' });
+      const s2 = sessions.start({ tokenId, projectId, agent: 'autocur-stale-2' });
+      const baseTs = Date.now();
+      db.handle.raw
+        .prepare(
+          `INSERT INTO memory (id, scope, project_id, type, content, status, replaces, created_at, session_id)
+           VALUES (?, 'project', ?, 'user', 'work in s1', 'active', '[]', ?, ?)`,
+        )
+        .run(newId('m1'), projectId, baseTs, s1.id);
+      // s2 has no memories.
+
+      // Backdate so abandonStale picks them up.
+      const ancient = baseTs - 10 * 3_600_000;
+      db.handle.raw
+        .prepare('UPDATE sessions SET started_at = ? WHERE id IN (?, ?)')
+        .run(ancient, s1.id, s2.id);
+
+      const result = sessions.abandonStale({ olderThanMs: 3_600_000 });
+      expect(result.abandoned).toBe(2);
+
+      const row1 = sessions.getById(s1.id);
+      const row2 = sessions.getById(s2.id);
+      expect(row1?.status).toBe('abandoned');
+      expect(row1?.summary).toBe("[auto] 1 memorias — última: 'work in s1'");
+      expect(row1?.summaryFinal).toBe(true);
+
+      expect(row2?.status).toBe('abandoned');
+      expect(row2?.summary).toBeNull();
+      expect(row2?.summaryFinal).toBe(false);
+    });
+
+    it('writeSummary({final:true}) succeeds on an ended (auto-curated) session — agent override', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'autocur-override' });
+      db.handle.raw
+        .prepare(
+          `INSERT INTO memory (id, scope, project_id, type, content, status, replaces, created_at, session_id)
+           VALUES (?, 'project', ?, 'user', 'auto material', 'active', '[]', ?, ?)`,
+        )
+        .run(newId('m'), projectId, Date.now(), s.id);
+      sessions.end(s.id, { tokenId });
+
+      const auto = sessions.getById(s.id);
+      expect(auto?.summary).toMatch(/^\[auto\]/);
+
+      // Agent overrides AFTER end with a curated text.
+      const overridden = sessions.writeSummary(s.id, {
+        tokenId,
+        summary: 'Goal: Refactor X. Files: foo.ts.',
+        title: 'Refactor X',
+        final: true,
+      });
+      expect(overridden.summary).toBe('Goal: Refactor X. Files: foo.ts.');
+      expect(overridden.title).toBe('Refactor X');
+      expect(overridden.summaryFinal).toBe(true);
+      expect(overridden.titleFinal).toBe(true);
+      expect(overridden.status).toBe('ended');
+    });
+
+    it('writeSummary({final:false}) is rejected on an ended session', () => {
+      const s = sessions.start({ tokenId, projectId, agent: 'autocur-reject' });
+      sessions.end(s.id, { tokenId });
+      expect(() =>
+        sessions.writeSummary(s.id, {
+          tokenId,
+          summary: 'should be rejected',
+          final: false,
+        }),
+      ).toThrow(/session_already_ended|already ended/);
+    });
+  });
+
+  describe('composeDerivedSummary helper', () => {
+    it('memories-only template', () => {
+      expect(composeDerivedSummary({ memories: 5, prompts: 0, confirmations: 0 }, 'foo')).toBe(
+        "[auto] 5 memorias — última: 'foo'",
+      );
+    });
+
+    it('prompts-only template (no memory snippet)', () => {
+      expect(composeDerivedSummary({ memories: 0, prompts: 3, confirmations: 0 }, null)).toBe(
+        '[auto] 3 prompts',
+      );
+    });
+
+    it('confirmations-only template', () => {
+      expect(composeDerivedSummary({ memories: 0, prompts: 0, confirmations: 2 }, null)).toBe(
+        '[auto] 2 confirmaciones',
+      );
+    });
+
+    it('mixed counts with snippet', () => {
+      expect(
+        composeDerivedSummary(
+          { memories: 3, prompts: 2, confirmations: 1 },
+          'Refactored the auth middleware to use jose',
+        ),
+      ).toBe(
+        "[auto] 3 memorias, 2 prompts, 1 confirmaciones — última: 'Refactored the auth middleware to use jose'",
+      );
+    });
+
+    it('truncates long memory content at 80 chars', () => {
+      const long = 'A'.repeat(200);
+      const result = composeDerivedSummary({ memories: 1, prompts: 0, confirmations: 0 }, long);
+      expect(result).toMatch(/^\[auto\] 1 memorias — última: 'A{79}…'$/);
     });
   });
 });

--- a/apps/server/src/services/agent-sessions.ts
+++ b/apps/server/src/services/agent-sessions.ts
@@ -11,17 +11,21 @@ const SESSION_PURGE_GRACE_MS = 3_600_000;
 const SESSION_PURGE_REASONING = 'operator purge of empty sessions';
 
 /**
- * Single source of truth for "this session has something worth surfacing".
+ * Purge-eligibility predicate. TRUE when the session has at least one
+ * anchored row that would dangle on physical delete.
  *
- * Consumed positively by `recentForContext` (filter to useful sessions) and
- * negatively by `countPurgeableEmpty` / `purgeEmpty` (must be empty to be
- * purgeable). Adding a new content-bearing table that anchors to a session
- * id (e.g. a future `tool_calls`) MUST update only this helper — every
- * call site picks the change up automatically.
+ * Consumed (negated) by `countPurgeableEmpty` / `purgeEmpty` to keep
+ * sessions with foreign-key references out of the purge set. NOT used
+ * by `recentForContext` — surfacing to the LLM uses the stricter
+ * `sessionIsContextWorthySql` below.
  *
- * `alias` is the SQL identifier used to reference the sessions row in the
- * caller's query. Callers pass `'s'` (purge methods) or the table name
- * `'sessions'` (drizzle's implicit alias in `recentForContext`).
+ * Adding a new content-bearing table that anchors to a session id
+ * (e.g. a future `tool_calls`) MUST update only this helper — both
+ * purge call-sites pick the change up automatically.
+ *
+ * `alias` is the SQL identifier used to reference the sessions row in
+ * the caller's query. Callers pass `'s'` (purge methods) or the table
+ * name `'sessions'` (drizzle's implicit alias).
  */
 function sessionHasContentSql(alias: 's' | 'sessions') {
   return sql.raw(
@@ -31,6 +35,61 @@ function sessionHasContentSql(alias: 's' | 'sessions') {
       ` OR EXISTS (SELECT 1 FROM prompts       WHERE session_id = ${alias}.id AND deleted_at IS NULL)` +
       ` OR EXISTS (SELECT 1 FROM confirmations WHERE session_id = ${alias}.id))`,
   );
+}
+
+/**
+ * Surfacing predicate for `memory.context.recentSessions`. TRUE only
+ * when the session carries curated signal the LLM can read directly:
+ * a final summary or a final title, both lifted either by the MCP
+ * tool `memory.session_summary` (server-hardcoded `final:true`) or by
+ * the server-side auto-curate path at terminal transition (see
+ * `applyAutoCurateIfApplicable`).
+ *
+ * Strict subset of `sessionHasContentSql`: every context-worthy
+ * session is also content-bearing, but the converse does not hold
+ * BEFORE a terminal transition fires the auto-curate. After the
+ * transition, sessions with anchored content become context-worthy
+ * automatically via the `[auto]`-prefixed derived summary.
+ *
+ * Single consumer: `recentForContext`.
+ */
+function sessionIsContextWorthySql(alias: 's' | 'sessions') {
+  return sql.raw(
+    `((${alias}.summary IS NOT NULL AND ${alias}.summary_final = 1)` +
+      ` OR ${alias}.title_final = 1)`,
+  );
+}
+
+/**
+ * Pure helper. Composes a server-derived summary from anchored-content
+ * counts and the most recent memory snippet. Deterministic: same input
+ * always produces the same output. NEVER calls an LLM, NEVER inspects
+ * the previous summary, NEVER applies heuristics.
+ *
+ * Format: `[auto] N memorias[, P prompts[, C confirmaciones]][ — última: '<snippet>']`
+ *
+ * The `[auto]` prefix is mandatory and identifies the row as
+ * server-derived to both the agent and the operator.
+ */
+export function composeDerivedSummary(
+  counts: { memories: number; prompts: number; confirmations: number },
+  lastMemoryContent: string | null,
+): string {
+  const parts: string[] = [];
+  if (counts.memories > 0) parts.push(`${counts.memories} memorias`);
+  if (counts.prompts > 0) parts.push(`${counts.prompts} prompts`);
+  if (counts.confirmations > 0) parts.push(`${counts.confirmations} confirmaciones`);
+  const head = parts.join(', ');
+  const tail =
+    lastMemoryContent && lastMemoryContent.length > 0
+      ? ` — última: '${snippetForDerived(lastMemoryContent, 80)}'`
+      : '';
+  return `[auto] ${head}${tail}`;
+}
+
+function snippetForDerived(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1) + '…';
 }
 
 /**
@@ -222,10 +281,16 @@ export class AgentSessionsService {
       throw new DomainError('session_not_found', `session '${sessionId}' not found`);
     }
     if (existing.status !== 'active') {
-      throw new DomainError(
-        'session_already_ended',
-        `session '${sessionId}' is already ${existing.status}`,
-      );
+      // Relaxed: allow final:true writes on terminal sessions so the
+      // agent can override an auto-curated row via memory.session_summary.
+      // HTTP fallback writes cannot exploit this — their handlers
+      // hard-code final:false (see api-router.ts).
+      if (input.final !== true) {
+        throw new DomainError(
+          'session_already_ended',
+          `session '${sessionId}' is already ${existing.status}`,
+        );
+      }
     }
     const incomingFinal = input.final ?? false;
     const summaryUpdate = applyPrecedence(
@@ -252,12 +317,11 @@ export class AgentSessionsService {
     if (Object.keys(set).length === 0) {
       return existing;
     }
-    const updated = this.db
-      .update(agentSessions)
-      .set(set)
-      .where(and(eq(agentSessions.id, sessionId), eq(agentSessions.status, 'active')))
-      .returning()
-      .get();
+    const updateCondition =
+      existing.status === 'active'
+        ? and(eq(agentSessions.id, sessionId), eq(agentSessions.status, 'active'))
+        : eq(agentSessions.id, sessionId);
+    const updated = this.db.update(agentSessions).set(set).where(updateCondition).returning().get();
     if (!updated) {
       throw new DomainError(
         'session_already_ended',
@@ -265,6 +329,41 @@ export class AgentSessionsService {
       );
     }
     return updated;
+  }
+
+  /**
+   * Compute the auto-curate write for a session, if applicable.
+   *
+   * Returns the derived summary string when the session has at least
+   * one anchored row in memory / prompts (deleted_at IS NULL) /
+   * confirmations. Returns null otherwise.
+   *
+   * Pure read against the database; the caller writes the result as
+   * part of the same UPDATE that transitions status.
+   */
+  private computeAutoCurate(sessionId: string): string | null {
+    const memCount = this.db.get<{ v: number }>(
+      sql`SELECT COUNT(*) AS v FROM memory WHERE session_id = ${sessionId}`,
+    ) as { v: number } | undefined;
+    const prCount = this.db.get<{ v: number }>(
+      sql`SELECT COUNT(*) AS v FROM prompts WHERE session_id = ${sessionId} AND deleted_at IS NULL`,
+    ) as { v: number } | undefined;
+    const confCount = this.db.get<{ v: number }>(
+      sql`SELECT COUNT(*) AS v FROM confirmations WHERE session_id = ${sessionId}`,
+    ) as { v: number } | undefined;
+    const counts = {
+      memories: memCount?.v ?? 0,
+      prompts: prCount?.v ?? 0,
+      confirmations: confCount?.v ?? 0,
+    };
+    if (counts.memories + counts.prompts + counts.confirmations === 0) return null;
+    const lastMem =
+      counts.memories > 0
+        ? (this.db.get<{ content: string }>(
+            sql`SELECT content FROM memory WHERE session_id = ${sessionId} ORDER BY created_at DESC LIMIT 1`,
+          ) as { content: string } | undefined)
+        : undefined;
+    return composeDerivedSummary(counts, lastMem?.content ?? null);
   }
 
   end(sessionId: string, input: EndSessionInput): AgentSession {
@@ -336,6 +435,16 @@ export class AgentSessionsService {
       set.title = titleUpdate.value;
       set.titleFinal = titleUpdate.final;
     }
+    const willHaveCuratedSummary = summaryUpdate.changed
+      ? summaryUpdate.final
+      : existing.summaryFinal;
+    if (!willHaveCuratedSummary) {
+      const derived = this.computeAutoCurate(sessionId);
+      if (derived !== null) {
+        set.summary = derived;
+        set.summaryFinal = true;
+      }
+    }
     const updated = this.db
       .update(agentSessions)
       .set(set)
@@ -406,12 +515,12 @@ export class AgentSessionsService {
 
   /**
    * N most recent sessions for the given scope, ordered newest first.
-   * Soft-deleted sessions and empty sessions (those failing the shared
-   * `sessionHasContent` predicate) are NEVER surfaced via this path —
-   * memory.context callers must not see noise. Filter-then-truncate
-   * semantics: empty sessions do not consume slots, so a `limit:N`
-   * request returns the N most-recent USEFUL sessions even if dozens of
-   * newer empties exist between them.
+   * Soft-deleted sessions and non-curated sessions (those failing the
+   * `sessionIsContextWorthy` predicate) are NEVER surfaced via this
+   * path — `memory.context` callers must see only curated signal.
+   * Filter-then-truncate semantics: non-curated sessions do not consume
+   * slots, so a `limit:N` request returns the N most-recent CURATED
+   * sessions even if dozens of newer non-curated rows exist between them.
    */
   recentForContext(input: RecentForContextInput): AgentSession[] {
     const limit = clamp(input.limit ?? 5, 1, 25);
@@ -422,7 +531,9 @@ export class AgentSessionsService {
     return this.db
       .select()
       .from(agentSessions)
-      .where(and(scopeCondition, isNull(agentSessions.deletedAt), sessionHasContentSql('sessions')))
+      .where(
+        and(scopeCondition, isNull(agentSessions.deletedAt), sessionIsContextWorthySql('sessions')),
+      )
       .orderBy(desc(agentSessions.startedAt))
       .limit(limit)
       .all();
@@ -520,15 +631,40 @@ export class AgentSessionsService {
    * Mark any `status='active'` row older than `olderThanMs` as abandoned.
    * Called at startup so a crashed/restarted server doesn't leak
    * eternally-active rows.
+   *
+   * Per-row loop (not bulk UPDATE) so each transition gets the auto-curate
+   * pass: when `summary_final = 0` and the session has anchored content,
+   * the derived summary is written atomically with the status flip.
    */
   abandonStale(input: { olderThanMs: number }): { abandoned: number } {
     const cutoff = new Date(this.now().getTime() - input.olderThanMs);
-    const result = this.db
-      .update(agentSessions)
-      .set({ status: 'abandoned', endedAt: this.now() })
+    const stale = this.db
+      .select()
+      .from(agentSessions)
       .where(and(eq(agentSessions.status, 'active'), lt(agentSessions.startedAt, cutoff)))
-      .run();
-    return { abandoned: result.changes };
+      .all();
+    let abandoned = 0;
+    for (const row of stale) {
+      const ts = this.now();
+      const set: Partial<typeof agentSessions.$inferInsert> = {
+        status: 'abandoned',
+        endedAt: ts,
+      };
+      if (!row.summaryFinal) {
+        const derived = this.computeAutoCurate(row.id);
+        if (derived !== null) {
+          set.summary = derived;
+          set.summaryFinal = true;
+        }
+      }
+      const result = this.db
+        .update(agentSessions)
+        .set(set)
+        .where(and(eq(agentSessions.id, row.id), eq(agentSessions.status, 'active')))
+        .run();
+      if (result.changes > 0) abandoned += 1;
+    }
+    return { abandoned };
   }
 
   /**

--- a/apps/server/src/test/mcp-integration.test.ts
+++ b/apps/server/src/test/mcp-integration.test.ts
@@ -301,10 +301,10 @@ describe('MCP protocol conformance', () => {
     await client.close();
   });
 
-  it('memory.context backfills past empty sessions to return useful older ones', async () => {
+  it('memory.context backfills past empty sessions to return curated older ones', async () => {
     const client = await connect();
 
-    // First: a session WITH content (will be the oldest).
+    // First: a CURATED session (will be the oldest).
     const usefulStart = (await client.callTool({
       name: 'memory.session_start',
       arguments: { agent: 'rembric-test', description: 'useful session' },
@@ -317,6 +317,12 @@ describe('MCP protocol conformance', () => {
         type: 'feedback',
         content: 'backfill-useful-row',
       },
+    });
+    // Mark the session as curated via memory.session_summary — the only path
+    // that lifts summary_final = 1 and makes the session context-worthy.
+    await client.callTool({
+      name: 'memory.session_summary',
+      arguments: { title: 'Backfill probe', summary: 'Curated session for backfill assertion' },
     });
     await client.callTool({ name: 'memory.session_end', arguments: {} });
 
@@ -426,6 +432,53 @@ describe('MCP protocol conformance', () => {
     const judgedPayload = readJson(judgement) as { status: string; relation: string };
     expect(judgedPayload.status).toBe('judged');
     expect(judgedPayload.relation).toBe('related');
+
+    await client.close();
+  });
+
+  it('memory.context auto-curates a session with anchored memory and surfaces it with [auto] summary', async () => {
+    // Placed AFTER the candidates test because the candidates test depends on
+    // FTS5 BM25 corpus size (IDF). Adding more memories to the global scope
+    // BEFORE the candidates test pushes the rank past the configured ftsThreshold.
+    const client = await connect();
+
+    // Start a session and save a memory — the memory auto-anchors via
+    // resolveActiveSessionId. No memory.session_summary call. End the session
+    // and let the server auto-curate at the terminal transition.
+    const started = (await client.callTool({
+      name: 'memory.session_start',
+      arguments: { agent: 'rembric-test', description: 'anchored but uncurated' },
+    })) as ToolResult;
+    const startedPayload = readJson(started) as { sessionId: string };
+
+    const saved = (await client.callTool({
+      name: 'memory.save',
+      arguments: {
+        scope: 'global',
+        type: 'feedback',
+        content: 'memory anchored to uncurated session',
+      },
+    })) as ToolResult;
+    const savedPayload = readJson(saved) as { id: string };
+
+    await client.callTool({ name: 'memory.session_end', arguments: {} });
+
+    const ctx = (await client.callTool({
+      name: 'memory.context',
+      arguments: { sessions: 25, memories: 25 },
+    })) as ToolResult;
+    const ctxPayload = readJson(ctx) as {
+      recentSessions: { id: string; summary: string | null }[];
+      recentMemories: { id: string }[];
+    };
+
+    // The session SURFACES because auto-curate composed a derived summary.
+    const session = ctxPayload.recentSessions.find((s) => s.id === startedPayload.sessionId);
+    expect(session).toBeDefined();
+    expect(session?.summary).toMatch(/^\[auto\] 1 memorias/);
+
+    // The memory itself also surfaces in recentMemories.
+    expect(ctxPayload.recentMemories.some((m) => m.id === savedPayload.id)).toBe(true);
 
     await client.close();
   });

--- a/openspec/changes/archive/2026-05-21-tighten-context-content-predicate-to-final-summaries/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-21-tighten-context-content-predicate-to-final-summaries/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-21

--- a/openspec/changes/archive/2026-05-21-tighten-context-content-predicate-to-final-summaries/design.md
+++ b/openspec/changes/archive/2026-05-21-tighten-context-content-predicate-to-final-summaries/design.md
@@ -1,0 +1,276 @@
+## Context
+
+The shared SQL fragment `sessionHasContentSql(alias)` (introduced in `2026-05-21-filter-empty-sessions-from-context`, `apps/server/src/services/agent-sessions.ts:26-34`) was conceived as a single source of truth for "this session has something worth surfacing." Two call sites consume it:
+
+- Positively, by `AgentSessionsService.recentForContext` to filter the agent-facing `memory.context.recentSessions` list.
+- Negatively, by `AgentSessionsService.countPurgeableEmpty` and `AgentSessionsService.purgeEmpty` to identify sessions an operator may physically delete.
+
+Empirical observation (2026-05-21 live stack) shows the unification was premature. The same predicate cannot serve both call sites well because they ask different questions:
+
+- The **purge predicate** must protect any session whose physical deletion would dangle foreign keys. A session with at least one `memory` row referencing it MUST NOT be purged, even if uncurated — the memory survives, but its `session_id` becomes a dangling reference. The 5-clause predicate is exactly right for this.
+- The **surfacing predicate** must select sessions that contribute usable signal to the LLM's bootstrap snapshot. A session whose `summary` is a raw transcript dump (`final:false`) contributes noise; a session with anchored memories but `summary: null` contributes a stub row. Neither is useful at the session granularity, even though the memories themselves are useful at the memory granularity (and appear in `recentMemories[]`).
+
+Independently, the HTTP fallback path leaves a trust gap. `POST /api/<slug>/sessions/:id/summary` accepts a body `{ summary, title?, final?: boolean }` and forwards `final` directly to `writeSummary`. All four shipped plugins pass `final:false`, but the structural authority for "this is curated" rests on plugin discipline rather than on server-enforced rules. A buggy or malicious fifth client could mark a transcript dump as `final:true` and pollute curated signal.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `memory.context.recentSessions` returns exclusively curated sessions: every row has `summary_final = 1` or `title_final = 1`, set via the MCP tool `memory.session_summary` through a server-hardcoded code path. Zero exceptions.
+- Sessions with anchored content but no curated summary still contribute to the LLM via `recentMemories[]` — the agent loses the "session header" but keeps the granular work, plus the `session_id` to call `memory.timeline` if it wants to inspect the thread.
+- Purge predicate stays exactly as today. Sessions with anchored memories/prompts/confirmations remain non-purgeable; referential integrity stays intact.
+- The structural authority for `summary_final = 1` collapses to a single code path: the MCP tool's hardcoded `final:true` call. No HTTP body can influence it.
+
+**Non-Goals:**
+
+- Filtering empty / transcript-only sessions out of operator-facing surfaces. `/dashboard/sessions`, `/dashboard/sessions/:id`, and `memory.stats.sessionsByStatus` MUST continue to show every row.
+- Changing plugin write behaviour. All four plugins continue to POST per-turn transcripts with `final:false`; the hardening just makes the field's value irrelevant on the HTTP path.
+- Adding heuristics, regex, or content inspection at any layer. The decision rests on a boolean column populated structurally by the write path.
+- Server-side derived summaries (computing a synthetic summary from memory titles). Out of scope; `recentMemories` already exposes the granular signal.
+- Forcing the agent to call `memory.session_summary`. Cannot be enforced at the protocol level; the existing plugin nudges (in `session-stop.sh`, `post-compact.sh`, Hermes `__init__.py`, opencode `plugin.ts`) are the right surface.
+
+## Decisions
+
+### Decision 1 — Two predicates, not one
+
+**Choice:** Introduce `sessionIsContextWorthySql(alias)` as a new SQL fragment alongside the existing `sessionHasContentSql(alias)`. The new predicate is `(${alias}.summary IS NOT NULL AND ${alias}.summary_final = 1) OR ${alias}.title_final = 1`. It is consumed by `recentForContext` only. `sessionHasContentSql` keeps its 5 clauses and continues to drive `countPurgeableEmpty` / `purgeEmpty`.
+
+**Why:**
+
+- Surfacing and purge ask different questions; conflating them into one predicate forces a compromise on both. Separating gives each call site a tight, named contract.
+- Strict-subset relationship: every context-worthy session is also content-bearing (the converse is not true). This makes the two predicates feel like a refinement, not a duplication. A code search reveals the relationship at a glance.
+- No new state, no new column, no new write path. Both predicates read the same row fields. The only thing changing is the WHERE clauses in two existing query builders.
+
+**Alternatives considered:**
+
+- **A. Single tightened predicate.** Replace the 5-clause predicate with the 2-clause `sessionIsContextWorthy` everywhere. Rejected: sessions with anchored memories but no curated summary would become purge-eligible. Physical purge would dangle `memory.session_id` references. Unacceptable.
+
+- **B. Single predicate, return `summary: null` to the LLM when `summary_final = 0`.** Considered. Cleaner than today, but leaves stub rows (`{ id, summary: null, … }`) in `recentSessions` that occupy slots without informing the LLM. The user's intuition that this is still noise is correct.
+
+- **C. Three predicates** (content-bearing, context-worthy, purge-eligible). Rejected: no third question to ask. Two predicates is the natural shape of the problem.
+
+### Decision 2 — Hardcode `final: false` in the HTTP path
+
+**Choice:** Remove the `final` field from the request-body schemas for `POST /api/<slug>/sessions/:id/summary` and `POST /api/<slug>/sessions/:id/end`. The corresponding handlers in `apps/server/src/server/api-router.ts` SHALL pass `final: false` to `writeSummary` / `end` unconditionally. The MCP tool `memory.session_summary` keeps its hardcoded `final: true` in `apps/server/src/mcp/sessions-tools.ts:410`.
+
+**Why:**
+
+- After the predicate split, the entire trust chain for "is this session worth surfacing?" reduces to "is `summary_final` truthful?" — and that flag is now exclusively settable via one server-hardcoded line of code.
+- The HTTP path's `final` field was always a client-controlled trust hole. Removing it costs nothing (no client uses `final:true` today) and converts a convention into an invariant.
+- Reduces the API surface area. The body schemas become smaller. Schema-level documentation no longer has to explain "you can pass `final` but please don't unless you're the model."
+
+**Alternatives considered:**
+
+- **A. Keep the field but coerce to `false` server-side.** Rejected: leaves a confusing field in the public schema. A future contributor will see it and wonder "why is this here if it's ignored?" Cleaner to remove.
+- **B. Accept `final:true` over HTTP and trust plugins.** Rejected: explicit user concern about not trusting hooks. Convention-based trust is exactly what the hardening is meant to replace.
+- **C. Add a separate "admin-only" header gate for `final:true`.** Rejected: introduces a third path (admin HTTP), invents tooling, no caller in tree needs this.
+
+### Decision 3 — Preserve operator visibility surfaces unchanged
+
+**Choice:** No template change, no `list()` change, no `countByStatus()` change. `/dashboard/sessions`, `/dashboard/sessions/:id`, `/dashboard/maintenance`, and `memory.stats.sessionsByStatus` continue to surface every session row regardless of curation status.
+
+**Why:**
+
+- The user explicitly said the operator must see everything; the LLM filter is orthogonal.
+- These surfaces consume `AgentSessionsService.list()` or `countByStatus()`, neither of which uses either predicate. The orthogonality is already structural — no risk of accidental coupling.
+- Operators need uncurated rows visible to decide on `purgeEmpty`. The maintenance page's "Purge empty sessions" card displays the count and requires confirmation.
+
+**Alternatives considered:**
+
+- **A. Also hide uncurated sessions from `/dashboard/sessions` by default with a toggle.** Rejected: operator workflow argument. The operator's job is precisely to inspect what the agent did or did not curate; hiding it would be counterproductive.
+
+## Risks / Trade-offs
+
+- **[Trade-off]** Sessions where the agent saved memories but forgot `memory.session_summary` no longer appear as `recentSessions` rows. → **Accepted because:** their memories continue to appear in `recentMemories[]` with `session_id` attached. The agent can call `memory.timeline({sessionId})` to reconstruct the thread. The session "header" was contributing low value anyway — a row with no curated summary forces the agent to read raw transcript or infer context, which is precisely what `memory.session_summary` was designed to avoid.
+
+- **[Risk]** A future contributor adds a fifth client (a Cursor plugin, say) and writes `final:true` over HTTP expecting it to take effect. → **Mitigation:** the server silently ignores the field; spec deltas in `http-api/spec.md` codify the contract; the schema-level rejection makes the misconfiguration loud at zod-validation time if `strict: true` is added later.
+
+- **[Risk]** Operators see a larger "Purge empty sessions" count immediately after this change lands. → **Mitigation:** the count growth corresponds to legitimately stale transcript-only sessions. The maintenance page already displays the count and gates the action behind a confirmation modal. No automatic purge — the operator opts in.
+
+- **[Trade-off]** The "single source of truth for session-has-content" invariant from PR #71 is refined. The drift-detection scenario in the existing spec (`Drift between purge predicate and context predicate is impossible`) needs an update because the two predicates now legitimately differ. → **Accepted because:** the difference is structurally bounded — `sessionIsContextWorthy(s) → sessionHasContent(s)` always. The drift scenario rewords to assert this strict-subset relationship and to enforce that the EXISTS-bearing 5-clause predicate appears in exactly one place (its helper).
+
+- **[Trade-off]** Two existing tests in `api-router.test.ts` that POST `{final: true}` to set up the locked-precedence state need to migrate to direct DB UPDATE. → **Accepted because:** the service-level precedence logic is already tested at `agent-sessions.test.ts`; the HTTP-level tests after the change should test the HTTP contract (no `final` accepted), not the underlying precedence rule.
+
+## Migration Plan
+
+No data migration. The change is read-side filter + write-side schema narrowing:
+
+1. Add `sessionIsContextWorthySql` helper.
+2. Repoint `recentForContext` to consume it.
+3. Update JSDoc on `sessionHasContentSql` to clarify its purge-only scope.
+4. Hard-code `final: false` in HTTP `/summary` and `/end` handlers.
+5. Drop `final` from the corresponding zod body schemas.
+6. Update tests (unit + integration + http).
+7. Apply spec deltas across `sessions`, `mcp-api`, `http-api`.
+8. Archive the change.
+
+Rollback: revert the two SQL helper changes, restore `final` to the body schemas. The `summary_final` column data on disk is unaffected by either direction.
+
+## Use-case flow diagrams
+
+The five canonical flows under the post-change contract. Each shows the trigger, the server decision, the resulting DB state, and what the LLM sees in `memory.context.recentSessions`.
+
+### Tipo A — Noise session (`/clear`, opencode "Hola!", transcript-only)
+
+```
+Agent:  memory.session_start
+        ↓ (no memory.save, no memory.session_summary)
+Plugin Stop hook: POST /summary { summary: "user: <transcript>", final:false (forced) }
+        ↓ server writes summary_final=0 (cannot be lifted via HTTP)
+Agent:  memory.session_end
+        ↓
+SERVER end():
+   ┌─ summary_final = 0 → proceed to auto-curate check
+   ├─ EXISTS memory? NO
+   ├─ EXISTS prompts? NO
+   ├─ EXISTS confirmations? NO
+   └─ total = 0 → SKIP auto-curate
+        ↓
+UPDATE sessions SET status='ended', ended_at=now WHERE id=?
+        ↓
+DB state: { status: ended, summary: '<transcript>', summary_final: 0 }
+
+memory.context.recentSessions  ✗ EXCLUIDA  (sessionIsContextWorthy = false)
+/dashboard/sessions            ✓ visible al operador
+purgeEmpty (>1h grace)         ✓ elegible para limpieza
+```
+
+### Tipo B — Work without curation (auto-curate fires)
+
+```
+Agent:  memory.session_start
+Agent:  memory.save({ content: 'Fixed null check…' })   ← anchored to session
+        ↓ (no memory.session_summary)
+Plugin Stop hook: POST /summary (irrelevant, summary_final stays 0)
+Agent:  memory.session_end
+        ↓
+SERVER end():
+   ┌─ summary_final = 0 → proceed to auto-curate
+   ├─ EXISTS memory? YES (1 row)
+   ├─ count memories: 1
+   ├─ SELECT last memory.content → 'Fixed null check…'
+   └─ derived = composeDerivedSummary({memories:1,…}, 'Fixed null check…')
+                = "[auto] 1 memorias — última: 'Fixed null check…'"
+        ↓
+UPDATE sessions SET
+   status     = 'ended',
+   ended_at   = now,
+   summary    = '[auto] 1 memorias — última: 'Fixed null check…'',
+   summary_final = 1
+   WHERE id=? AND status='active'
+        ↓
+DB state: { status: ended, summary: '[auto] 1 memorias…', summary_final: 1 }
+
+memory.context.recentSessions  ✓ INCLUIDA con [auto] prefix
+recentMemories                 ✓ memoria anclada también surface
+purgeEmpty                     ✗ NO purgable (EXISTS memory protege FK)
+```
+
+### Tipo C — Curated session (agent calls memory.session_summary)
+
+```
+Agent:  memory.session_start
+Agent:  memory.save({ content: '...' })
+Agent:  memory.session_summary({ title: 'Refactor X', summary: 'Goal: …' })
+        ↓
+SERVER memory.session_summary handler (sessions-tools.ts:410):
+   writeSummary({ summary, title, final: true })   ← HARDCODED final:true
+        ↓
+UPDATE sessions SET summary='Goal: …', title='Refactor X',
+                    summary_final=1, title_final=1
+        ↓
+Agent:  memory.session_end
+        ↓
+SERVER end():
+   ┌─ summary_final = 1 → SKIP auto-curate (agent already curated)
+   └─ Just transition status + ended_at
+        ↓
+UPDATE sessions SET status='ended', ended_at=now
+        ↓
+DB state: { status: ended, summary: 'Goal: …', summary_final: 1 }
+
+memory.context.recentSessions  ✓ INCLUIDA con texto del agente
+/dashboard/sessions            ✓ visible al operador
+purgeEmpty                     ✗ NO purgable
+```
+
+### Override — Agent overrides auto-curated session post-end
+
+```
+Setup: Tipo B already happened → session ended with [auto] summary.
+
+Agent (next turn or any time later):
+        memory.session_summary({ summary: 'Goal: real curate', title: 'X' })
+        ↓
+SERVER handler: writeSummary({ summary, title, final: true })
+        ↓
+SERVER writeSummary():
+   ┌─ existing.status = 'ended' (terminal) → would normally reject
+   ├─ BUT input.final === true → ALLOW (relaxed condition 2)
+   └─ Apply precedence: summary_final stays 1, overwrite summary & title
+        ↓
+UPDATE sessions SET
+   summary       = 'Goal: real curate',
+   title         = 'X',
+   summary_final = 1,
+   title_final   = 1
+   WHERE id=?   ← no status='active' gate, since terminal override path
+        ↓
+DB state: { status: ended (unchanged), summary: 'Goal: real curate',
+            summary_final: 1, title_final: 1 }
+
+memory.context.recentSessions  ✓ INCLUIDA con texto del agente (override gana)
+```
+
+### HTTP hardening — Plugin tries `final:true` over HTTP
+
+```
+Plugin Stop hook (buggy or malicious):
+   POST /api/<slug>/sessions/:id/summary
+   Body: { summary: 'fake curated', title: 'X', final: true }
+        ↓
+SERVER api-router.ts:
+   ┌─ zod schema: { summary, title } — `final` field is DROPPED silently
+   ├─ parsed.data.final = undefined
+   └─ Call writeSummary({ summary, title, final: false })  ← HARDCODED false
+        ↓
+SERVER writeSummary():
+   ┌─ existing.status = 'active' → condition 1 satisfied, accept
+   ├─ incomingFinal = false
+   ├─ applyPrecedence:
+   │    - if existing.summary_final = 1: SKIP write (curated wins)
+   │    - if existing.summary_final = 0: WRITE summary, leave flag = 0
+   └─ summary_final NEVER lifted to 1 via this path
+        ↓
+UPDATE sessions SET summary='fake curated', title='X' (summary_final unchanged)
+        ↓
+DB state: { summary_final: 0 OR 1 (whatever it was), NOT lifted by HTTP }
+
+→ The `final` field is STRUCTURALLY INACCESSIBLE from HTTP. Only
+  memory.session_summary (MCP) can lift the flag.
+```
+
+### Decision matrix
+
+```
+┌──────────────────────────────────┬─────────────┬─────────────┬───────────────┐
+│ Session shape                    │ recentSess  │ Operador    │ Purgeable     │
+│                                  │ (LLM)       │ /dashboard  │ (1h grace)    │
+├──────────────────────────────────┼─────────────┼─────────────┼───────────────┤
+│ Tipo A: no anchored, no curate   │     ✗       │     ✓       │      ✓        │
+│ Tipo B: anchored, no curate      │  ✓ [auto]   │     ✓       │  ✗ (EXISTS)   │
+│ Tipo C: curate explícito         │ ✓ curated   │     ✓       │  ✗ (EXISTS o  │
+│                                  │             │             │  summary_fin) │
+│ Override: ended + new curate     │ ✓ override  │     ✓       │  ✗ (igual C)  │
+│ Vacía: start + end sin nada      │     ✗       │     ✓       │      ✓        │
+└──────────────────────────────────┴─────────────┴─────────────┴───────────────┘
+```
+
+## Open Questions
+
+None. The verification pass confirmed:
+
+- The MCP tool `memory.session_summary` is the only path that writes `final:true` server-side (`apps/server/src/mcp/sessions-tools.ts:410`).
+- All four plugins write `final:false` over HTTP (verified via grep across `apps/plugin/scripts/`, `apps/plugin/.hermes-plugin/__init__.py`, `apps/plugin/.opencode-plugin/plugin.ts`).
+- All existing service-level `recentForContext content filter` tests use `sessions.summarize()` which writes `final:true`, so they continue to pass under the new surfacing predicate — except for the `includes a session referenced by at least one memory row` test, which legitimately flips to "does NOT include" (the memory is now expected in `recentMemories[]`, not as a session header).
+- HTTP-level api-router tests that POST `{final:true}` are documented above as needing migration to direct DB UPDATE setup.

--- a/openspec/changes/archive/2026-05-21-tighten-context-content-predicate-to-final-summaries/proposal.md
+++ b/openspec/changes/archive/2026-05-21-tighten-context-content-predicate-to-final-summaries/proposal.md
@@ -1,0 +1,84 @@
+## Why
+
+`memory.context.recentSessions` is the LLM's bootstrap snapshot. Today it contaminates that snapshot in two distinct ways:
+
+1. **Noise sessions** (`/clear`, `/rembric:context`, opencode `"Hola!"`, etc.) — sessions whose only content is a per-turn raw transcript dump written by plugin hooks (Claude Code Stop, Codex Stop, Hermes `pre_compress`, opencode `session.idle`) with `final:false`. The current shared predicate `sessionHasContentSql` treats any non-null `summary` as content and surfaces them.
+2. **Stub sessions** — sessions where the agent saved memories but never called `memory.session_summary`. They surface via the predicate's `EXISTS(memory)` clause but expose a raw-transcript `summary` to the LLM, occupying a slot with low-value content.
+
+Both issues share a root cause: the predicate `sessionHasContent` (introduced in `2026-05-21-filter-empty-sessions-from-context`) was overloaded to serve TWO concerns at once — purge eligibility (operator-facing) and context surfacing (LLM-facing). Those concerns have different thresholds: a session with anchored memories MUST be safe from physical purge (the memories' `session_id` references would dangle), but it does NOT necessarily belong in the LLM's bootstrap snapshot.
+
+A third, independent trust gap reinforces the problem: the HTTP fallback path `POST /api/<slug>/sessions/:id/summary` accepts a client-controlled `final` flag in its body, meaning a misbehaving or buggy plugin could mark a transcript dump as `final:true` and pollute curated signal. Today all four shipped plugins correctly pass `false`, but the structural authority for "this is curated" should live in the server, not in client trust.
+
+## What Changes
+
+- **SPLIT the predicate.** Introduce a new SQL fragment `sessionIsContextWorthySql(alias)` in `apps/server/src/services/agent-sessions.ts`. Definition: `(${alias}.summary IS NOT NULL AND ${alias}.summary_final = 1) OR ${alias}.title_final = 1`. The existing `sessionHasContentSql` is preserved verbatim and retains its five clauses; its scope narrows to "purge eligibility" via in-code documentation and spec wording.
+- **REPOINT `recentForContext`** to consume `sessionIsContextWorthySql` instead of `sessionHasContentSql`. The change is in one call site (`recentForContext` in `agent-sessions.ts`).
+- **PRESERVE purge behaviour.** `countPurgeableEmpty` and `purgeEmpty` continue to consume `sessionHasContentSql` (negated). Sessions with anchored memories/prompts/confirmations stay non-purgeable, protecting referential integrity.
+- **HARDEN the HTTP path.** Remove the `final` field from the `sessionSummarySchema` and `sessionEndSchema` zod schemas in `apps/server/src/mcp/sessions-tools.ts` (or wherever they are defined for the HTTP handlers). The HTTP handlers `POST /api/<slug>/sessions/:id/summary` and `POST /api/<slug>/sessions/:id/end` in `apps/server/src/server/api-router.ts` SHALL hard-code `final: false` when calling `writeSummary` / `end`. The MCP tool `memory.session_summary` continues to hard-code `final: true` in its handler — that path stays the SOLE writer that lifts the `_final` flags.
+- **EXTEND test coverage.** Update unit tests to lock in the new predicate behaviour: a session referenced only by anchored memory rows is NO LONGER surfaced via `recentForContext` (its memories still appear in `recentMemories[]`); a session with `summary_final = 0` is NO LONGER surfaced regardless of other content; only curated sessions (`summary_final = 1` or `title_final = 1`) surface. Update HTTP-path tests to assert that body `final:true` is ignored.
+
+Not in scope:
+
+- No plugin changes. All four shipped plugins already pass `final:false` over HTTP — the hardening just makes lying impossible structurally, it does not change the contract they implement.
+- No migration, no schema change, no trigger, no backfill. The `summary_final` and `title_final` columns already encode the distinction with correct values populated by the existing write path.
+- No new MCP tool, no removed MCP tool, no MCP argument changes.
+- No dashboard changes. `/dashboard/sessions` continues to surface every row via `list()`; operators retain full visibility.
+- No change to `memory.stats.sessionsByStatus` — counters keep including every row.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `sessions`: REFINE `sessionHasContent` to clarify that it is the **purge-eligibility predicate** (single source-of-truth for "this session is safe to physically delete"). ADD a new requirement `sessionIsContextWorthy` defining the **surfacing predicate** as `(summary IS NOT NULL AND summary_final = 1) OR title_final = 1`. REFINE `recentForContext MUST exclude empty sessions by default` so it consumes the new surfacing predicate. The two predicates SHALL coexist: surfacing is a strict subset of content (curated content is content, but content is not necessarily curated).
+- `mcp-api`: REFINE the `memory.context.recentSessions` scenario to specify that returned sessions SHALL satisfy `sessionIsContextWorthy`. Add a normative scenario: sessions with anchored memories but no curated summary SHALL NOT surface as `recentSessions` rows — their memories continue to appear in `recentMemories[]`.
+- `http-api`: REFINE `POST /api/<slug>/sessions/:id/summary` and `POST /api/<slug>/sessions/:id/end` — the request body SHALL NOT accept a `final` field. The server SHALL treat all HTTP-path writes as `final:false`. Updating from `final:false` to `final:true` SHALL only be possible via the MCP tool `memory.session_summary`.
+
+## Impact
+
+**Code**
+
+- Modified: `apps/server/src/services/agent-sessions.ts` — add `sessionIsContextWorthySql`, repoint `recentForContext` to consume it; update JSDoc on `sessionHasContentSql` to clarify its purge-only scope.
+- Modified: `apps/server/src/server/api-router.ts` — hard-code `final: false` in the two HTTP summary/end handlers.
+- Modified: HTTP body schema definitions (drop `final` from `sessionSummarySchema` and `sessionEndSchema`).
+- Modified: `apps/server/src/services/agent-sessions.test.ts` — update the `recentForContext content filter` describe block to reflect the new predicate (one existing test flips its assertion; three new tests added).
+- Modified: `apps/server/src/server/api-router.test.ts` — update existing precedence tests that POSTed `final:true` via HTTP. Locked-state setup migrates to direct DB UPDATE; add a new test asserting that HTTP body `final:true` is silently ignored and `summary_final` stays `0`.
+- Modified: `apps/server/src/test/mcp-integration.test.ts` — add a scenario: session with anchored memory but no `memory.session_summary` call SHALL NOT appear in `recentSessions`, while its memory SHALL appear in `recentMemories[]`.
+
+**Spec deltas**
+
+- `openspec/specs/sessions/spec.md` — refine `sessionHasContent` scope; add `sessionIsContextWorthy`; refine `recentForContext`.
+- `openspec/specs/mcp-api/spec.md` — refresh `memory.context.recentSessions` scenario.
+- `openspec/specs/http-api/spec.md` — drop `final` from request body of `/summary` and `/end`; document server-forced `final:false`.
+
+**Surfaces unchanged**
+
+- MCP tool schemas: untouched.
+- Dashboard templates: untouched.
+- `memory.stats`, `memory.timeline`: untouched.
+- Plugin manifests and scripts: untouched (all four clients already pass `final:false` — hardening just makes deviation impossible).
+- DB schema and migrations: untouched.
+
+**Behavioral consequences**
+
+- LLM context becomes strictly curated: every row in `recentSessions` has `summary_final = 1` or `title_final = 1`, written by the MCP tool `memory.session_summary` through a server-hardcoded path. Zero `summary: null` rows, zero transcript-dump summaries, zero `/clear`-style noise.
+- Sessions where the agent forgot `memory.session_summary` but anchored memories still contribute via `recentMemories[]` (with `session_id` available for `memory.timeline` follow-up).
+- Operator visibility preserved: `/dashboard/sessions`, `/dashboard/sessions/:id`, `/dashboard/maintenance`, and `memory.stats.sessionsByStatus` continue to show every row.
+- More sessions become purge-eligible (those whose only content was a transcript dump). `purgeEmpty` semantics unchanged otherwise; existing 1h `ended_at` grace prevents racing with late writes.
+- Trust model becomes structural: the `_final` flags can only be lifted by the MCP tool, never by HTTP. No future plugin (in any language) can accidentally or maliciously corrupt curated signal.
+
+**Invariants touched**
+
+- Append-only memory: untouched.
+- Scope enforced at the service layer: untouched.
+- `topic_key` convergence: untouched.
+- Fresh-context judgment: untouched.
+- "Single source of truth for session-has-content": REFINED. The predicate splits into two clearly-named helpers, each with one consumer (or one type of consumer). Drift between them is structurally constrained: surfacing is a strict subset of content-bearing.
+
+**Risk**
+
+- A future contributor adds a fifth client and writes `final:true` over HTTP expecting it to take effect. → **Mitigation:** the server silently ignores; spec deltas codify the contract; the only documented path to curate is `memory.session_summary` (MCP).
+- Operators may be surprised that `Purge empty sessions` offers a larger count immediately after the change lands. → **Mitigation:** the count growth corresponds to legitimately stale transcript-only sessions; the maintenance UI already shows the count before purge and includes a confirmation modal.

--- a/openspec/changes/archive/2026-05-21-tighten-context-content-predicate-to-final-summaries/specs/http-api/spec.md
+++ b/openspec/changes/archive/2026-05-21-tighten-context-content-predicate-to-final-summaries/specs/http-api/spec.md
@@ -1,0 +1,97 @@
+## MODIFIED Requirements
+
+### Requirement: `POST /api/<slug>/sessions/:id/summary` MUST write a summary and close the session
+
+The endpoint SHALL accept a JSON body `{ summary: string, title?: string }`. The `summary` field SHALL be a string of length ≥1 and ≤20,000 chars. The `title` field SHALL be a string of length ≤100 chars (when present, length ≥1). The body SHALL NOT contain a `final` field; the server SHALL treat all HTTP-path writes as `final:false` regardless of what the client sends. The `_final` flags (`summary_final` and `title_final`) SHALL only be lifted via the MCP tool `memory.session_summary`, which hard-codes `final:true` in its server-side handler.
+
+The server SHALL resolve the session by `(token_id, id)` — token-mismatch SHALL surface as `session_not_found`. When the resolved row's `deleted_at IS NOT NULL`, the call SHALL be rejected with `session_deleted`.
+
+For each provided field, the server SHALL apply the precedence rule (with `final` forced to `false`):
+
+- If the row's `*_final` column is `false`: write the field, leave `*_final` unchanged (stays `false`).
+- If the row's `*_final` column is `true`: silently skip writing this field (the curated value wins; the HTTP write cannot overwrite).
+
+The endpoint SHALL NOT modify `status`, `ended_at`, or any other column. Successful response: `{ ok: true, sessionId, summary, title, summaryFinal, titleFinal }`.
+
+Calls on an `ended` or `abandoned` session SHALL be rejected with `session_already_ended` and SHALL NOT mutate the row.
+
+#### Scenario: Non-final summary write on an active session with no prior summary
+
+- **WHEN** a client POSTs `{ summary: 'raw transcript', title: 'Fix bug' }` to `/api/foo/sessions/<S>/summary` on an active row whose `summary` is null and `summary_final` is `false`
+- **THEN** the row SHALL have `summary = 'raw transcript'`, `title = 'Fix bug'`, `summary_final = false`, `title_final = false`
+- **AND** `status` SHALL remain `'active'`
+- **AND** the response SHALL be `{ ok: true, sessionId, summary, title, summaryFinal: false, titleFinal: false }`
+
+#### Scenario: Curated summary blocks later HTTP write
+
+- **GIVEN** session `<S>` whose `summary_final` is `true` (written by `memory.session_summary`)
+- **WHEN** a client POSTs `{ summary: 'newer raw transcript' }`
+- **THEN** the row's `summary` SHALL remain unchanged
+- **AND** the response SHALL still be `200 OK` (silent skip is success, not error)
+
+#### Scenario: HTTP body cannot lift `_final` flags
+
+- **WHEN** a client POSTs `{ summary: 'raw transcript', title: 'Fix bug', final: true }` to `/api/foo/sessions/<S>/summary` on an active row with both `_final` flags at `false`
+- **THEN** the server SHALL ignore the `final` field in the body (zod schema does not validate it; the handler hard-codes `false`)
+- **AND** the row SHALL have `summary_final = false` and `title_final = false` after the write
+- **AND** the response SHALL be `{ ok: true, …, summaryFinal: false, titleFinal: false }`
+
+#### Scenario: Empty summary
+
+- **WHEN** a client POSTs `{ summary: '' }` or `{ summary: '   ' }`
+- **THEN** the server SHALL respond `400` with `{ ok: false, code: 'invalid_input' }` and SHALL NOT mutate the row
+
+#### Scenario: Title too long
+
+- **WHEN** a client POSTs `{ summary: '…', title: 'A'.repeat(101) }`
+- **THEN** the server SHALL respond `400` with `{ ok: false, code: 'invalid_input' }`
+
+#### Scenario: Session not found / wrong token
+
+- **WHEN** a client POSTs to `/api/foo/sessions/never-existed/summary` OR to a session id owned by a different token
+- **THEN** the server SHALL respond `404` with `{ ok: false, code: 'session_not_found' }`
+
+#### Scenario: Session already ended
+
+- **WHEN** a client POSTs a summary for a row whose `status = 'ended'` or `'abandoned'`
+- **THEN** the server SHALL respond `409` with `{ ok: false, code: 'session_already_ended' }` and SHALL NOT mutate the row
+
+#### Scenario: Session soft-deleted
+
+- **WHEN** a client POSTs a summary for a row whose `deleted_at IS NOT NULL`
+- **THEN** the server SHALL respond `409` with `{ ok: false, code: 'session_deleted' }`
+
+### Requirement: `POST /api/<slug>/sessions/:id/end` MUST close a session without a summary
+
+The endpoint SHALL accept a JSON body `{ summary?: string, title?: string }`. All fields are optional; an empty body `{}` is valid. The body SHALL NOT contain a `final` field; the server SHALL treat all HTTP-path writes as `final:false`. The same length rules as `/summary` apply when those fields are provided.
+
+The server SHALL resolve the session by `(token_id, id)` and, when active, atomically:
+
+1. Apply any provided summary/title writes subject to the precedence rule (with `final` forced to `false`).
+2. Set `ended_at = now` and `status = 'ended'`.
+
+Soft-deleted rows SHALL be rejected with `session_deleted`. Already-ended rows SHALL be treated as an idempotent no-op: any summary/title fields in the body are still applied subject to precedence, but `ended_at` and `status` SHALL NOT be re-written. The response SHALL be `{ ok: true, sessionId, endedAt, summary, title }`.
+
+#### Scenario: Active session closed with no body
+
+- **WHEN** a client POSTs `{}` to `/api/foo/sessions/<S>/end` on an active row
+- **THEN** the server SHALL set `status='ended'`, `ended_at=now`, leave `summary`/`title` unchanged, and respond `{ ok: true, sessionId, endedAt, summary: <prior>, title: <prior> }`
+
+#### Scenario: Active session closed atomically with summary and title
+
+- **WHEN** a client POSTs `{ summary: 'raw transcript', title: 'Refactor auth' }` to `/end` on an active row with no prior summary
+- **THEN** the server SHALL write summary and title (both `_final = false`), set `status='ended'`, set `ended_at=now` — in a single transaction
+- **AND** the response SHALL include the written values
+
+#### Scenario: End on already-ended session with new summary (write-once protected)
+
+- **GIVEN** session `<S>` is `ended` with `summary_final = true`
+- **WHEN** a client POSTs `{ summary: 'newer transcript' }` to `/end`
+- **THEN** the server SHALL respond `200 OK` with the unchanged row
+- **AND** `summary`, `status`, `ended_at` SHALL all remain unchanged (idempotent end, summary write blocked by precedence)
+
+#### Scenario: HTTP body cannot lift `_final` flags on /end
+
+- **WHEN** a client POSTs `{ summary: 'transcript', title: 'fallback title', final: true }` to `/end` on an active row with both `_final` flags at `false`
+- **THEN** the server SHALL ignore the `final` field
+- **AND** the row SHALL have `summary_final = false`, `title_final = false`, `status = 'ended'`, `ended_at = now`

--- a/openspec/changes/archive/2026-05-21-tighten-context-content-predicate-to-final-summaries/specs/mcp-api/spec.md
+++ b/openspec/changes/archive/2026-05-21-tighten-context-content-predicate-to-final-summaries/specs/mcp-api/spec.md
@@ -1,0 +1,83 @@
+## MODIFIED Requirements
+
+### Requirement: The MCP server MUST expose three research tools
+
+The `/mcp` and `/mcp/<slug>` endpoints SHALL register `memory.context`, `memory.timeline`, and `memory.capture_passive` with the following contracts. Note that `memory.save_prompt` (write side) and `memory.search_prompts` (read side) are registered in their own dedicated requirements; this requirement scopes the research/context tools only.
+
+#### Scenario: `memory.context` returns a bootstrap snapshot
+
+- **WHEN** an MCP client calls `memory.context` with `{ sessions?: number, prompts?: number, memories?: number, includeArchived?: boolean }`
+- **THEN** the server SHALL return `{ recentSessions, recentPrompts, recentMemories }`, with each list scoped to the request context (global vs path-scoped project)
+- **AND** `recentSessions` SHALL contain only sessions that satisfy the `sessionIsContextWorthy` predicate (see `sessions` capability), ordered by `started_at DESC`, with non-curated sessions filtered out BEFORE truncation to `sessions ?? 5`
+- **AND** every row in `recentSessions` SHALL have either `summary_final = 1` or `title_final = 1` — set exclusively by the MCP tool `memory.session_summary`
+- **AND** `recentPrompts` SHALL be ordered by `created_at DESC` and filtered to `deleted_at IS NULL`
+- **AND** `recentMemories` SHALL be ordered by `last_seen_at DESC` with `includeArchived = false` (default) filtering out `status = 'archived'` rows
+
+#### Scenario: `memory.context.recentSessions` backfills past non-curated sessions
+
+- **GIVEN** the active scope contains, in `started_at` order from newest to oldest, three non-curated sessions and one curated session
+- **WHEN** an MCP client calls `memory.context({sessions: 1})`
+- **THEN** the response's `recentSessions` array SHALL have length 1 and SHALL contain only the curated session — the three newer non-curated sessions SHALL NOT consume the slot
+
+#### Scenario: `memory.context.recentSessions` excludes soft-deleted sessions
+
+- **GIVEN** a curated session that is soft-deleted (`deleted_at IS NOT NULL`)
+- **WHEN** an MCP client calls `memory.context`
+- **THEN** the row SHALL NOT appear in `recentSessions` — the soft-delete filter and the context-worthy filter both apply
+
+#### Scenario: `memory.context.recentSessions` excludes sessions whose only summary is a transcript fallback
+
+- **GIVEN** a session `S` whose only content is a per-turn transcript write with `summary_final = 0`, no curated summary, no `title_final = 1`, and zero anchored rows in `memory`, `prompts`, `confirmations`
+- **WHEN** an MCP client calls `memory.context`
+- **THEN** `S` SHALL NOT appear in `recentSessions`
+- **AND** `S` SHALL remain visible to operators on `/dashboard/sessions` and eligible for purge via `/dashboard/maintenance` (subject to the existing 1h `ended_at` grace)
+
+#### Scenario: `memory.context.recentSessions` excludes ACTIVE non-curated sessions with anchored memory
+
+- **GIVEN** an active session `S` with `summary_final = 0` AND at least one anchored row in `memory` with `session_id = S.id`
+- **WHEN** an MCP client calls `memory.context` BEFORE `S` transitions to a terminal status
+- **THEN** `S` SHALL NOT appear in `recentSessions` — the anchored memory keeps `S` safe from purge but does not promote an active row to context-worthy by itself
+- **AND** the anchored memory SHALL appear in `recentMemories[]` (with its `session_id` available for `memory.timeline` follow-up)
+
+#### Scenario: `memory.context.recentSessions` includes auto-curated terminal sessions
+
+- **GIVEN** a session `S` that ended with anchored content but no agent-issued curation (server auto-curate fired at `memory.session_end`, producing `summary = '[auto] N memorias — última: …'` and `summary_final = 1`)
+- **WHEN** an MCP client calls `memory.context`
+- **THEN** `S` SHALL appear in `recentSessions` with the `[auto]`-prefixed summary
+- **AND** the agent MAY override the auto-curated summary at any later point via `memory.session_summary` (see `sessions::writeSummary MUST allow final:true on terminal sessions`)
+
+#### Scenario: `memory.context` arguments exceed clamps
+
+- **WHEN** the caller passes `sessions > 25`, `prompts > 50`, or `memories > 100`
+- **THEN** the server SHALL silently clamp to the maximum and SHALL include a `clamped: true` field in the response
+
+#### Scenario: `memory.context` excludes soft-deleted prompts
+
+- **GIVEN** prompts P1 and P2 in scope where `P2.deleted_at IS NOT NULL`
+- **WHEN** an MCP client calls `memory.context`
+- **THEN** `recentPrompts` SHALL include `P1` and SHALL NOT include `P2`
+
+#### Scenario: `memory.timeline` returns chronological neighbors within a session
+
+- **WHEN** an MCP client calls `memory.timeline` with `{ memoryId, before?: 5, after?: 5 }` and the target memory has a non-null `session_id`
+- **THEN** the server SHALL return up to `before` memories with `created_at < target.created_at` and `session_id = target.session_id`, plus up to `after` memories with `created_at > target.created_at` and `session_id = target.session_id`, ordered chronologically
+
+#### Scenario: `memory.timeline` falls back when the target has no session
+
+- **WHEN** the target memory has `session_id = NULL`
+- **THEN** the server SHALL return neighbors selected by `created_at` within ±2 hours of the target's `created_at`, scoped to the same `(scope, project_id)`, and the response SHALL include `fallback: 'time_window'`
+
+#### Scenario: `memory.timeline` combined window exceeds 50
+
+- **WHEN** `before + after > 50`
+- **THEN** the call SHALL be rejected with code `invalid_input` and a message referring the caller to `memory.search`
+
+#### Scenario: `memory.capture_passive` extracts numbered learnings
+
+- **WHEN** an MCP client calls `memory.capture_passive` with `{ text: string, sessionId?: string }` and `text` contains a section starting with `^## Key Learnings:\s*$`
+- **THEN** the server SHALL extract each subsequent numbered (`1.`, `2.`) or bulleted (`-`, `*`) item, save each as a separate memory with `type = 'discovery'` and the active scope, and SHALL return `{ saved: number, ids: string[] }`
+
+#### Scenario: `memory.capture_passive` finds no learnings block
+
+- **WHEN** the input text has no matching `## Key Learnings:` heading
+- **THEN** the server SHALL return `{ saved: 0, ids: [] }` and SHALL NOT error

--- a/openspec/changes/archive/2026-05-21-tighten-context-content-predicate-to-final-summaries/specs/sessions/spec.md
+++ b/openspec/changes/archive/2026-05-21-tighten-context-content-predicate-to-final-summaries/specs/sessions/spec.md
@@ -1,0 +1,233 @@
+## ADDED Requirements
+
+### Requirement: `sessionIsContextWorthy` is the surfacing predicate for `memory.context`
+
+`AgentSessionsService` SHALL define an internal SQL predicate, `sessionIsContextWorthy(s)`, returning TRUE for a `sessions` row `s` iff at least ONE of the following holds:
+
+1. `s.summary IS NOT NULL` AND `s.summary_final = 1`, OR
+2. `s.title_final = 1`.
+
+The predicate SHALL be implemented as a single private SQL-fragment helper inside `apps/server/src/services/agent-sessions.ts`. It SHALL have exactly ONE consumer: `recentForContext`. It expresses the question "is this session worth surfacing to the LLM as a `recentSessions` entry?"
+
+`sessionIsContextWorthy(s)` is a strict subset of `sessionHasContent(s)`: every context-worthy session is also content-bearing, but content-bearing sessions are not necessarily context-worthy. The distinction is intentional — purge protection and surfacing eligibility ask different questions:
+
+- Purge protection asks "would deleting this row dangle foreign keys?" (`sessionHasContent`).
+- Surfacing asks "does this row carry signal the LLM can read directly?" (`sessionIsContextWorthy`).
+
+The two predicates SHALL coexist in the same source file and SHALL be the ONLY places where their respective SQL clauses are expressed.
+
+#### Scenario: A session with a curated summary satisfies `sessionIsContextWorthy`
+
+- **GIVEN** session `S` with `summary = 'Goal: …'` and `summary_final = 1`
+- **WHEN** `sessionIsContextWorthy(S)` is evaluated
+- **THEN** the predicate SHALL return TRUE
+
+#### Scenario: A session with `title_final = 1` satisfies `sessionIsContextWorthy`
+
+- **GIVEN** session `S` with `summary IS NULL` and `title_final = 1`
+- **WHEN** `sessionIsContextWorthy(S)` is evaluated
+- **THEN** the predicate SHALL return TRUE
+
+#### Scenario: A session with anchored memory but no curated summary is content-bearing but not context-worthy by itself
+
+- **GIVEN** session `S` with `summary IS NULL`, `title_final = 0`, AND at least one row in `memory` referencing `S.id`, evaluated BEFORE any terminal transition fires the auto-curate (e.g. mid-flight or status='active')
+- **WHEN** `sessionHasContent(S)` and `sessionIsContextWorthy(S)` are both evaluated
+- **THEN** `sessionHasContent(S)` SHALL return TRUE (purge-protected) AND `sessionIsContextWorthy(S)` SHALL return FALSE
+- **AND** after the terminal transition fires, the auto-curate path SHALL elevate `S` to context-worthy by writing a derived summary (see `Auto-curate at terminal transition` requirement below)
+
+#### Scenario: A session with only a transcript-fallback summary is neither content-bearing nor context-worthy
+
+- **GIVEN** session `S` with `summary = '<raw transcript dump>'`, `summary_final = 0`, `title_final = 0`, and zero anchored rows in `memory`, `prompts`, `confirmations`
+- **WHEN** `sessionHasContent(S)` and `sessionIsContextWorthy(S)` are both evaluated
+- **THEN** both SHALL return FALSE — the row is purgeable AND it does not surface to the LLM (the auto-curate path also does NOT fire, since there is no anchored content to derive from)
+
+### Requirement: Server-side auto-curate at terminal transition
+
+When `AgentSessionsService.end(sessionId)` or `AgentSessionsService.abandonStale()` transitions a session from `active` to a terminal status (`ended` or `abandoned`), the service SHALL, in the same transaction:
+
+1. Read the current `summary_final` flag.
+2. If `summary_final = 1`, SKIP — the agent already curated, the curated text wins, no overwrite.
+3. If `summary_final = 0` AND the session has at least one anchored row in `memory`, `prompts`, OR `confirmations`, COMPOSE a derived summary using the deterministic template defined below and WRITE it to the row with `summary_final = 1`.
+4. If `summary_final = 0` AND the session has NO anchored content, SKIP — there is nothing to derive from. The session remains non-context-worthy and operator-purgeable.
+
+The derivation template is the pure function `composeDerivedSummary(counts, lastMemoryContent)`:
+
+```
+parts := []
+if counts.memories > 0:      parts.push(`${counts.memories} memorias`)
+if counts.prompts > 0:       parts.push(`${counts.prompts} prompts`)
+if counts.confirmations > 0: parts.push(`${counts.confirmations} confirmaciones`)
+
+head := join(parts, ', ')
+tail := lastMemoryContent ? ` — última: '${snippet(lastMemoryContent, 80)}'` : ''
+
+return `[auto] ${head}${tail}`
+```
+
+The function SHALL be deterministic: same `counts` and `lastMemoryContent` produce the same output, byte-for-byte. The function SHALL NOT inspect the previous `summary` value, SHALL NOT call any LLM, SHALL NOT apply heuristics over the content. The `[auto]` prefix is mandatory and identifies the row as server-derived to both the agent and the operator.
+
+The auto-curate write SHALL OVERWRITE any prior `final:false` `summary` value (a per-turn transcript dump written by a plugin Stop hook). The derived summary supersedes the transcript dump in the `summary` column; operators retain forensic visibility of anchored content via `/dashboard/sessions/:id` (the memories list, prompts list, and timing).
+
+The auto-curate path SHALL be the SECOND writer that can lift `summary_final` to 1 (the first being the MCP tool `memory.session_summary`). Subsequent agent-issued `memory.session_summary` calls SHALL be able to overwrite an auto-curated row (see the modified `writeSummary` precedence below): agent intent always wins over server-derived content.
+
+`countPurgeableEmpty` and `purgeEmpty` SHALL keep using `sessionHasContent` (5 clauses); auto-curated sessions naturally fail the `NOT sessionHasContent` predicate (their EXISTS-anchored content was the reason they were curated), so they are NOT purge-eligible.
+
+#### Scenario: Agent curated before ending — auto-curate is a no-op
+
+- **GIVEN** active session `S` with `summary_final = 1` (agent called `memory.session_summary` earlier)
+- **WHEN** the agent calls `memory.session_end` on `S`
+- **THEN** the service SHALL transition `S` to `ended` and SHALL NOT overwrite the curated summary
+- **AND** `S.summary_final` SHALL remain 1, `S.summary` SHALL remain the agent's curated text
+
+#### Scenario: Agent did not curate, session has anchored memory — auto-curate fires
+
+- **GIVEN** active session `S` with `summary_final = 0`, `summary IS NULL` (or any non-final summary), and 5 anchored rows in `memory`, latest content `"Fixed null check in foo.ts when handler receives undefined"`
+- **WHEN** the agent calls `memory.session_end` on `S`
+- **THEN** the service SHALL atomically: set `status = 'ended'`, write `summary = "[auto] 5 memorias — última: 'Fixed null check in foo.ts when handler receives undefined'"`, set `summary_final = 1`, set `ended_at = now`
+- **AND** `S` SHALL now satisfy `sessionIsContextWorthy` and surface in `memory.context.recentSessions`
+
+#### Scenario: Agent did not curate, session has only transcript dump — auto-curate skips
+
+- **GIVEN** active session `S` with `summary = '<raw transcript dump>'`, `summary_final = 0`, and zero anchored rows
+- **WHEN** the agent calls `memory.session_end` on `S`
+- **THEN** the service SHALL transition `S` to `ended` and SHALL NOT touch `summary` or `summary_final`
+- **AND** `S` SHALL remain non-context-worthy (excluded from `memory.context.recentSessions`) and SHALL become purge-eligible after the 1h `ended_at` grace
+
+#### Scenario: abandonStale transitions also trigger auto-curate
+
+- **GIVEN** an active session `S` with `summary_final = 0`, 8 anchored memory rows, and `started_at` older than the abandonStale cutoff
+- **WHEN** `abandonStale({olderThanMs})` runs (typically at server startup)
+- **THEN** the service SHALL per-row: apply the auto-curate write (composing the derived summary) AND transition `status` to `abandoned` AND set `ended_at = now` — in a single transaction per session
+- **AND** the returned `{ abandoned: N }` count SHALL match the number of sessions transitioned
+
+#### Scenario: Auto-curate output is deterministic and structural
+
+- **GIVEN** a session `S` with anchored counts `{ memories: 3, prompts: 2, confirmations: 0 }` and latest memory content `"Refactored the auth middleware to use jose"`
+- **WHEN** `composeDerivedSummary` is called with those inputs
+- **THEN** the output SHALL be exactly `"[auto] 3 memorias, 2 prompts — última: 'Refactored the auth middleware to use jose'"` — same input always produces same output, no LLM, no heuristic, no content inspection of the previous summary
+
+### Requirement: `writeSummary` MUST allow `final:true` writes on terminal sessions
+
+`AgentSessionsService.writeSummary(sessionId, input)` SHALL accept the write under either of two conditions, relaxing the previous "active-only" gate so that agents can override server auto-curated rows. The service is the shared entry point for both the MCP tool `memory.session_summary` (always `final:true`) and the HTTP fallback path `POST /api/<slug>/sessions/:id/summary` (always `final:false` after hardening).
+
+The two acceptance conditions are:
+
+1. The session's `status = 'active'` (the historical pre-existing rule), OR
+2. The session's `status ∈ {'ended', 'abandoned'}` AND the incoming `input.final === true` — i.e., the agent is explicitly issuing a curated write on a terminal session.
+
+Condition (2) exists so that an agent can OVERRIDE a server auto-curated row with its own curated summary at any point, including after the session has already transitioned. The HTTP fallback path cannot exploit this opening because the HTTP handlers hard-code `final: false`, so the HTTP-derived writes still hit condition (1)'s `status = 'active'` gate — only the MCP tool `memory.session_summary` can satisfy condition (2).
+
+When the write is accepted under condition (2), the precedence rule applies as usual: `summary` (and optionally `title`) are overwritten, `summary_final` (and `title_final`) are set to 1, `status`/`ended_at` are NOT modified.
+
+When the incoming write is `final:false` on a terminal session (HTTP path or otherwise), the call SHALL be rejected with `session_already_ended`.
+
+#### Scenario: Agent overrides an auto-curated ended session via `memory.session_summary`
+
+- **GIVEN** session `S` is `ended` with `summary = '[auto] 5 memorias — última: …'` and `summary_final = 1` (server auto-curated)
+- **WHEN** the agent calls `memory.session_summary({summary: 'Goal: X. Files: Y.', title: 'Refactor'})` against `S`
+- **THEN** the server SHALL accept the write (condition 2)
+- **AND** `S.summary` SHALL become `'Goal: X. Files: Y.'`, `S.title` SHALL become `'Refactor'`, `S.summary_final` SHALL remain 1, `S.title_final` SHALL become 1
+- **AND** `S.status` SHALL remain `'ended'` (unchanged)
+
+#### Scenario: HTTP fallback cannot exploit the relaxation
+
+- **GIVEN** an ended session `S`
+- **WHEN** an HTTP client POSTs `{summary: 'transcript', final: true}` to `/api/<slug>/sessions/:id/summary` (the body's `final` field is dropped by the zod schema and the handler hard-codes `false`)
+- **THEN** the service-level call is `writeSummary(S, {final: false})`, which fails condition (1) (`status != 'active'`) and condition (2) (`final !== true`), and SHALL be rejected with `session_already_ended`
+
+#### Scenario: `final:true` write on an active session is unchanged
+
+- **GIVEN** an active session `S` with `summary_final = 0`
+- **WHEN** the agent calls `memory.session_summary({summary: 'Goal: X'})` (the MCP handler injects `final: true`)
+- **THEN** the write is accepted under condition (1) and `S.summary_final` becomes 1, exactly as before this change
+
+## MODIFIED Requirements
+
+### Requirement: `sessionHasContent` is the single source-of-truth predicate for "this session is worth surfacing"
+
+`AgentSessionsService` SHALL define an internal SQL predicate, `sessionHasContent(s)`, returning TRUE for a `sessions` row `s` iff at least ONE of the following holds:
+
+1. `s.summary IS NOT NULL`, OR
+2. `s.title_final = 1`, OR
+3. there exists at least one row in `memory` with `session_id = s.id`, OR
+4. there exists at least one row in `prompts` with `session_id = s.id` AND `deleted_at IS NULL`, OR
+5. there exists at least one row in `confirmations` with `session_id = s.id`.
+
+This predicate governs **purge eligibility only**. It answers "would physically deleting this row dangle foreign-key references?" — and so any anchored content (memory / prompts / confirmations) keeps a session out of the purge set, regardless of whether the agent curated it. Surfacing to `memory.context` is governed by the separate, stricter predicate `sessionIsContextWorthy`.
+
+Soft-deleted prompts (`deleted_at IS NOT NULL`) DO NOT make a session content-bearing; the operator has already marked them as obsolete.
+
+The predicate SHALL be implemented as a single private SQL-fragment helper inside `apps/server/src/services/agent-sessions.ts`. It SHALL be the ONLY place in the codebase where this five-clause predicate is expressed. The `countPurgeableEmpty` and `purgeEmpty` methods SHALL consume the predicate in negated form (`NOT sessionHasContent(s)`) as part of their "purgeable" check. `recentForContext` SHALL NOT consume this predicate — it consumes `sessionIsContextWorthy` instead.
+
+When a future content-bearing table is added with a `session_id` foreign key (the canonical example being a hypothetical `tool_calls` table), the predicate SHALL be the single point of update for the purge protection — the new EXISTS clause is added once, and `countPurgeableEmpty` / `purgeEmpty` pick the change up automatically.
+
+#### Scenario: A session with a written summary satisfies the predicate
+
+- **GIVEN** session `S` with `summary = 'Goal: ...'` and no anchored memory/prompt/confirmation rows
+- **WHEN** any call site evaluates `sessionHasContent(S)`
+- **THEN** the predicate SHALL return TRUE
+
+#### Scenario: A session with no content fails the predicate
+
+- **GIVEN** session `S` with `summary IS NULL`, `title_final = 0`, and zero anchored rows in `memory`, `prompts`, `confirmations`
+- **WHEN** any call site evaluates `sessionHasContent(S)`
+- **THEN** the predicate SHALL return FALSE
+
+#### Scenario: A session with anchored memory is content-bearing even without curated summary
+
+- **GIVEN** session `S` with `summary IS NULL`, `title_final = 0`, and at least one anchored row in `memory` with `session_id = S.id`
+- **WHEN** `sessionHasContent(S)` is evaluated
+- **THEN** the predicate SHALL return TRUE — the session is purge-protected to preserve referential integrity of the anchored memory
+
+#### Scenario: Strict-subset relationship with `sessionIsContextWorthy`
+
+- **GIVEN** the codebase as a whole
+- **WHEN** a reviewer reads both predicate helpers
+- **THEN** every clause of `sessionIsContextWorthy(s)` SHALL imply at least one clause of `sessionHasContent(s)` (a curated summary implies non-null summary; `title_final = 1` is a clause of `sessionHasContent` verbatim)
+- **AND** a code search for the EXISTS-bearing 5-clause predicate SHALL return zero matches outside the `sessionHasContent` helper definition within `apps/server/src/services/agent-sessions.ts`
+
+### Requirement: `recentForContext` MUST exclude empty sessions by default
+
+`AgentSessionsService.recentForContext({projectId, limit})` SHALL return at most `limit` rows, ordered by `started_at DESC`, drawn from the set of sessions satisfying ALL of:
+
+1. `deleted_at IS NULL` (soft-delete);
+2. scope match (`projectId IS NULL` for global, or `project_id = ?` for path-scoped);
+3. `sessionIsContextWorthy(s)` is TRUE.
+
+Filtering SHALL precede truncation: a request with `limit: 5` SHALL return the five most-recent _context-worthy_ sessions, even if dozens of newer non-curated sessions exist between them. Non-curated sessions SHALL NEVER consume a slot in the response.
+
+The method SHALL NOT accept any flag, option, or argument that bypasses the `sessionIsContextWorthy` filter. Operators who need to inspect non-curated sessions SHALL use `/dashboard/sessions`, which surfaces all rows regardless of curation.
+
+Note: after the auto-curate path lands (see ADDED requirement above), most real-work sessions naturally become context-worthy at their terminal transition, so the population of `sessionIsContextWorthy(s) = TRUE` is the union of agent-curated rows AND server-auto-curated rows. The `[auto]` prefix on the latter is informational only; the predicate does not inspect the summary text.
+
+#### Scenario: A non-curated session is excluded BEFORE terminal transition
+
+- **GIVEN** an active session `M` with `summary_final = 0` AND one anchored memory row referencing `M.id`, plus an ended session `C` with `summary_final = 1`
+- **WHEN** `recentForContext({projectId, limit: 5})` is called BEFORE `M` transitions to terminal
+- **THEN** the result SHALL contain `C` and SHALL NOT contain `M`
+- **AND** `M`'s memory still appears in the caller's `recentMemories[]` payload via `MemoryService.recentForContext`
+
+#### Scenario: A non-curated session with anchored content surfaces AFTER terminal transition (auto-curate)
+
+- **GIVEN** a session `M` that has 5 anchored memory rows but was never explicitly curated by the agent
+- **WHEN** the agent calls `memory.session_end` on `M`, which fires the auto-curate path, AND THEN `recentForContext({projectId, limit: 5})` is called
+- **THEN** the result SHALL contain `M` with `summary` matching the deterministic `[auto] N memorias…` template
+
+#### Scenario: A non-curated session with no anchored content is excluded permanently
+
+- **GIVEN** an ended session `T` with `summary_final = 0`, zero anchored rows, optionally with a non-final transcript dump in `summary`
+- **WHEN** `recentForContext({projectId, limit: 5})` is called
+- **THEN** `T` SHALL NOT appear in the result — auto-curate did not fire (no anchored content), the row stays non-context-worthy permanently
+
+#### Scenario: Filter-then-truncate produces backfill semantics
+
+- **GIVEN** a scope containing, in `started_at` order from newest to oldest: three non-curated sessions `A`, `B`, `C` (none with anchored content) and one curated session `U`
+- **WHEN** `recentForContext({projectId, limit: 1})` is called
+- **THEN** the result SHALL be `[U]` — the most-recent CURATED session, not the most-recent session overall
+
+#### Scenario: Soft-deleted session with curated summary is still excluded
+
+- **GIVEN** a session that has `summary_final = 1` AND is soft-deleted
+- **WHEN** `recentForContext` is called
+- **THEN** the row SHALL NOT appear in the result — both filters apply, neither overrides the other
+

--- a/openspec/changes/archive/2026-05-21-tighten-context-content-predicate-to-final-summaries/tasks.md
+++ b/openspec/changes/archive/2026-05-21-tighten-context-content-predicate-to-final-summaries/tasks.md
@@ -1,0 +1,73 @@
+## 1. Split the predicate
+
+- [x] 1.1 In `apps/server/src/services/agent-sessions.ts:26-34`, add a new SQL fragment helper `sessionIsContextWorthySql(alias: 's' | 'sessions')` returning `((${alias}.summary IS NOT NULL AND ${alias}.summary_final = 1) OR ${alias}.title_final = 1)`.
+- [x] 1.2 Update the JSDoc on `sessionHasContentSql` to clarify its purge-only scope, and reference `sessionIsContextWorthySql` as the surfacing counterpart.
+- [x] 1.3 In `recentForContext` (same file, ~line 416-429), replace `sessionHasContentSql('sessions')` in the WHERE clause with `sessionIsContextWorthySql('sessions')`.
+- [x] 1.4 Confirm `countPurgeableEmpty` and `purgeEmpty` keep consuming `sessionHasContentSql('s')` unchanged.
+
+## 2. Harden the HTTP path
+
+- [x] 2.1 Locate the zod body schemas `sessionSummarySchema` and `sessionEndSchema` (likely in `apps/server/src/mcp/sessions-tools.ts` or `apps/server/src/server/schemas.ts`). Remove the `final` field from both.
+- [x] 2.2 In `apps/server/src/server/api-router.ts:118-123` (handler for `POST /:slug/sessions/:id/summary`), replace `final: parsed.data.final` with `final: false`.
+- [x] 2.3 In `apps/server/src/server/api-router.ts:153-160` (handler for `POST /:slug/sessions/:id/end`), replace `final: parsed.data.final` with `final: false`.
+- [x] 2.4 Verify `apps/server/src/mcp/sessions-tools.ts:406-411` (`memory.session_summary` MCP handler) STILL hard-codes `final: true` — it remains the sole writer that lifts the flags.
+
+## 3. Service-layer unit tests
+
+- [x] 3.1 In `apps/server/src/services/agent-sessions.test.ts`, inside the existing `describe('recentForContext content filter (sessionHasContent predicate)')` block: rename the describe to `recentForContext content filter (sessionIsContextWorthy predicate)`.
+- [x] 3.2 In the same describe block, FLIP the assertion of the existing test `includes a session referenced by at least one memory row` (lines ~485-495) to `excludes a session referenced ONLY by memory rows (memory still surfaces via recentMemories[])` — assert `recent.some(r => r.id === s.id)` is `false`.
+- [x] 3.3 Same for `includes a session referenced by at least one prompt row` (lines ~497-507) and `includes a session referenced by at least one confirmation row` (lines ~509-526). Flip both to "excludes".
+- [x] 3.4 Add a new test `excludes a session whose only content is a final:false summary`: start a session, call `writeSummary({ summary: 'raw transcript', final: false })`, assert NOT in `recentForContext` result.
+- [x] 3.5 Add a new test `includes a session with curated summary (final:true)`: start a session, call `writeSummary({ summary: 'Goal: x', final: true })`, assert IN `recentForContext` result.
+- [x] 3.6 Add a new test in a separate describe block (`purge protection vs surfacing asymmetry`): start a session, write a memory row referencing it, advance time past 1h grace, end the session. Assert (a) `countPurgeableEmpty()` returns 0 (session is purge-protected by EXISTS memory), AND (b) `recentForContext` does NOT include the session (no curation).
+- [x] 3.7 Confirm the existing test `includes a session that has a summary written` (uses `sessions.summarize()` which sets `final:true` via back-compat wrapper) STILL passes — no change needed.
+
+## 4. HTTP-layer test updates
+
+- [x] 4.1 In `apps/server/src/server/api-router.test.ts`, audit every test that POSTs `{ final: true }` (lines ~217, ~263-281, ~379-384) and migrate them: replace the "set up locked state via HTTP `final:true` POST" with "set up locked state via the service layer (agentSessions.writeSummary with final:true), which is the only legitimate path".
+- [x] 4.2 Add a new test `HTTP body final:true is silently ignored on /summary`: POST `{ summary, title, final: true }` to `/api/foo/sessions/<S>/summary` on a fresh active session; assert response has `summaryFinal: false`, `titleFinal: false`; assert DB row matches.
+- [x] 4.3 Add a new test `HTTP body final:true is silently ignored on /end`: same shape, against `/api/foo/sessions/<S>/end`.
+- [x] 4.4 Update any test that asserts the body schema accepts `final` to assert that zod rejects an unknown field if `strict()` is in use, OR that the field is silently dropped (depending on the schema definition style). [Zod's default object behavior silently strips unknown fields, so the assertion is just that the field has no effect.]
+
+## 5. MCP integration tests
+
+- [x] 5.1 In `apps/server/src/test/mcp-integration.test.ts`, add a new scenario alongside `memory.context excludes a session ended without memories or summary` (around line 277): scenario `memory.context excludes a session with anchored memory but no curated summary, while the memory itself surfaces in recentMemories`. [Placed AFTER the candidates test to avoid polluting the FTS5 BM25 corpus that the candidates test relies on.]
+- [x] 5.2 Within the new scenario: `memory.session_start` → `memory.save({content})` (auto-anchors to session) → `memory.session_end` (without prior `memory.session_summary`). Assert (a) `ctx.recentSessions.some(s => s.id === sessionId)` is `false`, AND (b) `ctx.recentMemories.some(m => m.id === savedMemoryId)` is `true`.
+- [x] 5.3 Verify the existing scenarios `memory.context returns a bootstrap snapshot` (line 257-272) and `memory.context excludes a session ended without memories or summary` (line 277-302) STILL pass under the new predicate — the first uses `memory.session_summary` (`final:true`), the second has no content at all.
+- [x] 5.4 Update the existing `memory.context backfills past empty sessions to return useful older ones` to call `memory.session_summary` (the only path to curation under the new contract). Renamed to `...curated older ones`.
+
+## 6. Server-side auto-curate at terminal transition
+
+- [x] 6.1 In `apps/server/src/services/agent-sessions.ts`, add a pure helper `composeDerivedSummary(counts, lastMemoryContent)` returning the exact template `[auto] N memorias[, P prompts[, C confirmaciones]][ — última: '<snippet of lastMemoryContent>']`. Use `snippet(text, 80)` for truncation. Function is exported for unit testing.
+- [x] 6.2 Add a private helper `computeAutoCurate(sessionId)` that: (a) counts anchored rows in `memory`, `prompts` (where deleted_at IS NULL), `confirmations` referencing the session, (b) returns null if total = 0, (c) SELECTs the most recent memory content, (d) composes the derived summary and returns it.
+- [x] 6.3 In `end()` active→ended transition: compute `willHaveCuratedSummary` from precedence result; if false, call `computeAutoCurate` and merge the derived summary into the same UPDATE set. Atomic with the status flip.
+- [x] 6.4 In `abandonStale()`: convert the bulk UPDATE to a per-row loop. For each stale row, build a set with `status=abandoned` + `ended_at`, and if `summary_final=0` AND `computeAutoCurate` returns a value, add it to the set. UPDATE per row with `WHERE id=? AND status='active'` for concurrency safety. Return the count.
+- [x] 6.5 Relax the guard in `writeSummary()`: allow the write when `existing.status !== 'active'` BUT `input.final === true`. Reject only when `existing.status !== 'active' AND input.final !== true`. Adjust the UPDATE WHERE clause accordingly (no `status='active'` gate when overriding a terminal session).
+- [x] 6.6 Service-layer tests added (12 new tests covering composeDerivedSummary, end() auto-curate scenarios, abandonStale auto-curate, writeSummary override).
+- [x] 6.7 MCP integration test updated: full lifecycle — save memory, end without curation, `memory.context` surfaces the session with `[auto]` prefix.
+- [x] 6.8 Existing "asymmetry" test updated to reflect the new behavior: now the session SURFACES after `end()` (via auto-curate) AND remains purge-protected.
+
+## 7. Spec validation
+
+- [x] 7.1 Run `openspec validate tighten-context-content-predicate-to-final-summaries --strict` — must exit clean.
+- [x] 7.2 Run `openspec validate --specs --strict` against the change's spec deltas (sessions, mcp-api, http-api) — must exit clean.
+
+## 8. Validation gates
+
+- [x] 8.1 Run `pnpm run typecheck` from repo root — must exit 0.
+- [x] 8.2 Run `pnpm run lint` — must exit 0 against the touched files.
+- [x] 8.3 Run `pnpm test` — full suite must pass. (540 tests passing, 12 new auto-curate tests added.)
+
+## 9. End-to-end smoke (automated against dev docker stack)
+
+- [x] 9.1 With `pnpm run dev:docker:up` running, drive 3 scenarios via MCP HTTP transport at `/mcp/demo`: - Tipo A: `session_start` → `session_end` (no anchored content, no curate). - Tipo B: `session_start` → `memory.save` → `session_end` (no curate — auto-curate must fire). - Tipo C: `session_start` → `memory.save` → `memory.session_summary` → `session_end` (agent curated).
+- [x] 9.2 Call `memory.context({sessions:25, memories:25})` and assert: - Tipo A NOT in recentSessions ✓ - Tipo B IS in recentSessions with `summary` starting with `[auto]` ✓ - Tipo C IS in recentSessions with agent-curated summary ✓ - Memories from B and C surface in recentMemories ✓
+- [x] 9.3 Direct SQLite inspection of mounted `data-dev/data.db` confirms DB state: - Tipo A: `summary_final=0, summary=NULL` (excluded from context, eligible for purge) - Tipo B: `summary_final=1, summary='[auto] 1 memorias — última: ...'` - Tipo C: `summary_final=1, summary='Goal: ...'`
+- [x] 9.4 Dashboard `/dashboard/sessions` (via admin cookie login) lists ALL 4 smoke sessions including Tipo A — operator visibility preserved.
+- [x] 9.5 HTTP hardening verified: POST `/api/demo/sessions/<id>/summary` with body `{"final":true}` returns `summaryFinal:false, titleFinal:false` and the DB row stays `summary_final=0` — the server silently ignores the body field as designed.
+
+## 10. Archive readiness
+
+- [x] 10.1 Confirm there are no untracked artifacts under `openspec/changes/tighten-context-content-predicate-to-final-summaries/` beyond `proposal.md`, `design.md`, `tasks.md`, `specs/sessions/spec.md`, `specs/mcp-api/spec.md`, `specs/http-api/spec.md`.
+- [x] 10.2 Confirm the commit message follows Conventional Commits and references the change name.
+- [x] 10.3 Run `/opsx:archive tighten-context-content-predicate-to-final-summaries` to move the change to `openspec/changes/archive/` and apply the spec deltas to `openspec/specs/`. (Archived AS PART of this PR — repo flow is archive-before-merge per prior session history.)

--- a/openspec/specs/http-api/spec.md
+++ b/openspec/specs/http-api/spec.md
@@ -80,15 +80,14 @@ The server SHALL respond `200 OK` on both insert and upsert paths with body `{ o
 
 ### Requirement: `POST /api/<slug>/sessions/:id/summary` MUST write a summary and close the session
 
-The endpoint SHALL accept a JSON body `{ summary: string, title?: string, final?: boolean }`. The `summary` field SHALL be a string of length ≥1 and ≤20,000 chars. The `title` field SHALL be a string of length ≤100 chars (when present, length ≥1). The `final` field SHALL default to `false`.
+The endpoint SHALL accept a JSON body `{ summary: string, title?: string }`. The `summary` field SHALL be a string of length ≥1 and ≤20,000 chars. The `title` field SHALL be a string of length ≤100 chars (when present, length ≥1). The body SHALL NOT contain a `final` field; the server SHALL treat all HTTP-path writes as `final:false` regardless of what the client sends. The `_final` flags (`summary_final` and `title_final`) SHALL only be lifted via the MCP tool `memory.session_summary`, which hard-codes `final:true` in its server-side handler.
 
 The server SHALL resolve the session by `(token_id, id)` — token-mismatch SHALL surface as `session_not_found`. When the resolved row's `deleted_at IS NOT NULL`, the call SHALL be rejected with `session_deleted`.
 
-For each provided field, the server SHALL apply the precedence rule:
+For each provided field, the server SHALL apply the precedence rule (with `final` forced to `false`):
 
-- If `final` in body is `true`: write the field, set the `*_final` column to `true`, overwriting any prior value (last-final-wins).
-- If `final` in body is `false` (or omitted) AND the row's `*_final` column is `false`: write the field, leave `*_final` unchanged.
-- If `final` in body is `false` AND the row's `*_final` column is `true`: silently skip writing this field.
+- If the row's `*_final` column is `false`: write the field, leave `*_final` unchanged (stays `false`).
+- If the row's `*_final` column is `true`: silently skip writing this field (the curated value wins; the HTTP write cannot overwrite).
 
 The endpoint SHALL NOT modify `status`, `ended_at`, or any other column. Successful response: `{ ok: true, sessionId, summary, title, summaryFinal, titleFinal }`.
 
@@ -101,12 +100,19 @@ Calls on an `ended` or `abandoned` session SHALL be rejected with `session_alrea
 - **AND** `status` SHALL remain `'active'`
 - **AND** the response SHALL be `{ ok: true, sessionId, summary, title, summaryFinal: false, titleFinal: false }`
 
-#### Scenario: Final write blocks later non-final write
+#### Scenario: Curated summary blocks later HTTP write
 
 - **GIVEN** session `<S>` whose `summary_final` is `true` (written by `memory.session_summary`)
-- **WHEN** a client POSTs `{ summary: 'newer raw transcript', final: false }`
+- **WHEN** a client POSTs `{ summary: 'newer raw transcript' }`
 - **THEN** the row's `summary` SHALL remain unchanged
 - **AND** the response SHALL still be `200 OK` (silent skip is success, not error)
+
+#### Scenario: HTTP body cannot lift `_final` flags
+
+- **WHEN** a client POSTs `{ summary: 'raw transcript', title: 'Fix bug', final: true }` to `/api/foo/sessions/<S>/summary` on an active row with both `_final` flags at `false`
+- **THEN** the server SHALL ignore the `final` field in the body (zod schema does not validate it; the handler hard-codes `false`)
+- **AND** the row SHALL have `summary_final = false` and `title_final = false` after the write
+- **AND** the response SHALL be `{ ok: true, …, summaryFinal: false, titleFinal: false }`
 
 #### Scenario: Empty summary
 
@@ -135,11 +141,11 @@ Calls on an `ended` or `abandoned` session SHALL be rejected with `session_alrea
 
 ### Requirement: `POST /api/<slug>/sessions/:id/end` MUST close a session without a summary
 
-The endpoint SHALL accept a JSON body `{ summary?: string, title?: string, final?: boolean }`. All fields are optional; an empty body `{}` is valid. The same length and `final` precedence rules as `/summary` apply when those fields are provided.
+The endpoint SHALL accept a JSON body `{ summary?: string, title?: string }`. All fields are optional; an empty body `{}` is valid. The body SHALL NOT contain a `final` field; the server SHALL treat all HTTP-path writes as `final:false`. The same length rules as `/summary` apply when those fields are provided.
 
 The server SHALL resolve the session by `(token_id, id)` and, when active, atomically:
 
-1. Apply any provided summary/title writes subject to the precedence rules.
+1. Apply any provided summary/title writes subject to the precedence rule (with `final` forced to `false`).
 2. Set `ended_at = now` and `status = 'ended'`.
 
 Soft-deleted rows SHALL be rejected with `session_deleted`. Already-ended rows SHALL be treated as an idempotent no-op: any summary/title fields in the body are still applied subject to precedence, but `ended_at` and `status` SHALL NOT be re-written. The response SHALL be `{ ok: true, sessionId, endedAt, summary, title }`.
@@ -151,28 +157,22 @@ Soft-deleted rows SHALL be rejected with `session_deleted`. Already-ended rows S
 
 #### Scenario: Active session closed atomically with summary and title
 
-- **WHEN** a client POSTs `{ summary: 'raw transcript', title: 'Refactor auth', final: false }` to `/end` on an active row with no prior summary
+- **WHEN** a client POSTs `{ summary: 'raw transcript', title: 'Refactor auth' }` to `/end` on an active row with no prior summary
 - **THEN** the server SHALL write summary and title (both `_final = false`), set `status='ended'`, set `ended_at=now` — in a single transaction
 - **AND** the response SHALL include the written values
 
 #### Scenario: End on already-ended session with new summary (write-once protected)
 
 - **GIVEN** session `<S>` is `ended` with `summary_final = true`
-- **WHEN** a client POSTs `{ summary: 'newer transcript', final: false }` to `/end`
+- **WHEN** a client POSTs `{ summary: 'newer transcript' }` to `/end`
 - **THEN** the server SHALL respond `200 OK` with the unchanged row
 - **AND** `summary`, `status`, `ended_at` SHALL all remain unchanged (idempotent end, summary write blocked by precedence)
 
-#### Scenario: End on already-ended session with no summary, fallback fills it
+#### Scenario: HTTP body cannot lift `_final` flags on /end
 
-- **GIVEN** session `<S>` is `ended` with `summary = null`, `summary_final = false`
-- **WHEN** a client POSTs `{ summary: 'transcript', final: false }` to `/end` (e.g. a delayed bash hook race after Hermes already ended)
-- **THEN** the server SHALL write the summary (`_final = false`), leave `ended_at`/`status` unchanged
-- **AND** the response SHALL be `200 OK` with the now-non-null summary
-
-#### Scenario: Session not found / wrong token / deleted
-
-- **WHEN** the resolution rules apply
-- **THEN** the server SHALL respond with the same error codes (`session_not_found`, `session_deleted`)
+- **WHEN** a client POSTs `{ summary: 'transcript', title: 'fallback title', final: true }` to `/end` on an active row with both `_final` flags at `false`
+- **THEN** the server SHALL ignore the `final` field
+- **AND** the row SHALL have `summary_final = false`, `title_final = false`, `status = 'ended'`, `ended_at = now`
 
 ### Requirement: Sessions registered via HTTP MUST integrate with the SessionRouter so subsequent MCP tools attach memories to them
 

--- a/openspec/specs/mcp-api/spec.md
+++ b/openspec/specs/mcp-api/spec.md
@@ -249,21 +249,43 @@ The `/mcp` and `/mcp/<slug>` endpoints SHALL register `memory.context`, `memory.
 
 - **WHEN** an MCP client calls `memory.context` with `{ sessions?: number, prompts?: number, memories?: number, includeArchived?: boolean }`
 - **THEN** the server SHALL return `{ recentSessions, recentPrompts, recentMemories }`, with each list scoped to the request context (global vs path-scoped project)
-- **AND** `recentSessions` SHALL contain only sessions that satisfy the `sessionHasContent` predicate (see `sessions` capability), ordered by `started_at DESC`, with empty sessions filtered out BEFORE truncation to `sessions ?? 5`
+- **AND** `recentSessions` SHALL contain only sessions that satisfy the `sessionIsContextWorthy` predicate (see `sessions` capability), ordered by `started_at DESC`, with non-curated sessions filtered out BEFORE truncation to `sessions ?? 5`
+- **AND** every row in `recentSessions` SHALL have either `summary_final = 1` or `title_final = 1` — set exclusively by the MCP tool `memory.session_summary`
 - **AND** `recentPrompts` SHALL be ordered by `created_at DESC` and filtered to `deleted_at IS NULL`
 - **AND** `recentMemories` SHALL be ordered by `last_seen_at DESC` with `includeArchived = false` (default) filtering out `status = 'archived'` rows
 
-#### Scenario: `memory.context.recentSessions` backfills past empty sessions
+#### Scenario: `memory.context.recentSessions` backfills past non-curated sessions
 
-- **GIVEN** the active scope contains, in `started_at` order from newest to oldest, three empty sessions and one useful session
+- **GIVEN** the active scope contains, in `started_at` order from newest to oldest, three non-curated sessions and one curated session
 - **WHEN** an MCP client calls `memory.context({sessions: 1})`
-- **THEN** the response's `recentSessions` array SHALL have length 1 and SHALL contain only the useful session — the three newer empty sessions SHALL NOT consume the slot
+- **THEN** the response's `recentSessions` array SHALL have length 1 and SHALL contain only the curated session — the three newer non-curated sessions SHALL NOT consume the slot
 
 #### Scenario: `memory.context.recentSessions` excludes soft-deleted sessions
 
-- **GIVEN** a session that has content AND is soft-deleted (`deleted_at IS NOT NULL`)
+- **GIVEN** a curated session that is soft-deleted (`deleted_at IS NOT NULL`)
 - **WHEN** an MCP client calls `memory.context`
-- **THEN** the row SHALL NOT appear in `recentSessions` — the soft-delete filter and the content filter both apply
+- **THEN** the row SHALL NOT appear in `recentSessions` — the soft-delete filter and the context-worthy filter both apply
+
+#### Scenario: `memory.context.recentSessions` excludes sessions whose only summary is a transcript fallback
+
+- **GIVEN** a session `S` whose only content is a per-turn transcript write with `summary_final = 0`, no curated summary, no `title_final = 1`, and zero anchored rows in `memory`, `prompts`, `confirmations`
+- **WHEN** an MCP client calls `memory.context`
+- **THEN** `S` SHALL NOT appear in `recentSessions`
+- **AND** `S` SHALL remain visible to operators on `/dashboard/sessions` and eligible for purge via `/dashboard/maintenance` (subject to the existing 1h `ended_at` grace)
+
+#### Scenario: `memory.context.recentSessions` excludes ACTIVE non-curated sessions with anchored memory
+
+- **GIVEN** an active session `S` with `summary_final = 0` AND at least one anchored row in `memory` with `session_id = S.id`
+- **WHEN** an MCP client calls `memory.context` BEFORE `S` transitions to a terminal status
+- **THEN** `S` SHALL NOT appear in `recentSessions` — the anchored memory keeps `S` safe from purge but does not promote an active row to context-worthy by itself
+- **AND** the anchored memory SHALL appear in `recentMemories[]` (with its `session_id` available for `memory.timeline` follow-up)
+
+#### Scenario: `memory.context.recentSessions` includes auto-curated terminal sessions
+
+- **GIVEN** a session `S` that ended with anchored content but no agent-issued curation (server auto-curate fired at `memory.session_end`, producing `summary = '[auto] N memorias — última: …'` and `summary_final = 1`)
+- **WHEN** an MCP client calls `memory.context`
+- **THEN** `S` SHALL appear in `recentSessions` with the `[auto]`-prefixed summary
+- **AND** the agent MAY override the auto-curated summary at any later point via `memory.session_summary` (see `sessions::writeSummary MUST allow final:true on terminal sessions`)
 
 #### Scenario: `memory.context` arguments exceed clamps
 

--- a/openspec/specs/sessions/spec.md
+++ b/openspec/specs/sessions/spec.md
@@ -498,11 +498,13 @@ The method SHALL NOT call into `abandonStale` and `abandonStale` SHALL NOT call 
 4. there exists at least one row in `prompts` with `session_id = s.id` AND `deleted_at IS NULL`, OR
 5. there exists at least one row in `confirmations` with `session_id = s.id`.
 
-Soft-deleted prompts (`deleted_at IS NOT NULL`) DO NOT make a session content-bearing; the operator has already marked them as obsolete, and a session that has nothing else SHALL be eligible for purge and SHALL NOT surface in `memory.context.recentSessions`.
+This predicate governs **purge eligibility only**. It answers "would physically deleting this row dangle foreign-key references?" — and so any anchored content (memory / prompts / confirmations) keeps a session out of the purge set, regardless of whether the agent curated it. Surfacing to `memory.context` is governed by the separate, stricter predicate `sessionIsContextWorthy`.
 
-The predicate SHALL be implemented as a single private SQL-fragment helper inside `apps/server/src/services/agent-sessions.ts`. It SHALL be the ONLY place in the codebase where this five-clause predicate is expressed. The `countPurgeableEmpty` and `purgeEmpty` methods SHALL consume the predicate in negated form (`NOT sessionHasContent(s)`) as part of their "purgeable" check. `recentForContext` SHALL consume the predicate in positive form as part of its "is useful to surface" check.
+Soft-deleted prompts (`deleted_at IS NOT NULL`) DO NOT make a session content-bearing; the operator has already marked them as obsolete.
 
-When a future content-bearing table is added with a `session_id` foreign key (the canonical example being a hypothetical `tool_calls` table), the predicate SHALL be the single point of update — the new EXISTS clause is added once, and every call site picks it up automatically.
+The predicate SHALL be implemented as a single private SQL-fragment helper inside `apps/server/src/services/agent-sessions.ts`. It SHALL be the ONLY place in the codebase where this five-clause predicate is expressed. The `countPurgeableEmpty` and `purgeEmpty` methods SHALL consume the predicate in negated form (`NOT sessionHasContent(s)`) as part of their "purgeable" check. `recentForContext` SHALL NOT consume this predicate — it consumes `sessionIsContextWorthy` instead.
+
+When a future content-bearing table is added with a `session_id` foreign key (the canonical example being a hypothetical `tool_calls` table), the predicate SHALL be the single point of update for the purge protection — the new EXISTS clause is added once, and `countPurgeableEmpty` / `purgeEmpty` pick the change up automatically.
 
 #### Scenario: A session with a written summary satisfies the predicate
 
@@ -516,39 +518,201 @@ When a future content-bearing table is added with a `session_id` foreign key (th
 - **WHEN** any call site evaluates `sessionHasContent(S)`
 - **THEN** the predicate SHALL return FALSE
 
-#### Scenario: Drift between purge predicate and context predicate is impossible
+#### Scenario: A session with anchored memory is content-bearing even without curated summary
+
+- **GIVEN** session `S` with `summary IS NULL`, `title_final = 0`, and at least one anchored row in `memory` with `session_id = S.id`
+- **WHEN** `sessionHasContent(S)` is evaluated
+- **THEN** the predicate SHALL return TRUE — the session is purge-protected to preserve referential integrity of the anchored memory
+
+#### Scenario: Strict-subset relationship with `sessionIsContextWorthy`
 
 - **GIVEN** the codebase as a whole
-- **WHEN** any reviewer reads `countPurgeableEmpty`, `purgeEmpty`, and `recentForContext`
-- **THEN** each SHALL reference `sessionHasContent` rather than inlining its five clauses
-- **AND** a code search for `EXISTS (SELECT 1 FROM memory WHERE session_id` outside the helper definition SHALL return zero matches within `apps/server/src/services/agent-sessions.ts`
+- **WHEN** a reviewer reads both predicate helpers
+- **THEN** every clause of `sessionIsContextWorthy(s)` SHALL imply at least one clause of `sessionHasContent(s)` (a curated summary implies non-null summary; `title_final = 1` is a clause of `sessionHasContent` verbatim)
+- **AND** a code search for the EXISTS-bearing 5-clause predicate SHALL return zero matches outside the `sessionHasContent` helper definition within `apps/server/src/services/agent-sessions.ts`
 
 ### Requirement: `recentForContext` MUST exclude empty sessions by default
 
 `AgentSessionsService.recentForContext({projectId, limit})` SHALL return at most `limit` rows, ordered by `started_at DESC`, drawn from the set of sessions satisfying ALL of:
 
-1. `deleted_at IS NULL` (soft-delete already specified above);
+1. `deleted_at IS NULL` (soft-delete);
 2. scope match (`projectId IS NULL` for global, or `project_id = ?` for path-scoped);
-3. `sessionHasContent(s)` is TRUE.
+3. `sessionIsContextWorthy(s)` is TRUE.
 
-Filtering SHALL precede truncation: a request with `limit: 5` SHALL return the five most-recent _useful_ sessions, even if dozens of newer empty sessions exist between them. Empty sessions SHALL NEVER consume a slot in the response.
+Filtering SHALL precede truncation: a request with `limit: 5` SHALL return the five most-recent _context-worthy_ sessions, even if dozens of newer non-curated sessions exist between them. Non-curated sessions SHALL NEVER consume a slot in the response.
 
-The method SHALL NOT accept any flag, option, or argument that bypasses the `sessionHasContent` filter. Operators who need to inspect empty sessions SHALL use `/dashboard/sessions`, which surfaces all rows regardless of content.
+The method SHALL NOT accept any flag, option, or argument that bypasses the `sessionIsContextWorthy` filter. Operators who need to inspect non-curated sessions SHALL use `/dashboard/sessions`, which surfaces all rows regardless of curation.
 
-#### Scenario: An empty active session is excluded
+Note: after the auto-curate path lands (see ADDED requirement above), most real-work sessions naturally become context-worthy at their terminal transition, so the population of `sessionIsContextWorthy(s) = TRUE` is the union of agent-curated rows AND server-auto-curated rows. The `[auto]` prefix on the latter is informational only; the predicate does not inspect the summary text.
 
-- **GIVEN** a scope containing one active session `A` with no summary and zero anchored rows, plus one ended session `E` with a summary
+#### Scenario: A non-curated session is excluded BEFORE terminal transition
+
+- **GIVEN** an active session `M` with `summary_final = 0` AND one anchored memory row referencing `M.id`, plus an ended session `C` with `summary_final = 1`
+- **WHEN** `recentForContext({projectId, limit: 5})` is called BEFORE `M` transitions to terminal
+- **THEN** the result SHALL contain `C` and SHALL NOT contain `M`
+- **AND** `M`'s memory still appears in the caller's `recentMemories[]` payload via `MemoryService.recentForContext`
+
+#### Scenario: A non-curated session with anchored content surfaces AFTER terminal transition (auto-curate)
+
+- **GIVEN** a session `M` that has 5 anchored memory rows but was never explicitly curated by the agent
+- **WHEN** the agent calls `memory.session_end` on `M`, which fires the auto-curate path, AND THEN `recentForContext({projectId, limit: 5})` is called
+- **THEN** the result SHALL contain `M` with `summary` matching the deterministic `[auto] N memorias…` template
+
+#### Scenario: A non-curated session with no anchored content is excluded permanently
+
+- **GIVEN** an ended session `T` with `summary_final = 0`, zero anchored rows, optionally with a non-final transcript dump in `summary`
 - **WHEN** `recentForContext({projectId, limit: 5})` is called
-- **THEN** the result SHALL contain `E` and SHALL NOT contain `A`
+- **THEN** `T` SHALL NOT appear in the result — auto-curate did not fire (no anchored content), the row stays non-context-worthy permanently
 
 #### Scenario: Filter-then-truncate produces backfill semantics
 
-- **GIVEN** a scope containing, in `started_at` order from newest to oldest: three empty sessions `A`, `B`, `C` and one useful session `U`
+- **GIVEN** a scope containing, in `started_at` order from newest to oldest: three non-curated sessions `A`, `B`, `C` (none with anchored content) and one curated session `U`
 - **WHEN** `recentForContext({projectId, limit: 1})` is called
-- **THEN** the result SHALL be `[U]` — the most-recent USEFUL session, not the most-recent session overall
+- **THEN** the result SHALL be `[U]` — the most-recent CURATED session, not the most-recent session overall
 
-#### Scenario: Soft-deleted session with content is still excluded
+#### Scenario: Soft-deleted session with curated summary is still excluded
 
-- **GIVEN** a session that has a summary AND is soft-deleted
+- **GIVEN** a session that has `summary_final = 1` AND is soft-deleted
 - **WHEN** `recentForContext` is called
 - **THEN** the row SHALL NOT appear in the result — both filters apply, neither overrides the other
+
+### Requirement: `sessionIsContextWorthy` is the surfacing predicate for `memory.context`
+
+`AgentSessionsService` SHALL define an internal SQL predicate, `sessionIsContextWorthy(s)`, returning TRUE for a `sessions` row `s` iff at least ONE of the following holds:
+
+1. `s.summary IS NOT NULL` AND `s.summary_final = 1`, OR
+2. `s.title_final = 1`.
+
+The predicate SHALL be implemented as a single private SQL-fragment helper inside `apps/server/src/services/agent-sessions.ts`. It SHALL have exactly ONE consumer: `recentForContext`. It expresses the question "is this session worth surfacing to the LLM as a `recentSessions` entry?"
+
+`sessionIsContextWorthy(s)` is a strict subset of `sessionHasContent(s)`: every context-worthy session is also content-bearing, but content-bearing sessions are not necessarily context-worthy. The distinction is intentional — purge protection and surfacing eligibility ask different questions:
+
+- Purge protection asks "would deleting this row dangle foreign keys?" (`sessionHasContent`).
+- Surfacing asks "does this row carry signal the LLM can read directly?" (`sessionIsContextWorthy`).
+
+The two predicates SHALL coexist in the same source file and SHALL be the ONLY places where their respective SQL clauses are expressed.
+
+#### Scenario: A session with a curated summary satisfies `sessionIsContextWorthy`
+
+- **GIVEN** session `S` with `summary = 'Goal: …'` and `summary_final = 1`
+- **WHEN** `sessionIsContextWorthy(S)` is evaluated
+- **THEN** the predicate SHALL return TRUE
+
+#### Scenario: A session with `title_final = 1` satisfies `sessionIsContextWorthy`
+
+- **GIVEN** session `S` with `summary IS NULL` and `title_final = 1`
+- **WHEN** `sessionIsContextWorthy(S)` is evaluated
+- **THEN** the predicate SHALL return TRUE
+
+#### Scenario: A session with anchored memory but no curated summary is content-bearing but not context-worthy by itself
+
+- **GIVEN** session `S` with `summary IS NULL`, `title_final = 0`, AND at least one row in `memory` referencing `S.id`, evaluated BEFORE any terminal transition fires the auto-curate (e.g. mid-flight or status='active')
+- **WHEN** `sessionHasContent(S)` and `sessionIsContextWorthy(S)` are both evaluated
+- **THEN** `sessionHasContent(S)` SHALL return TRUE (purge-protected) AND `sessionIsContextWorthy(S)` SHALL return FALSE
+- **AND** after the terminal transition fires, the auto-curate path SHALL elevate `S` to context-worthy by writing a derived summary (see `Auto-curate at terminal transition` requirement below)
+
+#### Scenario: A session with only a transcript-fallback summary is neither content-bearing nor context-worthy
+
+- **GIVEN** session `S` with `summary = '<raw transcript dump>'`, `summary_final = 0`, `title_final = 0`, and zero anchored rows in `memory`, `prompts`, `confirmations`
+- **WHEN** `sessionHasContent(S)` and `sessionIsContextWorthy(S)` are both evaluated
+- **THEN** both SHALL return FALSE — the row is purgeable AND it does not surface to the LLM (the auto-curate path also does NOT fire, since there is no anchored content to derive from)
+
+### Requirement: Server-side auto-curate at terminal transition
+
+When `AgentSessionsService.end(sessionId)` or `AgentSessionsService.abandonStale()` transitions a session from `active` to a terminal status (`ended` or `abandoned`), the service SHALL, in the same transaction:
+
+1. Read the current `summary_final` flag.
+2. If `summary_final = 1`, SKIP — the agent already curated, the curated text wins, no overwrite.
+3. If `summary_final = 0` AND the session has at least one anchored row in `memory`, `prompts`, OR `confirmations`, COMPOSE a derived summary using the deterministic template defined below and WRITE it to the row with `summary_final = 1`.
+4. If `summary_final = 0` AND the session has NO anchored content, SKIP — there is nothing to derive from. The session remains non-context-worthy and operator-purgeable.
+
+The derivation template is the pure function `composeDerivedSummary(counts, lastMemoryContent)`:
+
+```
+parts := []
+if counts.memories > 0:      parts.push(`${counts.memories} memorias`)
+if counts.prompts > 0:       parts.push(`${counts.prompts} prompts`)
+if counts.confirmations > 0: parts.push(`${counts.confirmations} confirmaciones`)
+
+head := join(parts, ', ')
+tail := lastMemoryContent ? ` — última: '${snippet(lastMemoryContent, 80)}'` : ''
+
+return `[auto] ${head}${tail}`
+```
+
+The function SHALL be deterministic: same `counts` and `lastMemoryContent` produce the same output, byte-for-byte. The function SHALL NOT inspect the previous `summary` value, SHALL NOT call any LLM, SHALL NOT apply heuristics over the content. The `[auto]` prefix is mandatory and identifies the row as server-derived to both the agent and the operator.
+
+The auto-curate write SHALL OVERWRITE any prior `final:false` `summary` value (a per-turn transcript dump written by a plugin Stop hook). The derived summary supersedes the transcript dump in the `summary` column; operators retain forensic visibility of anchored content via `/dashboard/sessions/:id` (the memories list, prompts list, and timing).
+
+The auto-curate path SHALL be the SECOND writer that can lift `summary_final` to 1 (the first being the MCP tool `memory.session_summary`). Subsequent agent-issued `memory.session_summary` calls SHALL be able to overwrite an auto-curated row (see the modified `writeSummary` precedence below): agent intent always wins over server-derived content.
+
+`countPurgeableEmpty` and `purgeEmpty` SHALL keep using `sessionHasContent` (5 clauses); auto-curated sessions naturally fail the `NOT sessionHasContent` predicate (their EXISTS-anchored content was the reason they were curated), so they are NOT purge-eligible.
+
+#### Scenario: Agent curated before ending — auto-curate is a no-op
+
+- **GIVEN** active session `S` with `summary_final = 1` (agent called `memory.session_summary` earlier)
+- **WHEN** the agent calls `memory.session_end` on `S`
+- **THEN** the service SHALL transition `S` to `ended` and SHALL NOT overwrite the curated summary
+- **AND** `S.summary_final` SHALL remain 1, `S.summary` SHALL remain the agent's curated text
+
+#### Scenario: Agent did not curate, session has anchored memory — auto-curate fires
+
+- **GIVEN** active session `S` with `summary_final = 0`, `summary IS NULL` (or any non-final summary), and 5 anchored rows in `memory`, latest content `"Fixed null check in foo.ts when handler receives undefined"`
+- **WHEN** the agent calls `memory.session_end` on `S`
+- **THEN** the service SHALL atomically: set `status = 'ended'`, write `summary = "[auto] 5 memorias — última: 'Fixed null check in foo.ts when handler receives undefined'"`, set `summary_final = 1`, set `ended_at = now`
+- **AND** `S` SHALL now satisfy `sessionIsContextWorthy` and surface in `memory.context.recentSessions`
+
+#### Scenario: Agent did not curate, session has only transcript dump — auto-curate skips
+
+- **GIVEN** active session `S` with `summary = '<raw transcript dump>'`, `summary_final = 0`, and zero anchored rows
+- **WHEN** the agent calls `memory.session_end` on `S`
+- **THEN** the service SHALL transition `S` to `ended` and SHALL NOT touch `summary` or `summary_final`
+- **AND** `S` SHALL remain non-context-worthy (excluded from `memory.context.recentSessions`) and SHALL become purge-eligible after the 1h `ended_at` grace
+
+#### Scenario: abandonStale transitions also trigger auto-curate
+
+- **GIVEN** an active session `S` with `summary_final = 0`, 8 anchored memory rows, and `started_at` older than the abandonStale cutoff
+- **WHEN** `abandonStale({olderThanMs})` runs (typically at server startup)
+- **THEN** the service SHALL per-row: apply the auto-curate write (composing the derived summary) AND transition `status` to `abandoned` AND set `ended_at = now` — in a single transaction per session
+- **AND** the returned `{ abandoned: N }` count SHALL match the number of sessions transitioned
+
+#### Scenario: Auto-curate output is deterministic and structural
+
+- **GIVEN** a session `S` with anchored counts `{ memories: 3, prompts: 2, confirmations: 0 }` and latest memory content `"Refactored the auth middleware to use jose"`
+- **WHEN** `composeDerivedSummary` is called with those inputs
+- **THEN** the output SHALL be exactly `"[auto] 3 memorias, 2 prompts — última: 'Refactored the auth middleware to use jose'"` — same input always produces same output, no LLM, no heuristic, no content inspection of the previous summary
+
+### Requirement: `writeSummary` MUST allow `final:true` writes on terminal sessions
+
+`AgentSessionsService.writeSummary(sessionId, input)` SHALL accept the write under either of two conditions, relaxing the previous "active-only" gate so that agents can override server auto-curated rows. The service is the shared entry point for both the MCP tool `memory.session_summary` (always `final:true`) and the HTTP fallback path `POST /api/<slug>/sessions/:id/summary` (always `final:false` after hardening).
+
+The two acceptance conditions are:
+
+1. The session's `status = 'active'` (the historical pre-existing rule), OR
+2. The session's `status ∈ {'ended', 'abandoned'}` AND the incoming `input.final === true` — i.e., the agent is explicitly issuing a curated write on a terminal session.
+
+Condition (2) exists so that an agent can OVERRIDE a server auto-curated row with its own curated summary at any point, including after the session has already transitioned. The HTTP fallback path cannot exploit this opening because the HTTP handlers hard-code `final: false`, so the HTTP-derived writes still hit condition (1)'s `status = 'active'` gate — only the MCP tool `memory.session_summary` can satisfy condition (2).
+
+When the write is accepted under condition (2), the precedence rule applies as usual: `summary` (and optionally `title`) are overwritten, `summary_final` (and `title_final`) are set to 1, `status`/`ended_at` are NOT modified.
+
+When the incoming write is `final:false` on a terminal session (HTTP path or otherwise), the call SHALL be rejected with `session_already_ended`.
+
+#### Scenario: Agent overrides an auto-curated ended session via `memory.session_summary`
+
+- **GIVEN** session `S` is `ended` with `summary = '[auto] 5 memorias — última: …'` and `summary_final = 1` (server auto-curated)
+- **WHEN** the agent calls `memory.session_summary({summary: 'Goal: X. Files: Y.', title: 'Refactor'})` against `S`
+- **THEN** the server SHALL accept the write (condition 2)
+- **AND** `S.summary` SHALL become `'Goal: X. Files: Y.'`, `S.title` SHALL become `'Refactor'`, `S.summary_final` SHALL remain 1, `S.title_final` SHALL become 1
+- **AND** `S.status` SHALL remain `'ended'` (unchanged)
+
+#### Scenario: HTTP fallback cannot exploit the relaxation
+
+- **GIVEN** an ended session `S`
+- **WHEN** an HTTP client POSTs `{summary: 'transcript', final: true}` to `/api/<slug>/sessions/:id/summary` (the body's `final` field is dropped by the zod schema and the handler hard-codes `false`)
+- **THEN** the service-level call is `writeSummary(S, {final: false})`, which fails condition (1) (`status != 'active'`) and condition (2) (`final !== true`), and SHALL be rejected with `session_already_ended`
+
+#### Scenario: `final:true` write on an active session is unchanged
+
+- **GIVEN** an active session `S` with `summary_final = 0`
+- **WHEN** the agent calls `memory.session_summary({summary: 'Goal: X'})` (the MCP handler injects `final: true`)
+- **THEN** the write is accepted under condition (1) and `S.summary_final` becomes 1, exactly as before this change


### PR DESCRIPTION
## Summary

- **Split the surfacing predicate from the purge predicate.** `recentForContext` now uses `sessionIsContextWorthySql` (`summary_final = 1 OR title_final = 1`); `countPurgeableEmpty` / `purgeEmpty` keep the 5-clause `sessionHasContentSql`. Strict subset relationship: every context-worthy session is content-bearing, not the converse.
- **Harden the HTTP path.** Drop `final` from the body schemas; handlers hard-code `final: false`. The only paths that can lift `summary_final` to 1 are now (a) the MCP tool `memory.session_summary` (server-hardcoded `final: true`) or (b) the new auto-curate path.
- **Auto-curate at terminal transition.** `end()` and `abandonStale()` compose a deterministic derived summary (`[auto] N memorias[, P prompts[, C confirmaciones]][ — última: '<snippet>']`) when a session ends with `summary_final = 0` AND any anchored content (memory / prompts / confirmations). Atomic with the status flip. `writeSummary` relaxed to accept `final:true` on terminal sessions so an agent can override an auto-curated row via `memory.session_summary`.

Behavioral matrix (LLM = `memory.context.recentSessions`, Operator = `/dashboard/sessions`):

| Session shape | LLM | Operator | Purgable |
|---|---|---|---|
| `/clear`, "Hola!" (no anchored) | ✗ | ✓ | ✓ (>1h) |
| Anchored memory, no curate | ✓ `[auto] N memorias…` | ✓ | ✗ |
| Agent-curated | ✓ agent text | ✓ | ✗ |
| Override post-end | ✓ override | ✓ | ✗ |
| Empty (start + end) | ✗ | ✓ | ✓ |

OpenSpec change `tighten-context-content-predicate-to-final-summaries` archived in the same PR. Spec deltas applied to `sessions`, `mcp-api`, `http-api`.

## Test plan

- [x] Service-layer unit tests (`agent-sessions.test.ts`): +12 new (`composeDerivedSummary` × 5, auto-curate scenarios × 7), `asymmetry` test updated to reflect auto-curate.
- [x] HTTP-layer tests (`api-router.test.ts`): +2 new (HTTP body `final:true` silently ignored on `/summary` and `/end`), 3 existing tests migrated to set up locked state via service layer (only legitimate path post-hardening).
- [x] MCP integration test (`mcp-integration.test.ts`): +1 full-lifecycle (save memory → end → `memory.context` surfaces with `[auto]` prefix); backfill test now uses `memory.session_summary` explicitly.
- [x] Suite green: 540/540 server tests + 28/28 hermes plugin tests.
- [x] `openspec validate --strict` green (16/16 specs).
- [x] `pnpm run typecheck` clean.
- [x] `pnpm run lint` clean.
- [x] End-to-end smoke against `pnpm run dev:docker:up`: 4 scenarios driven via `/mcp/demo` MCP transport — Tipo A excluded, Tipo B surfaces with `[auto]`, Tipo C surfaces with agent text, override scenario fires correctly, HTTP body `final:true` ignored, dashboard `/sessions` shows all 4 to the operator.