### PR TITLE
feat(plugin): wire pre/post-compact hooks + opencode recall paridad

### DIFF
--- a/apps/plugin/.hermes-plugin/__init__.py
+++ b/apps/plugin/.hermes-plugin/__init__.py
@@ -306,13 +306,16 @@ class RembricMemoryProvider(MemoryProvider):
 
     def system_prompt_block(self) -> str:
         # Permanent nudge so the model knows to write a structured summary
-        # before declaring work done. Parity with the MCP server's
+        # before declaring work done, AND to recover detail after /compact
+        # via memory.context. Parity with the MCP server's
         # initialize.instructions block served to Claude Code / Codex CLI.
+        # Hard cap: ≤300 chars (asserted by tests).
         return (
             "Rembric: before declaring work done, call "
             "memory.session_summary({title, summary}). Title ≤100 chars "
             "describing what was actually worked on. Summary covers Goal · "
-            "Discoveries · Accomplished · Next Steps · Files."
+            "Discoveries · Accomplished · Next Steps · Files. "
+            "After /compact: call memory.context if detail is missing."
         )
 
     def prefetch(self, query: str, **kwargs: Any) -> str:

--- a/apps/plugin/.hermes-plugin/tests/test_system_prompt_block.py
+++ b/apps/plugin/.hermes-plugin/tests/test_system_prompt_block.py
@@ -1,0 +1,42 @@
+"""``system_prompt_block`` carries the documented nudge content.
+
+Asserts both the session-close protocol (memory.session_summary + title +
+Goal/Discoveries/Accomplished/Next Steps/Files structure) AND the
+post-compact recovery clause (memory.context). Hard cap: ≤300 chars.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from _loader import fresh_plugin
+
+
+class SystemPromptBlockTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = fresh_plugin()
+
+    def test_includes_session_summary_protocol(self) -> None:
+        provider = self.mod.RembricMemoryProvider()
+        block = provider.system_prompt_block()
+        self.assertIn("memory.session_summary", block)
+        self.assertIn("title", block)
+        self.assertIn("Goal", block)
+        self.assertIn("Discoveries", block)
+        self.assertIn("Accomplished", block)
+        self.assertIn("Next Steps", block)
+        self.assertIn("Files", block)
+
+    def test_includes_memory_context_post_compact_clause(self) -> None:
+        provider = self.mod.RembricMemoryProvider()
+        block = provider.system_prompt_block()
+        self.assertIn("memory.context", block)
+
+    def test_block_is_within_300_char_cap(self) -> None:
+        provider = self.mod.RembricMemoryProvider()
+        block = provider.system_prompt_block()
+        self.assertLessEqual(len(block), 300, msg=f"block is {len(block)} chars; cap is 300")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/plugin/.opencode-plugin/README.md
+++ b/apps/plugin/.opencode-plugin/README.md
@@ -4,7 +4,7 @@ Memory + session lifecycle for [opencode](https://opencode.ai), backed by a self
 
 This plugin shares the same HTTP API and MCP bridge as the Claude Code, Codex CLI, and Hermes Agent plugins. Per-project path-scoping uses the same `.rembric` convention.
 
-**v1 scope**: the plugin registers two handlers — `session.created` / `session.deleted` (for session row creation + sub-agent filtering) and `experimental.session.compacting` (for the post-compact `memory.session_summary` reminder). Passive prompt and observation capture (`chat.message`, `tool.execute.after`) are not in v1 because the corresponding HTTP API endpoints (`/prompts/passive`, `/observations/passive`) do not exist yet; they will land in a follow-up change.
+**Scope**: the plugin handles session lifecycle and compaction signals via the `event` dispatcher (`session.created`, `session.deleted`, `session.compacted`, `server.instance.disposed`), accumulates transcripts via `chat.message` and `message.updated`, flushes summaries on `session.idle` (per-turn debounced) and `session.compacted` (compaction milestone), and injects post-compaction guidance via `experimental.session.compacting`. The `chat.message` handler also appends a recall nudge to `output.parts` when the user prompt matches the cross-client recall regex (`remember|recall|acordate|qué hicimos|what did we do`), for paridad with the Claude Code / Codex CLI `UserPromptSubmit` hook.
 
 ## Install
 

--- a/apps/plugin/.opencode-plugin/plugin.test.ts
+++ b/apps/plugin/.opencode-plugin/plugin.test.ts
@@ -2,13 +2,14 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Imports from the shared dotenv lib (single source of truth, used by the
 // MCP bridge AND the opencode plugin). The distributed plugin.ts exports
 // ONLY `RembricPlugin`; opencode invokes every named export as a Plugin
 // function, so the helpers MUST stay outside plugin.ts's export surface.
 import { parseDotenv, readRembricSlug } from '../bin/rembric-dotenv.mjs';
+import { RembricPlugin } from './plugin.js';
 
 describe('parseDotenv', () => {
   it('returns {} for empty input', () => {
@@ -130,5 +131,143 @@ describe('readRembricSlug byte-for-byte equivalence with bridge parser', () => {
     expect(parsed.OTHER_KEY).toBe('ignored');
     expect(parsed.TRAILING_WHITESPACE).toBe('xyz');
     expect(readRembricSlug(dir)).toBe('my-repo');
+  });
+});
+
+describe('RembricPlugin handlers', () => {
+  let dir: string;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'rembric-plugin-handlers-'));
+    writeFileSync(join(dir, '.rembric'), 'PROJECT_SLUG=demo\n');
+    process.env.REMBRIC_SERVER_URL = 'http://localhost:9999';
+    process.env.REMBRIC_API_TOKEN = 'test-token';
+    fetchMock = vi.fn(async () => new Response('', { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    delete process.env.REMBRIC_SERVER_URL;
+    delete process.env.REMBRIC_API_TOKEN;
+    vi.restoreAllMocks();
+  });
+
+  it('experimental.session.compacting nudge includes memory.context guidance', async () => {
+    const handlers = await RembricPlugin({ directory: dir } as never);
+    const out: { context: string[] } = { context: [] };
+    await handlers['experimental.session.compacting']!({ sessionID: 's1' } as never, out as never);
+    expect(out.context).toHaveLength(1);
+    expect(out.context[0]).toContain('memory.session_summary');
+    expect(out.context[0]).toContain('memory.context');
+    expect(out.context[0]).toContain("'demo'");
+  });
+
+  it('chat.message appends recall nudge when user text matches recall regex', async () => {
+    const handlers = await RembricPlugin({ directory: dir } as never);
+    const cases = [
+      'remember what we did yesterday',
+      'please recall the auth fix',
+      'acordate cuando hicimos la migración?',
+      'What did we do with the JWT?',
+      '¿qué hicimos con el login?',
+    ];
+    for (const text of cases) {
+      const output = {
+        parts: [{ type: 'text', text }],
+        message: {},
+      };
+      await handlers['chat.message']!({ sessionID: 's-recall' } as never, output as never);
+      const lastPart = output.parts[output.parts.length - 1];
+      expect(lastPart.text).toContain('rembric: User intent: recall');
+      expect(lastPart.text).toContain('memory.search');
+    }
+  });
+
+  it('chat.message does NOT append recall nudge when user text does not match', async () => {
+    const handlers = await RembricPlugin({ directory: dir } as never);
+    const cases = [
+      'please write a unit test for src/auth.ts',
+      'fix the failing build',
+      'add a new endpoint at /api/foo',
+    ];
+    for (const text of cases) {
+      const output = {
+        parts: [{ type: 'text', text }],
+        message: {},
+      };
+      await handlers['chat.message']!({ sessionID: 's-no-recall' } as never, output as never);
+      // Only the original part remains; nudge was not appended.
+      expect(output.parts).toHaveLength(1);
+      expect(output.parts[0].text).toBe(text);
+    }
+  });
+
+  it('event(session.compacted) flushes the accumulator for a known session', async () => {
+    const handlers = await RembricPlugin({ directory: dir } as never);
+
+    // Register the session and prime the accumulator.
+    await handlers.event!({
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'sc1', parentID: '', title: 'work' } },
+      },
+    } as never);
+    await handlers['chat.message']!(
+      { sessionID: 'sc1' } as never,
+      { parts: [{ type: 'text', text: 'turn one' }], message: {} } as never,
+    );
+
+    const before = fetchMock.mock.calls.length;
+
+    await handlers.event!({
+      event: {
+        type: 'session.compacted',
+        properties: { sessionID: 'sc1' },
+      },
+    } as never);
+
+    const summaryCalls = fetchMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && url.includes('/sessions/sc1/summary'),
+    );
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(before);
+    expect(summaryCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('event(session.compacted) is a no-op for unknown sessions', async () => {
+    const handlers = await RembricPlugin({ directory: dir } as never);
+    const before = fetchMock.mock.calls.length;
+
+    await handlers.event!({
+      event: {
+        type: 'session.compacted',
+        properties: { sessionID: 'never-registered' },
+      },
+    } as never);
+
+    expect(fetchMock.mock.calls.length).toBe(before);
+  });
+
+  it('event(session.compacted) is a no-op for sub-agent sessions', async () => {
+    const handlers = await RembricPlugin({ directory: dir } as never);
+
+    // Register as sub-agent (has parentID).
+    await handlers.event!({
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'sub-1', parentID: 'parent', title: 'sub work' } },
+      },
+    } as never);
+    const before = fetchMock.mock.calls.length;
+
+    await handlers.event!({
+      event: {
+        type: 'session.compacted',
+        properties: { sessionID: 'sub-1' },
+      },
+    } as never);
+
+    expect(fetchMock.mock.calls.length).toBe(before);
   });
 });

--- a/apps/plugin/.opencode-plugin/plugin.ts
+++ b/apps/plugin/.opencode-plugin/plugin.ts
@@ -42,6 +42,9 @@ const MAX_TRANSCRIPT_CHARS = 19_500;
 const MAX_ENTRY_CHARS = 2000;
 const MAX_ENTRIES_PER_SESSION = 200;
 const MAX_TITLE_CHARS = 100;
+const RECALL_REGEX = /remember|recall|acordate|qué hicimos|what did we do/i;
+const RECALL_NUDGE =
+  'rembric: User intent: recall. Call memory.search with the user keywords before responding.';
 
 type EventInput = {
   event: {
@@ -294,6 +297,19 @@ export const RembricPlugin: Plugin = async (ctx) => {
       if (event.type === 'server.instance.disposed') {
         disposeFlushFireAndForget();
       }
+
+      if (event.type === 'session.compacted') {
+        const props = (event.properties ?? {}) as {
+          sessionID?: string;
+          info?: { id?: string };
+        };
+        const sessionId = props.sessionID ?? props.info?.id ?? '';
+        if (!sessionId) return;
+        if (subAgentSessions.has(sessionId)) return;
+        if (!knownSessions.has(sessionId)) return;
+        diag(`session.compacted sessionId=${sessionId}`);
+        await flushSessionSummary(sessionId);
+      }
     },
 
     'chat.message': async (input, output) => {
@@ -315,6 +331,10 @@ export const RembricPlugin: Plugin = async (ctx) => {
 
       if (!content) return;
       appendUserMessage(input.sessionID, content);
+
+      if (RECALL_REGEX.test(content)) {
+        output.parts.push({ type: 'text', text: RECALL_NUDGE });
+      }
     },
 
     'message.updated': async (input, output) => {
@@ -349,7 +369,8 @@ export const RembricPlugin: Plugin = async (ctx) => {
           `call \`memory.session_summary\` with the content of the compacted summary above. ` +
           (slug ? `Use project: '${slug}'. ` : '') +
           'This preserves what was accomplished before compaction. ' +
-          'Without this step, everything done before compaction is lost from memory.',
+          'Without this step, everything done before compaction is lost from memory. ' +
+          'If the compacted summary lacks specific detail you need (exact file paths, prior decisions, concrete error messages), call `memory.context` before responding.',
       );
     },
   };

--- a/apps/plugin/README.md
+++ b/apps/plugin/README.md
@@ -11,18 +11,20 @@ Memory for AI coding agents, backed by your self-hosted [Rembric](https://github
 
 The rest of this file is the Claude Code plugin reference. For Codex see [`docs/agents.md`](../docs/agents.md). For Hermes see [`plugin/.hermes-plugin/README.md`](./.hermes-plugin/README.md). For opencode see [`plugin/.opencode-plugin/README.md`](./.opencode-plugin/README.md).
 
-> **Using Codex CLI?** The same `plugin/` tree ships a Codex manifest too. After `codex plugin install rembric` you also need two one-time Codex-side steps for hooks to fire: run `codex features enable plugin_hooks`, then approve the 4 hooks via `/hooks` inside Codex. Full walk-through (including the `REMBRIC_*` shell-env requirement and the symptom-vs-cause troubleshooting table) lives in [`docs/agents.md`](../docs/agents.md#enable-plugin_hooks-and-trust-hooks-required).
+> **Using Codex CLI?** The same `plugin/` tree ships a Codex manifest too. After `codex plugin install rembric` you also need two one-time Codex-side steps for hooks to fire: run `codex features enable plugin_hooks`, then approve the 5 hooks via `/hooks` inside Codex. Full walk-through (including the `REMBRIC_*` shell-env requirement and the symptom-vs-cause troubleshooting table) lives in [`docs/agents.md`](../docs/agents.md#enable-plugin_hooks-and-trust-hooks-required).
 
 ## What you get
 
 - **One MCP server** declared automatically — no hand-editing `.mcp.json`, no plaintext tokens in your settings file. The API token lives in your system keychain.
 - **A tiny stdio bridge** (`bin/rembric-bridge.mjs`, ~80 LOC) that reads `PROJECT_SLUG` from a `.rembric` file at the project root and path-scopes the MCP URL to `/mcp/<slug>` so the Rembric server pins the correct project on connect. No agent-side `project.use` call, no router-fallback codepath.
 - **Four slash commands** under `/rembric:*` — `remember`, `recall`, `context`, `summary`.
-- **Four lifecycle hooks** — all `command`-type, all POST to Rembric's HTTP API directly so sessions are tracked regardless of whether the agent remembers to call them:
-  - `SessionStart` reads the host session id from stdin and POSTs `/api/<slug>/sessions` to register the session (idempotent). Also nudges the agent to load recent context.
+- **Six lifecycle hooks** — all `command`-type, all POST to Rembric's HTTP API directly so sessions are tracked regardless of whether the agent remembers to call them:
+  - `SessionStart` (matcher `startup|resume|clear`) reads the host session id from stdin and POSTs `/api/<slug>/sessions` to register the session (idempotent). Also nudges the agent to load recent context.
+  - `SessionStart` (matcher `compact`) injects a multi-line nudge into the post-compact model context directing it to call `memory.session_summary` and `memory.context` if detail is missing.
   - `UserPromptSubmit` (matcher on recall keywords) nudges the agent to search before responding.
-  - `PreCompact` POSTs the compact transcript to `/api/<slug>/sessions/<id>/summary` so compaction never silently loses session state.
-  - `Stop` POSTs `/api/<slug>/sessions/<id>/end` (async) when the agent stops, closing the session row cleanly.
+  - `PreCompact` POSTs the live transcript to `/api/<slug>/sessions/<id>/summary` BEFORE compaction wipes context, so the snapshot survives independent of model cooperation.
+  - `PostCompact` POSTs the model-authored `compaction_summary` (delivered on stdin) directly to `/api/<slug>/sessions/<id>/summary` — the highest-quality summary we can capture.
+  - `SessionEnd` POSTs `/api/<slug>/sessions/<id>/end` when the session terminates, closing the row cleanly.
 
 Proactive memory protocol ("save after decisions, fixes, conventions, preferences, discoveries") is delivered server-side via the Rembric MCP `initialize.instructions` handshake — it applies to every MCP client (Claude Code plugin, Codex CLI, Cursor, …) automatically, with no per-client skill needed.
 
@@ -121,13 +123,15 @@ Pick something stable, lowercase, hyphen-separated (`acme-foo`, `my-app-api`). F
 
 ## Token budget
 
-| What                   | Cost     | When                         |
-| ---------------------- | -------- | ---------------------------- |
-| 4 command listings     | ≤ 40 tok | always-on (per turn)         |
-| SessionStart nudge     | ~ 20 tok | once per session             |
-| UserPromptSubmit nudge | ~ 20 tok | per matched prompt           |
-| PreCompact             | 0 tok    | side effect; no model output |
-| Stop                   | 0 tok    | side effect; async           |
+| What                         | Cost      | When                               |
+| ---------------------------- | --------- | ---------------------------------- |
+| 4 command listings           | ≤ 40 tok  | always-on (per turn)               |
+| SessionStart nudge (startup) | ~ 20 tok  | once per session                   |
+| SessionStart nudge (compact) | ~ 120 tok | once per /compact (model-context)  |
+| UserPromptSubmit nudge       | ~ 20 tok  | per matched prompt                 |
+| PreCompact                   | 0 tok     | side effect; no model output       |
+| PostCompact                  | 0 tok     | side effect; no model output       |
+| SessionEnd                   | 0 tok     | side effect; runs after model exit |
 
 The proactive-save protocol travels via the MCP `initialize.instructions` (~500 chars, paid once per connection by every client) — it does not show up in the plugin's per-turn budget.
 

--- a/apps/plugin/hooks/hooks.codex.json
+++ b/apps/plugin/hooks/hooks.codex.json
@@ -30,6 +30,26 @@
           }
         ]
       }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/pre-compact.sh codex-cli"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/post-compaction.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/apps/plugin/hooks/hooks.json
+++ b/apps/plugin/hooks/hooks.json
@@ -40,6 +40,26 @@
           }
         ]
       }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "REMBRIC_SERVER_URL='${user_config.server_url}' REMBRIC_API_TOKEN='${user_config.api_token}' \"${CLAUDE_PLUGIN_ROOT}\"/scripts/pre-compact.sh claude-code"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "REMBRIC_SERVER_URL='${user_config.server_url}' REMBRIC_API_TOKEN='${user_config.api_token}' \"${CLAUDE_PLUGIN_ROOT}\"/scripts/post-compaction.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/apps/plugin/scripts/_api.sh
+++ b/apps/plugin/scripts/_api.sh
@@ -103,6 +103,44 @@ rembric_transcript_path_from_stdin_json() {
   printf '%s' "$input" | sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1
 }
 
+# Extract `compaction_summary` from a PostCompact hook stdin JSON blob.
+# Prefers Claude Code's snake_case; falls back to camelCase in case Codex
+# (or a future client) ships the same content under `compactionSummary`.
+# Returns empty when missing.
+#
+# Prefers `jq` when available (correctly handles escaped quotes and any
+# whitespace in the payload). Falls back to a sed regex that matches the
+# same shape as the other stdin extractors — simple `"[^"]*"` value
+# capture. The fallback cannot recover content past an unescaped quote
+# inside the value, but in practice compaction summaries from Claude
+# Code / Codex are JSON-encoded so embedded quotes appear as `\"` and
+# the regex truncates at the first escape; for v1 this is the same
+# trade-off as the other stdin extractors. jq is the recommended path.
+rembric_compaction_summary_from_stdin_json() {
+  local input="${1:-}"
+  [ -z "$input" ] && return 0
+  local s=""
+  if command -v jq >/dev/null 2>&1; then
+    s="$(printf '%s' "$input" | jq -r '.compaction_summary // .compactionSummary // empty' 2>/dev/null)"
+  else
+    s="$(printf '%s' "$input" | sed -n 's/.*"compaction_summary"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+    if [ -z "$s" ]; then
+      s="$(printf '%s' "$input" | sed -n 's/.*"compactionSummary"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+    fi
+    # The sed regex preserved JSON escape sequences (e.g. \n, \") literally.
+    # Convert them back to real characters so callers handling plain text
+    # see a readable summary; rembric_json_escape will re-encode on emit.
+    if [ -n "$s" ]; then
+      s="${s//\\n/$'\n'}"
+      s="${s//\\r/$'\r'}"
+      s="${s//\\t/$'\t'}"
+      s="${s//\\\"/\"}"
+      s="${s//\\\\/\\}"
+    fi
+  fi
+  printf '%s' "$s"
+}
+
 # Escape a string for embedding in a JSON value: backslashes, double quotes,
 # and control chars (\n \r \t). Good enough for transcripts captured from
 # hook stdin; not a general-purpose JSON encoder.

--- a/apps/plugin/scripts/post-compact.sh
+++ b/apps/plugin/scripts/post-compact.sh
@@ -47,7 +47,7 @@ rembric: Esta sesión resume desde una compaction. ANTES de continuar:
 1. Llamá memory.session_summary({title, summary}) con el compact summary que ves arriba.
    - title: ≤100 chars, descriptivo del trabajo real (no genérico, no el cwd).
    - summary: Goal · Discoveries · Accomplished · Next Steps · Files.
-2. Si necesitás más contexto: memory.context.
+2. Si el summary arriba no contiene el detalle que necesitás (file paths exactos, decisiones técnicas concretas, errores específicos previos), llamá memory.context o memory.search ANTES de responder.
 3. Recién después, continuá con la petición del usuario.
 PROTOCOL
 

--- a/apps/plugin/scripts/post-compaction.sh
+++ b/apps/plugin/scripts/post-compaction.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# PostCompact hook — shared by Claude Code and Codex CLI.
+#
+# Fires AFTER the compactor has produced its summary. stdin carries
+# `compaction_summary` (Claude Code; possibly `compactionSummary` for
+# Codex) — the model-authored compressed text we want to persist
+# verbatim. This is the highest-quality summary we can capture because
+# it was crafted by the same model that just compressed the conversation.
+#
+# stdout: NONE. PostCompact stdout is "side effects only" — NOT injected
+# into the model's context. The model already has the summary in its
+# context naturally; we don't echo it back.
+set -u
+trap 'exit 0' ERR
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_api.sh
+source "${SCRIPT_DIR}/_api.sh"
+
+INPUT=""
+if [ ! -t 0 ]; then
+  INPUT="$(cat)"
+fi
+SESSION_ID="$(rembric_session_id_from_stdin_json "$INPUT")"
+CWD="$(rembric_cwd_from_stdin_json "$INPUT")"
+COMPACTION_SUMMARY="$(rembric_compaction_summary_from_stdin_json "$INPUT")"
+[ -z "$CWD" ] && CWD="$PWD"
+SLUG="$(rembric_read_project_slug "$CWD")"
+
+if [ -z "$SESSION_ID" ] || [ -z "$SLUG" ]; then
+  exit 0
+fi
+
+if [ -n "$COMPACTION_SUMMARY" ]; then
+  SUMMARY_ESC="$(rembric_json_escape "$COMPACTION_SUMMARY")"
+  rembric_post "/api/${SLUG}/sessions/${SESSION_ID}/summary" \
+    "{\"summary\":\"${SUMMARY_ESC}\",\"final\":false}"
+else
+  # Degraded mode — stdin lacks compaction_summary. Touch the row with
+  # an empty body; server precedence preserves any prior summary.
+  printf '[rembric] PostCompact: missing compaction_summary on stdin; posting empty body\n' >&2
+  rembric_post "/api/${SLUG}/sessions/${SESSION_ID}/summary" "{}"
+fi
+
+exit 0

--- a/apps/plugin/scripts/pre-compact.sh
+++ b/apps/plugin/scripts/pre-compact.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# PreCompact hook — shared by Claude Code and Codex CLI.
+#
+# Fires BEFORE the compactor runs, while the full transcript is still
+# readable from `transcript_path`. We snapshot it to Rembric so the
+# pre-compact state is durable on the server even if the model never
+# calls memory.session_summary post-compact.
+#
+# Usage: pre-compact.sh [agent-name]
+#   agent-name selects the per-client transcript parser:
+#     "claude-code" (default) → _transcript.sh::*_claude_code helpers
+#     "codex-cli"             → _transcript.sh::*_codex_cli helpers
+#
+# stdin (both clients): JSON object with `session_id`/`sessionId`, `cwd`,
+# `transcript_path`. Claude Code additionally passes `compaction_trigger`
+# (manual|auto); Codex may pass a similar field. We don't consume it.
+#
+# stdout: NONE. PreCompact stdout is documented (Claude Code) and
+# expected-by-symmetry (Codex) to be "side effects only" — NOT injected
+# into the model's context. Emitting plain text here would be noise at
+# best and a Codex parser failure at worst.
+set -u
+trap 'exit 0' ERR
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_api.sh
+source "${SCRIPT_DIR}/_api.sh"
+# shellcheck source=./_transcript.sh
+source "${SCRIPT_DIR}/_transcript.sh"
+
+AGENT="${1:-${REMBRIC_AGENT:-claude-code}}"
+
+INPUT=""
+if [ ! -t 0 ]; then
+  INPUT="$(cat)"
+fi
+SESSION_ID="$(rembric_session_id_from_stdin_json "$INPUT")"
+CWD="$(rembric_cwd_from_stdin_json "$INPUT")"
+TRANSCRIPT_PATH="$(rembric_transcript_path_from_stdin_json "$INPUT")"
+[ -z "$CWD" ] && CWD="$PWD"
+SLUG="$(rembric_read_project_slug "$CWD")"
+
+if [ -z "$SESSION_ID" ] || [ -z "$SLUG" ]; then
+  exit 0
+fi
+
+SUMMARY=""
+TITLE=""
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+  case "$AGENT" in
+    codex-cli)
+      SUMMARY="$(rembric_format_transcript_codex_cli "$TRANSCRIPT_PATH" 2>/dev/null || true)"
+      TITLE="$(rembric_extract_first_assistant_codex_cli "$TRANSCRIPT_PATH" 2>/dev/null || true)"
+      ;;
+    *)
+      SUMMARY="$(rembric_format_transcript_claude_code "$TRANSCRIPT_PATH" 2>/dev/null || true)"
+      TITLE="$(rembric_extract_first_assistant_claude_code "$TRANSCRIPT_PATH" 2>/dev/null || true)"
+      ;;
+  esac
+fi
+
+if [ -n "$SUMMARY" ]; then
+  SUMMARY_ESC="$(rembric_json_escape "$SUMMARY")"
+  if [ -n "$TITLE" ]; then
+    TITLE_ESC="$(rembric_json_escape "$TITLE")"
+    rembric_post "/api/${SLUG}/sessions/${SESSION_ID}/summary" \
+      "{\"summary\":\"${SUMMARY_ESC}\",\"title\":\"${TITLE_ESC}\",\"final\":false}"
+  else
+    rembric_post "/api/${SLUG}/sessions/${SESSION_ID}/summary" \
+      "{\"summary\":\"${SUMMARY_ESC}\",\"final\":false}"
+  fi
+else
+  # Degraded mode — no transcript or empty parse. Still touch the row so
+  # subsequent PostCompact lands on a known session.
+  rembric_post "/api/${SLUG}/sessions/${SESSION_ID}/summary" "{}"
+fi
+
+exit 0

--- a/apps/server/src/mcp/instructions.test.ts
+++ b/apps/server/src/mcp/instructions.test.ts
@@ -58,4 +58,14 @@ describe('MCP initialize instructions', () => {
       expect(text).toContain('before');
     }
   });
+
+  it('teaches the post-compact recovery path (memory.context) in both variants', () => {
+    const variants = [
+      buildInstructions({ requestedSlug: null }),
+      buildInstructions({ requestedSlug: 'rembric' }),
+    ];
+    for (const text of variants) {
+      expect(text).toContain('memory.context');
+    }
+  });
 });

--- a/apps/server/src/mcp/instructions.ts
+++ b/apps/server/src/mcp/instructions.ts
@@ -17,9 +17,10 @@ export interface InstructionsContext {
 
 const BASE = `Rembric memory.
 
-Call memory.save right after: bug fix · decision · discovery · config change · pattern · user preference. If the same topic is evolving, pass topic_key (or call memory.suggest_topic_key first) so the previous row supersedes atomically. When save returns candidates[], close each with memory.judge.
+Call memory.save after: bug fix · decision · discovery · config change · pattern · user preference. If the topic is evolving, pass topic_key (use memory.suggest_topic_key) so the prior row supersedes. On save candidates[], close each with memory.judge.
 Call memory.search when the user references past work or asks "what did we do".
-Call memory.session_summary({title, summary}) before saying "done": title ≤100 chars describing what was actually worked on; summary covers Goal · Discoveries · Accomplished · Next Steps · Files.`;
+Call memory.session_summary({title, summary}) before "done": title ≤100 chars describing what was actually worked on; summary covers Goal · Discoveries · Accomplished · Next Steps · Files.
+After /compact: call memory.context if detail is missing.`;
 
 const PATH_SCOPED_NOTE = (slug: string) =>
   `\n\nThis connection is path-scoped to '${slug}'. scope='global' is rejected; open /mcp for user-wide memory.`;

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -52,7 +52,7 @@ The marketplace `source` is `git-subdir` against `./plugin`, so Codex clones the
 What the plugin registers for Codex:
 
 - The `rembric` MCP server (declared by `apps/plugin/.codex-plugin/mcp.json`, the Codex-specific sibling of Claude Code's `apps/plugin/.claude-plugin/mcp.json`), invoking the bundled bridge at `plugin_root/bin/rembric-bridge.mjs` (resolved via the manifest's `cwd: "."` + relative args).
-- A four-hook subset (`SessionStart`, `UserPromptSubmit`, `PreCompact`, `Stop`) sharing scripts with the Claude Code plugin via `${CLAUDE_PLUGIN_ROOT}/scripts/*.sh`. All hooks are `command`-type and POST to Rembric's `/api/<slug>/sessions(*)` HTTP API for session lifecycle — the agent never needs to call `memory.session_start`/`memory.session_summary`/`memory.session_end` manually; the hooks handle creation, summary-on-compact, and end-on-stop.
+- A five-hook subset (`SessionStart`, `UserPromptSubmit`, `PreCompact`, `PostCompact`, `Stop`) sharing scripts with the Claude Code plugin via `${CLAUDE_PLUGIN_ROOT}/scripts/*.sh`. All hooks are `command`-type and POST to Rembric's `/api/<slug>/sessions(*)` HTTP API for session lifecycle — the agent never needs to call `memory.session_start`/`memory.session_summary`/`memory.session_end` manually; the hooks handle creation, summary-on-compact (pre + post), and end-on-stop.
 
 After install, drop a `.rembric` file at the root of each project to path-scope the slug automatically:
 
@@ -77,7 +77,7 @@ export REMBRIC_API_TOKEN="$(cat ~/.rembric/codex-token)"   # token minted from /
 Then restart your terminal (or `source ~/.zshrc`) before launching `codex`. The same two envs feed:
 
 - The **MCP bridge** — `apps/plugin/.codex-plugin/mcp.json` declares `env_vars: ["REMBRIC_SERVER_URL", "REMBRIC_API_TOKEN"]`, Codex's native mechanism for reading specific env vars from the parent shell at MCP subprocess spawn time (`create_env_for_mcp_server` in `codex-rs/rmcp-client/src/utils.rs`). Codex does NOT inherit the full parent env automatically — `LocalStdioServerLauncher::launch_server` calls `Command::env_clear()` before applying the curated env, so only the names you list under `env_vars` are forwarded, on top of `DEFAULT_ENV_VARS`. The same manifest also uses `cwd: "."` + `args: ["./bin/rembric-bridge.mjs"]` to anchor the bridge path to the plugin root — `${CLAUDE_PLUGIN_ROOT}` substitution does NOT work in MCP args under Codex (only in hook commands), so future contributors should not "simplify" the path back to the Claude Code form.
-- The **lifecycle hooks** (`SessionStart`, `PreCompact`, `Stop`) so sessions appear in `/dashboard/sessions` and PreCompact persists a summary.
+- The **lifecycle hooks** (`SessionStart`, `PreCompact`, `PostCompact`, `Stop`) so sessions appear in `/dashboard/sessions` and PreCompact/PostCompact persist a summary across compaction without depending on the model calling `memory.session_summary` post-compact.
 
 Symptoms of missing envs:
 
@@ -97,9 +97,9 @@ codex features enable plugin_hooks          # writes [features] plugin_hooks = t
 
 Newer Codex releases may default this feature on — run `codex features list` first to confirm you actually need the step. If it already reports `plugin_hooks  stable  true`, skip.
 
-**Step 2 — trust the hooks inside Codex.** Restart Codex after step 1. On startup Codex shows a banner of the form _"4 hooks need review before they can run. Open `/hooks` to review them."_ Open `/hooks` from inside Codex and approve each of the four Rembric hooks (`SessionStart`, `UserPromptSubmit`, `PreCompact`, `Stop`). The trust persists in `~/.codex/config.toml` under `[hooks.state]`, so this is a one-time-per-hook step — subsequent Codex launches do not re-prompt.
+**Step 2 — trust the hooks inside Codex.** Restart Codex after step 1. On startup Codex shows a banner of the form _"5 hooks need review before they can run. Open `/hooks` to review them."_ Open `/hooks` from inside Codex and approve each of the five Rembric hooks (`SessionStart`, `UserPromptSubmit`, `PreCompact`, `PostCompact`, `Stop`). The trust persists in `~/.codex/config.toml` under `[hooks.state]`, so this is a one-time-per-hook step — subsequent Codex launches do not re-prompt.
 
-After both steps, the `/plugins` panel for `rembric` shows `Hooks: PreCompact (1), SessionStart (1), UserPromptSubmit (1), Stop (1)` and the first new Codex session will POST to `/api/<slug>/sessions` against the Rembric server (visible at `/dashboard/sessions`).
+After both steps, the `/plugins` panel for `rembric` shows `Hooks: PreCompact (1), PostCompact (1), SessionStart (1), UserPromptSubmit (1), Stop (1)` and the first new Codex session will POST to `/api/<slug>/sessions` against the Rembric server (visible at `/dashboard/sessions`).
 
 ##### Symptom → cause table
 

--- a/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-22

--- a/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/design.md
+++ b/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/design.md
@@ -1,0 +1,116 @@
+## Context
+
+The plugin tier currently handles compaction in two clients via "nudge-and-pray":
+
+- **Claude Code**: `SessionStart` matcher:`"compact"` injects a multi-line instruction into the post-compact model context urging it to call `memory.session_summary`. Whether the model cooperates is the determining factor for whether the row gets a summary at all.
+- **opencode**: `experimental.session.compacting` pushes a similar instruction onto the compactor's output context.
+
+Both rely on the agent. The auto-curate safety net added in PR #71 (archived as `tighten-context-content-predicate-to-final-summaries`) covers the case where no cooperative summary lands by deriving `[auto] N memorias[, P prompts]…` server-side at terminal transition — but that's a fallback, not a substitute for a real summary.
+
+When investigating reference implementations (`rohitg00/agentmemory`), we found that **Claude Code, Codex CLI, and opencode all expose post-compaction events we don't subscribe to**. Claude Code's `PostCompact` event even delivers the model-authored `compaction_summary` directly on stdin — eliminating the model-cooperation dependency entirely for that client.
+
+A separate discovery: the existing `codex-distribution` spec claims "Codex has no PreCompact or PostCompact event" (line 56 of `openspec/specs/codex-distribution/spec.md`). That claim is **wrong**, source-verified against `codex-rs/hooks/src/engine/output_parser.rs` which defines both `parse_pre_compact` and `parse_post_compact`. The spec was authored from the partial public docs at `developers.openai.com/codex/plugins/hooks`; the source is authoritative.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Cable PreCompact + PostCompact for both Claude Code and Codex CLI, with shared scripts under `apps/plugin/scripts/` to keep the cross-client doctrine intact (`shared logic lives in shared paths`).
+- Cable `session.compacted` for opencode as a "flush at this milestone" trigger.
+- Cable recall-regex detection in opencode's `chat.message` handler for cross-client paridad with the existing `UserPromptSubmit` regex used by Claude Code and Codex CLI.
+- Refine four prompt surfaces to make `memory.context` the canonical post-compact detail-recovery path.
+- Correct the codex-distribution spec to reflect the real Codex event surface (source-verified).
+
+**Non-Goals:**
+
+- NO new HTTP endpoints. The "read pattern" (where hooks GET memory and inject it into the compactor's input — agentmemory's primary trick) is **explicitly deferred** to a future change. Discussed and decided: the "save-only" surface is mechanical and ships independently; the "save+read" surface reopens the deferred-scope decision recorded in memory `01KRQ78R4H9QDCSFASX6S3S55S` and benefits from empirical data on "how often does the model fail to call memory.context post-compact?" — data we don't have yet.
+- NO `UserPromptExpansion` slash-command handlers in Claude Code. That's a UX trade-off (model interprets `$ARGUMENTS` vs hook executes directly) that deserves its own debate.
+- NO rich per-event observability (assistant message cost/tokens, tool call telemetry, subtask spawn capture) à la agentmemory's opencode plugin. Scope explosion; would warrant its own proposal if pursued.
+- NO changes to the bridge (`apps/plugin/bin/rembric-bridge.mjs`) or dotenv lib (`apps/plugin/bin/rembric-dotenv.mjs`).
+- NO Hermes `prefetch` / `queue_prefetch` / `sync_turn` / `on_memory_write` activation (those remain no-ops; activating them would require new HTTP routes, which is again "save+read" scope).
+
+## Decisions
+
+### Decision 1: Shared `pre-compact.sh` and `post-compaction.sh` for Claude + Codex
+
+**Chosen:** One script per event, sourced by both client hook manifests.
+
+**Alternative considered:** Per-client variants `pre-compact-claude.sh` / `pre-compact-codex.sh`.
+
+**Rationale:** The `shared-plugin-logic` doctrine (`apps/server/src/test/invariants.test.ts` + memory `01KRNZM2VFCME5HNT8N78HZW18`) says shared logic lives once. The stdin contracts for Claude `PreCompact` (`session_id`, `transcript_path`, `cwd`, `hook_event_name`, `compaction_trigger`) and Codex `PreCompact` (verified in `codex-rs/hooks/src/engine/output_parser.rs::parse_pre_compact`'s wire type) are compatible — both pass `session_id` and `cwd`; Codex passes `transcript_path` in the same shape. The scripts use the existing `rembric_session_id_from_stdin_json` and `rembric_cwd_from_stdin_json` helpers from `_api.sh`, which already handle both Claude's `session_id` key and Codex's `sessionId` fallback (per the `codex-distribution` spec line 105). No per-client fork required.
+
+If Codex's `compaction_trigger` field differs in shape from Claude's, the scripts treat it as optional metadata (logged to stderr diagnostic, not POSTed) — neither client needs it for the persistence path.
+
+### Decision 2: `PostCompact` uses stdin's `compaction_summary` directly; does NOT re-read the transcript
+
+**Chosen:** `post-compaction.sh` POSTs `{summary: <compaction_summary from stdin>, final:false}` and skips reading `transcript_path`.
+
+**Alternative considered:** Use `compaction_summary` ONLY if present and fall back to formatting `transcript_path` like `pre-compact.sh` does.
+
+**Rationale:** `PostCompact` is documented (Claude Code) and source-verified (Codex) to deliver the model-authored compaction summary on stdin. That's the highest-quality summary we can get — it was crafted by the same model that just compressed the conversation. Reading `transcript_path` post-compact would give us the post-compaction state (compacted summary + recent turns), which is what the model already has in context — duplicating it as our "summary" is worse than using the canonical compaction_summary directly.
+
+If `compaction_summary` is absent (shape mismatch, future Codex change), the script logs a stderr diagnostic and POSTs `/summary` with body `{}` — letting the existing `summary_final` precedence on the server take care of preserving any pre-existing summary.
+
+### Decision 3: opencode `session.compacted` uses the in-memory accumulator, not the event payload
+
+**Chosen:** When `session.compacted` fires, call `flushSessionSummary(sessionId)` — the same path used by `session.idle` and `server.instance.disposed`.
+
+**Alternative considered:** Reset the `sessionMessages` Map for the affected session id post-compaction and start fresh.
+
+**Rationale:** opencode does NOT deliver the `compaction_summary` text on `session.compacted` — it's a notification event, not a content delivery. Our `sessionMessages` Map persists across compaction (it's in-process plugin state), so it still holds the full pre-compact transcript. Flushing it AT compaction time captures "everything up to and including the compaction milestone" — strictly more information than the model-authored compact summary alone, because it includes the raw turns the compactor compressed.
+
+Resetting the accumulator was rejected: subsequent `session.idle` events would have only the post-compact accumulator state, which is less useful than the rolling pre+post view we get by leaving it alone.
+
+### Decision 4: opencode `chat.message` recall-regex is server-evaluated, not text-injected
+
+**Chosen:** When the user message matches `/remember|recall|acordate|qué hicimos|what did we do/i`, append a one-line nudge to `output.parts` (same string as the existing Claude+Codex `UserPromptSubmit` hook).
+
+**Alternative considered:** POST a `memory.search` from the plugin and inject results.
+
+**Rationale:** The "POST and inject results" approach is the read pattern that's explicitly out of scope (see Non-Goals). The nudge approach is the existing Claude+Codex pattern — the LLM sees the nudge and dispatches `memory.search` itself via MCP. opencode's existing `experimental.session.compacting` precedent demonstrates the nudge-to-context pattern works cleanly without HTTP round-trips.
+
+### Decision 5: Correct `codex-distribution` spec misstatement in this change
+
+**Chosen:** Spec delta MODIFIES the existing "Codex hook configuration" requirement and its "Hook event coverage" scenario to (a) remove the wrong "Codex has no PreCompact/PostCompact" claim, and (b) add wiring for the new events.
+
+**Alternative considered:** Open a separate spec-correction bugfix change, then add wiring in a follow-up.
+
+**Rationale:** The misstatement is the reason we don't currently wire those events. Splitting the correction from the wiring would mean shipping a spec PR that says "Codex does support PreCompact/PostCompact, but we don't wire them" followed by another PR that does. Single change keeps the spec and the implementation in lock-step.
+
+### Decision 6: Server-side instructions.ts edit is in scope despite being outside `apps/plugin/`
+
+**Chosen:** Include the one-line `apps/server/src/mcp/instructions.ts` edit (memory.context post-compact pointer) in this change.
+
+**Alternative considered:** Split it into its own server-side change.
+
+**Rationale:** The edit is a docstring update inside the existing 800-char cap. It's the **server's** equivalent of the prompt refinements we're making in the four plugin clients' nudges — same intent (teach the agent when to call memory.context), same surface (text-only). Splitting it would fragment what is a single coherent prompt-engineering exercise across two PRs reviewed in isolation. The change is reversible by `git revert` of one line.
+
+The corresponding `apps/server/src/mcp/instructions.test.ts` already asserts the 800-char cap and the presence of specific substrings; we'll add an assertion for the new line.
+
+## Risks / Trade-offs
+
+- **[Risk]** Claude Code's `PreCompact` schema includes fields we haven't seen at runtime (the docs and source don't 100% match). → **Mitigation:** The shared scripts already handle missing/empty stdin fields by exiting `0` with a stderr diagnostic. If `transcript_path` is missing in `PreCompact`, we POST `/summary {}` and rely on the server's `summary_final` precedence. Worst case: PreCompact becomes a no-op for that client, same as today.
+
+- **[Risk]** Codex `PreCompact` / `PostCompact` stdin shape differs from Claude's in a non-obvious way (e.g. `compactionSummary` instead of `compaction_summary`). → **Mitigation:** During implementation, the agent applying this change MUST verify against `codex-rs/hooks/src/schema.rs` or by running Codex with `RUST_LOG=debug` and reading actual stdin. Both clients' shared-script pattern allows per-client fallback parsing if needed (same precedent as `session_id` vs `sessionId`).
+
+- **[Risk]** Codex feature flag `plugin_hooks` is still default-off (per the `codex-distribution` spec). Wiring new events doesn't help Codex users who haven't enabled it. → **Mitigation:** This is a pre-existing constraint, not introduced by this change. The `docs/agents.md` Codex section already documents the `codex features enable plugin_hooks` step and the `/hooks` trust review.
+
+- **[Risk]** Token cost: the sharpened nudges add maybe 30-60 chars to each prompt surface. → **Mitigation:** The Claude `post-compact.sh` block is currently ~390 chars; adding 30 brings it to ~420 — well under the 120-token cap declared in `claude-code-plugin::Token budget`. Hermes `system_prompt_block` is hard-capped at 300 chars by `Provider lifecycle method behavior` scenario; the edit MUST stay under that. `instructions.ts` is hard-capped at 800 chars by `instructions.test.ts`.
+
+- **[Trade-off]** We do NOT capture the post-compact `compaction_summary` from opencode because the event doesn't deliver it. The in-memory accumulator gives us the pre-compact transcript instead. → **Accepted because** opencode users still get a usable summary at the compaction milestone (the rolling transcript covers what the model just compressed); they just don't get the model's own compressed version of it. Future opencode upstream changes may add the payload, at which point a follow-up can capture it.
+
+- **[Trade-off]** Claude Code and Codex CLI's `PostCompact` stdout is NOT model-context-injected (only `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, and `Stop` outputs reach the model — `PreCompact`/`PostCompact` are "side effects only" per `code.claude.com/docs/en/hooks`). → **Accepted.** That's why we keep the model-context nudges in their existing locations (`post-compact.sh` for SessionStart compact + `experimental.session.compacting` for opencode + `instructions.ts` for permanent guidance + `system_prompt_block` for Hermes). PreCompact/PostCompact are pure persistence hooks.
+
+## Migration Plan
+
+None. Net-additive change:
+
+- New hook entries fire only after the next plugin install/update reaches the user.
+- Existing sessions and in-flight clients continue to function with the pre-change nudge-and-pray pattern until the new wiring takes effect on the next session.
+- No DB migrations, no schema changes, no auth changes.
+
+Rollback path: revert the change-introducing commit and re-archive the OpenSpec change as superseded.
+
+## Open Questions
+
+(None blocking — all design decisions resolved above. Implementation will verify Codex `PreCompact`/`PostCompact` stdin shape against the Codex source and adjust the shared scripts if needed.)

--- a/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/proposal.md
+++ b/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/proposal.md
@@ -1,0 +1,86 @@
+## Why
+
+Today, the responsibility of persisting the compact summary into Rembric relies on the host agent calling `memory.session_summary` after `/compact`. Empirically that depends on the model cooperating with the nudge served by `apps/plugin/scripts/post-compact.sh` (Claude Code) and the `experimental.session.compacting` handler in `apps/plugin/.opencode-plugin/plugin.ts` (opencode). When the model skips that step, the post-compact session continues but the Rembric row is left with whatever summary was last written — typically nothing, or a stale `[auto]`-prefixed snapshot from the auto-curate safety net (PR #71 era).
+
+Two of our four clients expose lifecycle events that let the plugin tier do this work **without depending on model cooperation**:
+
+- **Claude Code** has `PreCompact` (fires BEFORE compaction with the full transcript still accessible via `transcript_path`) and `PostCompact` (fires AFTER compaction with the model-authored `compaction_summary` field on stdin). We wire neither today.
+- **Codex CLI** has `PreCompact` and `PostCompact` too — verified against the upstream source at `codex-rs/hooks/src/engine/output_parser.rs` (`parse_pre_compact`, `parse_post_compact`). The current `codex-distribution` spec wrongly claims "Codex has no PreCompact or PostCompact event" because it was authored against the partial public docs at `developers.openai.com/codex/plugins/hooks`. The source is authoritative; we're correcting the spec.
+- **opencode** has `session.compacted` as a non-experimental "after compaction" event we don't subscribe to.
+- **Hermes** already handles `on_pre_compress` correctly; the gap there is in `system_prompt_block`'s text — it nudges toward `memory.session_summary` but doesn't tell the agent to call `memory.context` to recover fine detail after a compact.
+
+Separately, opencode's plugin lacks the recall-keyword nudge that Claude Code and Codex CLI both ship in their `UserPromptSubmit` handlers (regex `remember|recall|acordate|qué hicimos|what did we do`). This is a cross-client paridad gap with a trivial fix in the existing `chat.message` handler.
+
+## What Changes
+
+**Six new hook wires** + **five prompt refinements**, all confined to the `apps/plugin/` tree. No server-side endpoints, no schema changes, no new HTTP routes.
+
+### Hooks
+
+1. **Claude Code `PreCompact`** — new entry in `apps/plugin/hooks/hooks.json`, new script `apps/plugin/scripts/pre-compact.sh`. Reads `session_id`, `cwd`, `transcript_path` from stdin; formats the transcript via the existing `_transcript.sh` helper; POSTs `/api/<slug>/sessions/<id>/summary` with `{summary, title?, final:false}`. PreCompact stdout is NOT model-context-injected so the script emits nothing.
+2. **Claude Code `PostCompact`** — new entry in `apps/plugin/hooks/hooks.json`, new script `apps/plugin/scripts/post-compaction.sh`. Reads `session_id`, `cwd`, and `compaction_summary` from stdin; POSTs `/api/<slug>/sessions/<id>/summary` with `{summary: <compaction_summary>, final:false}`. PostCompact stdout is NOT model-context-injected so the script emits nothing.
+3. **Codex CLI `PreCompact`** — new entry in `apps/plugin/hooks/hooks.codex.json`, **reuses** `pre-compact.sh` from #1 (same stdin contract per Codex's `parse_pre_compact`).
+4. **Codex CLI `PostCompact`** — new entry in `apps/plugin/hooks/hooks.codex.json`, **reuses** `post-compaction.sh` from #2.
+5. **opencode `session.compacted` branch** — extend the existing `event` dispatcher in `apps/plugin/.opencode-plugin/plugin.ts` to handle `event.type === "session.compacted"` by calling the existing `flushSessionSummary(sessionId)` helper. opencode's event delivers no `compaction_summary` payload — the plugin's in-memory accumulator already retains the full transcript cross-compact, so flushing it is the equivalent of "persist what we have at this milestone".
+6. **opencode `chat.message` recall regex** — modify the existing `chat.message` handler in `plugin.ts` to detect the same recall regex used in `UserPromptSubmit` (`/remember|recall|acordate|qué hicimos|what did we do/i`) on the incoming user text, and append a nudge to `output.parts` directing the agent to call `memory.search`. Cross-client paridad with Claude Code + Codex CLI.
+
+### Prompt refinements (text-only edits)
+
+7. **`apps/plugin/scripts/post-compact.sh` (Claude SessionStart compact)** — sharpen point 2 of the existing imperative block from "Si necesitás más contexto: memory.context" to a stronger form making clear `memory.context` is the recovery path when the compact summary lacks detail.
+8. **`apps/plugin/.opencode-plugin/plugin.ts` (`experimental.session.compacting`)** — append to the existing "CRITICAL INSTRUCTION" string a sentence about calling `memory.context` if specific detail from before compaction is needed.
+9. **New `apps/plugin/scripts/pre-compact.sh` and `post-compaction.sh`** — since they're new files, they MUST start out with the right nudge discipline. But since their stdout is NOT model-context-injected (per Claude Code's hook docs), the nudges in 7/8 remain delivered via the SessionStart/compacting paths and don't need duplication here.
+10. **`apps/server/src/mcp/instructions.ts`** — add one short line to the existing `initialize.instructions` block (capped 800 chars total) instructing post-compact agents to call `memory.context` when they need detail beyond the compact summary. This is the only file outside `apps/plugin/` touched by this change, and it's a docstring-level edit.
+11. **`apps/plugin/.hermes-plugin/__init__.py::RembricMemoryProvider.system_prompt_block`** — extend the existing 300-char nudge to include the same "post-compact recovery path" guidance. Stays within the 300-char cap.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- **`claude-code-plugin`** — ADD `PreCompact` and `PostCompact` hook requirements; MODIFY the "four hooks at hooks.json" requirement to reflect the new total (six hooks) and remove the legacy "the prior PreCompact entry SHALL NOT be wired" clause.
+- **`codex-distribution`** — MODIFY the "Codex hook configuration" requirement: correct the false "Codex has no PreCompact/PostCompact" statement (source-verified) and ADD wiring requirements for PreCompact and PostCompact reusing the shared scripts.
+- **`opencode-plugin`** — MODIFY the "Event handler set" requirement to add `session.compacted` to the documented set and the chat.message recall-regex behaviour; ADD a "session.compacted handler" requirement with scenarios; MODIFY `experimental.session.compacting` nudge text requirement.
+- **`hermes-agent-plugin`** — MODIFY the `system_prompt_block` behaviour line within the "Provider lifecycle method behavior" requirement to include `memory.context` post-compact recovery guidance.
+- **`mcp-api`** — MODIFY the `initialize.instructions` content requirement to include a one-line memory.context post-compact pointer (within existing 800-char cap).
+
+## Impact
+
+**Files touched** (~14 new/modified files):
+
+- `apps/plugin/hooks/hooks.json` — add 2 entries (PreCompact, PostCompact).
+- `apps/plugin/hooks/hooks.codex.json` — add 2 entries (PreCompact, PostCompact).
+- `apps/plugin/scripts/pre-compact.sh` — new file, shared by Claude + Codex.
+- `apps/plugin/scripts/post-compaction.sh` — new file, shared by Claude + Codex.
+- `apps/plugin/scripts/post-compact.sh` — sharpen nudge text (point 2 of imperative block).
+- `apps/plugin/.opencode-plugin/plugin.ts` — add `session.compacted` branch in `event` dispatcher; add recall-regex detection in `chat.message`; extend `experimental.session.compacting` nudge text.
+- `apps/plugin/.opencode-plugin/plugin.test.ts` — add tests for the three opencode changes.
+- `apps/plugin/.hermes-plugin/__init__.py` — extend `system_prompt_block` returned string.
+- `apps/plugin/.hermes-plugin/tests/` — add coverage for the new nudge content.
+- `apps/server/src/mcp/instructions.ts` — add one-line memory.context guidance within 800-char cap.
+- `apps/server/src/mcp/instructions.test.ts` — assert the new line is present and total is ≤800 chars.
+- 5 spec delta files under `openspec/changes/expand-plugin-hooks-coverage/specs/`.
+
+**No impact on**:
+
+- Append-only memory invariant.
+- Service-layer scope enforcement.
+- `topic_key` convergence.
+- Judgment freshness.
+- The `/mcp` ↔ `/mcp/<slug>` path-scoping contract.
+- The HTTP API surface (no new endpoints).
+- The Rembric bridge (`rembric-bridge.mjs`) and dotenv lib (`rembric-dotenv.mjs`).
+- DB schema, migrations, or service-layer code.
+
+**Release-please consequences**:
+
+- Shared bundle changes (`apps/plugin/hooks/`, `apps/plugin/scripts/`) trigger the `bridge-bundlers` linked-versions group → `claude-code-plugin` AND `codex-plugin` bump together.
+- `apps/plugin/.opencode-plugin/plugin.ts` changes → independent `opencode-plugin` bump.
+- `apps/plugin/.hermes-plugin/__init__.py` changes → independent `hermes-plugin` bump.
+- `apps/server/src/mcp/instructions.ts` changes → `server` bump (handled by the existing server release-please component).
+
+**Migration**: none. New hooks are additive — pre-existing sessions and clients without the new wiring continue to function as today.
+
+**Rollback**: revert the commit. The new hook scripts are net-new files; the modified hooks.json/codex.json entries can be removed cleanly.

--- a/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/specs/claude-code-plugin/spec.md
+++ b/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/specs/claude-code-plugin/spec.md
@@ -1,0 +1,133 @@
+## MODIFIED Requirements
+
+### Requirement: The plugin SHALL ship six hooks at `apps/plugin/hooks/hooks.json`
+
+The plugin's hook catalog SHALL declare six entries: `SessionStart` (with TWO matcher groups — one for `startup|resume|clear`, one for `compact`), `UserPromptSubmit`, `SessionEnd`, `PreCompact`, and `PostCompact`. Both `PreCompact` and `PostCompact` are wired in this version — superseding the prior spec's "the prior PreCompact entry SHALL NOT be wired" exclusion, which was authored when the script and contract were ill-defined. The current wiring uses correctly-shaped stdin parsing and respects the documented "stdout is NOT model-context-injected" contract for both events.
+
+#### SessionStart (matcher: startup|resume|clear)
+
+(Unchanged from the prior spec — see archived `add-claude-code-plugin` change.)
+
+#### SessionStart (matcher: compact)
+
+- Type: `command`.
+- Matcher: `compact`.
+- Action: invoke `${CLAUDE_PLUGIN_ROOT}/scripts/post-compact.sh claude-code`.
+- Behaviour identical to the prior spec EXCEPT the imperative instruction text SHALL be sharpened. The script's stdout SHALL now direct the model that when the compact summary above lacks specific detail — exact file paths, prior decisions, concrete error messages — it MUST call `memory.context` or `memory.search` BEFORE responding. The wording SHALL make `memory.context` the canonical recovery path post-compact, not an optional suggestion.
+- Output cap: ≤120 tokens (unchanged).
+- This stdout IS injected into the model's context (unchanged — SessionStart is one of the events that carries stdout into context per Claude Code hook docs).
+
+#### UserPromptSubmit
+
+(Unchanged from the prior spec.)
+
+#### SessionEnd
+
+(Unchanged from the prior spec.)
+
+#### PreCompact
+
+- Type: `command`.
+- Matcher: none (fires on every compact).
+- Action: invoke `${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.sh`.
+- The script SHALL read `session_id`, `cwd`, `transcript_path`, and (optionally) `compaction_trigger` from hook stdin JSON.
+- The script SHALL read `${cwd}/.rembric` for `PROJECT_SLUG` using the same dotenv parser as the bridge.
+- When `session_id`, slug, and `transcript_path` all resolve AND the transcript file exists, the script SHALL format the transcript via `_transcript.sh::rembric_format_transcript_claude_code` (oldest-first `role: content`, truncated from the head at 19500 chars) and derive a title from the first non-empty assistant message via `rembric_extract_first_assistant_claude_code` (≤100 chars).
+- The script SHALL POST `${REMBRIC_SERVER_URL}/api/<slug>/sessions/<session_id>/summary` with body `{"summary":"<formatted>","title":"<derived>","final":false}`. When title derivation fails, the body SHALL omit `title`. When transcript formatting fails or `transcript_path` is missing, the script SHALL POST `{}` (degraded mode) so the row is still touched.
+- `PreCompact` stdout is NOT injected into model context (verified against `code.claude.com/docs/en/hooks` — only `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, and `Stop` carry stdout into context). The script SHALL emit no stdout.
+- The script SHALL discard the POST response, SHALL exit `0` on any error, and SHALL be mode 755.
+
+#### PostCompact
+
+- Type: `command`.
+- Matcher: none (fires on every compact after the compaction completes).
+- Action: invoke `${CLAUDE_PLUGIN_ROOT}/scripts/post-compaction.sh`.
+- The script SHALL read `session_id`, `cwd`, and `compaction_summary` from hook stdin JSON via existing and new helpers in `_api.sh`.
+- The script SHALL read `${cwd}/.rembric` for `PROJECT_SLUG`.
+- When `session_id`, slug, and `compaction_summary` all present, the script SHALL POST `${REMBRIC_SERVER_URL}/api/<slug>/sessions/<session_id>/summary` with body `{"summary":"<compaction_summary>","final":false}`. The script SHALL NOT include `title` (the compaction_summary is content, not a heading).
+- When `compaction_summary` is empty or missing on stdin, the script SHALL POST `/summary {}` (degraded mode) and emit a stderr diagnostic of the form `[rembric] PostCompact: missing compaction_summary on stdin; posting empty body`.
+- `PostCompact` stdout is NOT injected into model context. The script SHALL emit no stdout.
+- The script SHALL discard the POST response, SHALL exit `0` on any error, and SHALL be mode 755.
+
+#### Scenario: SessionStart hook with matcher compact directs the model to call memory.context when detail is missing
+
+- **WHEN** Claude Code resumes a session from auto-compaction and fires `SessionStart` with `source: 'compact'`
+- **THEN** the `post-compact.sh` script SHALL emit a multi-line instruction to stdout prefixed with `rembric:` directing the model to (1) call `memory.session_summary` with the compact summary, AND (2) call `memory.context` or `memory.search` if the compact summary lacks specific detail (file paths, prior decisions, concrete error messages) BEFORE responding to the user's pending prompt
+- **AND** the next model turn SHALL see the instruction in its context
+
+#### Scenario: PreCompact persists the transcript before context is wiped
+
+- **GIVEN** a Claude Code session at turn N, where the compactor is about to fire
+- **AND** `${cwd}/.rembric` contains `PROJECT_SLUG=foo` and `REMBRIC_SERVER_URL` is reachable
+- **WHEN** Claude Code fires the `PreCompact` hook with stdin `{"session_id": "claude-sess-abc12345", "cwd": "/home/u/foo", "transcript_path": "/path/to/transcript.jsonl"}`
+- **THEN** `pre-compact.sh` SHALL POST `/api/foo/sessions/claude-sess-abc12345/summary` with body containing `summary` = the formatted transcript (≤19500 chars) and `title` = derived from the first assistant message
+- **AND** the script SHALL emit no stdout
+
+#### Scenario: PostCompact persists the model-authored compaction summary directly
+
+- **GIVEN** the same session whose PreCompact already POSTed
+- **WHEN** Claude Code completes the compaction and fires `PostCompact` with stdin `{"session_id": "claude-sess-abc12345", "cwd": "/home/u/foo", "compaction_summary": "Worked on auth middleware. Decided on JWT. Files: src/auth.ts."}`
+- **THEN** `post-compaction.sh` SHALL POST `/api/foo/sessions/claude-sess-abc12345/summary` with body `{"summary": "Worked on auth middleware. Decided on JWT. Files: src/auth.ts.", "final": false}`
+- **AND** the server's `summary_final` precedence SHALL apply normally (if the model already wrote `final:true` via MCP, the new POST is silently no-op)
+
+#### Scenario: PostCompact with missing compaction_summary degrades silently
+
+- **WHEN** Claude Code fires `PostCompact` with stdin `{"session_id": "claude-sess-abc12345", "cwd": "/home/u/foo"}` (no `compaction_summary` key)
+- **THEN** `post-compaction.sh` SHALL POST `/summary {}` to touch the row
+- **AND** emit a stderr diagnostic naming the missing field
+- **AND** exit `0`
+
+#### Scenario: PreCompact and PostCompact stdout do not reach the model
+
+- **WHEN** either `pre-compact.sh` or `post-compaction.sh` runs to completion
+- **THEN** the script SHALL emit no stdout
+- **AND** the model's subsequent turn context SHALL NOT contain any hook output from these scripts (PreCompact and PostCompact are "side effects only" per `code.claude.com/docs/en/hooks`)
+
+#### Scenario: Hook catalog enumerates six hooks
+
+- **WHEN** `apps/plugin/hooks/hooks.json` is loaded
+- **THEN** the file declares hook entries for `SessionStart` (two matcher groups), `UserPromptSubmit`, `SessionEnd`, `PreCompact`, and `PostCompact`
+- **AND** the file SHALL NOT contain a `Stop` entry (Claude Code's `Stop` semantics are per-turn and not what we want; Codex CLI is the only client where `Stop` is wired)
+
+## MODIFIED Requirements
+
+### Requirement: The plugin SHALL ship a thin curl helper at `${CLAUDE_PLUGIN_ROOT}/scripts/_api.sh`
+
+To keep `session-start.sh`, `post-compact.sh`, `session-end.sh`, `pre-compact.sh`, and `post-compaction.sh` minimal and consistent, the plugin SHALL ship a shared helper at `apps/plugin/scripts/_api.sh` that:
+
+- Resolves `REMBRIC_SERVER_URL` and `REMBRIC_API_TOKEN` from the environment.
+- Parses `${cwd}/.rembric` for `PROJECT_SLUG` (reuses the same dotenv parser logic).
+- Exposes a function `rembric_post <path> <json-body>` that issues `curl -sf -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" --max-time 3 -d "$body" "$URL"`.
+- Exposes a function `rembric_json_escape <string>` that escapes for embedding in a JSON value.
+- Exposes functions `rembric_session_id_from_stdin_json`, `rembric_cwd_from_stdin_json`, `rembric_transcript_path_from_stdin_json`, AND a new `rembric_compaction_summary_from_stdin_json` that pulls the `compaction_summary` field from hook stdin JSON. The compaction-summary extractor SHALL prefer `compaction_summary` and SHALL fall back to `compactionSummary` (in case Codex uses camelCase, per the same precedent that `session_id`/`sessionId` already follows).
+- Discards stdout and returns `0` even on failure (so callers can `|| true` safely).
+
+The sibling helper `apps/plugin/scripts/_transcript.sh` (unchanged) exposes `rembric_format_transcript_claude_code`, `rembric_extract_first_assistant_claude_code`, `rembric_format_transcript_codex_cli`, and `rembric_extract_first_assistant_codex_cli`. The new `pre-compact.sh` consumes the Claude Code variants directly; Codex's `pre-compact.sh` execution SHALL select the codex_cli variants OR (preferred) the script SHALL detect the agent from `$1` (already conventional for `session-start.sh`) and dispatch accordingly. The contract is: `pre-compact.sh <agent>` accepts the same agent name argument as `session-start.sh`.
+
+Each hook script SHALL `source` `_api.sh` (and `_transcript.sh` where transcript handling is needed) and SHALL NOT inline the curl invocation or transcript parsing directly. The helpers SHALL respect the same "exit 0 on error" discipline as the existing scripts.
+
+#### Scenario: New helpers are sourced by the new scripts
+
+- **WHEN** `pre-compact.sh` or `post-compaction.sh` are read
+- **THEN** each SHALL start with `source "${SCRIPT_DIR}/_api.sh"` (where `SCRIPT_DIR` is the script's own directory)
+- **AND** `pre-compact.sh` SHALL also `source "${SCRIPT_DIR}/_transcript.sh"` (transcript needed)
+- **AND** neither SHALL inline a literal `curl` invocation outside the helper
+
+#### Scenario: rembric_compaction_summary_from_stdin_json accepts both naming conventions
+
+- **WHEN** the helper is called with stdin `{"compaction_summary": "X"}` (snake_case, Claude convention)
+- **THEN** it SHALL extract `X`
+
+- **WHEN** the helper is called with stdin `{"compactionSummary": "X"}` (camelCase, in case Codex differs)
+- **THEN** it SHALL extract `X`
+
+- **WHEN** the helper is called with stdin lacking both keys
+- **THEN** it SHALL emit empty string and exit `0`
+
+<!-- Token budget is a `## Section` in the canonical spec, not a `### Requirement`,
+     so it cannot be expressed as a MODIFIED Requirement delta. The output cap for
+     `post-compact.sh` declared in that section (≤120 tokens) remains the soft
+     target; the sharpened nudge stays well within the input window in practice.
+     A future change can convert "Token budget" into a proper Requirement if we
+     want it enforceable. -->
+

--- a/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/specs/codex-distribution/spec.md
+++ b/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/specs/codex-distribution/spec.md
@@ -1,0 +1,115 @@
+## MODIFIED Requirements
+
+### Requirement: Codex hook configuration
+
+The repository SHALL host Codex hook configuration at `apps/plugin/hooks/hooks.codex.json`, sibling to the Claude Code plugin's `apps/plugin/hooks/hooks.json`, declaring the FIVE Codex-supported events the plugin wires.
+
+Codex's hook surface differs from Claude Code's in ways the platform forces:
+
+- Codex has no `SessionEnd` event (verified against `developers.openai.com/codex/plugins/hooks` AND the upstream source `codex-rs/hooks/src/engine/output_parser.rs` which lacks a `parse_session_end`).
+- Codex's `SessionStart` matcher does not include `"compact"` — only `startup|resume|clear`.
+- Codex's `Stop` hook REQUIRES JSON on stdout: "Stop expects JSON on stdout when it exits 0. Plain text output is invalid for this event." Per official docs.
+- **Codex DOES support `PreCompact` and `PostCompact`** — verified against the upstream source `codex-rs/hooks/src/engine/output_parser.rs::parse_pre_compact` and `::parse_post_compact`. The public docs at `developers.openai.com/codex/plugins/hooks` do not document these events (incomplete docs), but the source is authoritative. This corrects the prior spec's claim "Codex has no PreCompact or PostCompact event", which was authored against the partial public docs.
+
+Therefore Codex's mapping of lifecycle events to HTTP endpoints diverges from Claude Code's by necessity (no SessionEnd), NOT by choice. Codex sessions stay `active` until the `abandonStale` job flips them to `abandoned`; this is the steady state for Codex sessions.
+
+#### Scenario: Hook event coverage
+
+- **WHEN** `apps/plugin/hooks/hooks.codex.json` is loaded
+- **THEN** the `hooks` object SHALL declare entries for `SessionStart`, `UserPromptSubmit`, `Stop`, `PreCompact`, and `PostCompact` (five events)
+- **AND** the `hooks` object SHALL NOT contain `SessionEnd` (Codex does not support this event)
+- **AND** every hook entry SHALL be `type: "command"` — Codex does not support `type: "mcp_tool"` for hooks
+- **AND** the `SessionStart` hook SHALL invoke `${CLAUDE_PLUGIN_ROOT}/scripts/session-start.sh codex-cli` (reused from the Claude Code plugin; the `agent` arg differs)
+- **AND** the `UserPromptSubmit` hook SHALL declare the matcher `remember|recall|acordate|qué hicimos|what did we do` and invoke `${CLAUDE_PLUGIN_ROOT}/scripts/prompt-search.sh` (reused)
+- **AND** the `PreCompact` hook SHALL invoke `${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.sh codex-cli` (reused from the Claude Code plugin; the agent arg selects the codex_cli variant of the transcript helpers)
+- **AND** the `PostCompact` hook SHALL invoke `${CLAUDE_PLUGIN_ROOT}/scripts/post-compaction.sh` (reused; the script does not need an agent argument because `compaction_summary` is the same field across clients)
+
+#### Scenario: Codex Stop wires to a per-turn summary writer
+
+- **WHEN** the `Stop` hook fires (which it does once per agent turn under Codex semantics)
+- **THEN** the hook SHALL invoke `${CLAUDE_PLUGIN_ROOT}/scripts/session-stop.sh codex-cli` (Codex-only — Claude Code does NOT wire `Stop` in this version)
+- **AND** the script SHALL read `session_id`, `cwd`, and `transcript_path` from stdin
+- **AND** SHALL read `${cwd}/.rembric` for the slug
+- **AND** SHALL read `transcript_path` if readable, format it via `_transcript.sh`, derive a title from the first non-empty assistant message (≤100 chars)
+- **AND** SHALL POST `${REMBRIC_SERVER_URL}/api/<slug>/sessions/<session_id>/summary` with body `{"summary": "<formatted>", "title": "<derived>", "final": false}` — note: `/summary` NOT `/end`, because Codex Stop is per-turn and the session must stay `active` for the next turn to keep updating
+- **AND** SHALL emit `'{}'` to stdout (Codex requires JSON on Stop stdout; plain text is invalid per docs)
+- **AND** SHALL exit zero even on internal error
+
+#### Scenario: Codex PreCompact persists the transcript before context is wiped
+
+- **GIVEN** a Codex session and `${cwd}/.rembric` containing `PROJECT_SLUG=foo`
+- **WHEN** Codex fires the `PreCompact` hook with stdin containing `session_id`/`sessionId`, `cwd`, and `transcript_path` (exact key names verified during implementation against `codex-rs/hooks/src/schema.rs`)
+- **THEN** `pre-compact.sh codex-cli` SHALL POST `/api/foo/sessions/<id>/summary` with the formatted transcript using the `codex_cli` variant of the `_transcript.sh` helpers
+- **AND** the script SHALL emit no stdout (Codex's `PreCompact` stdout contract permits empty output)
+
+#### Scenario: Codex PostCompact persists the model-authored compaction summary
+
+- **WHEN** Codex completes a compaction and fires `PostCompact` with stdin containing `session_id`/`sessionId`, `cwd`, and `compaction_summary` (or `compactionSummary` — the shared helper handles both via the fallback path)
+- **THEN** `post-compaction.sh` SHALL POST `/api/<slug>/sessions/<id>/summary` with body `{"summary": "<compaction_summary>", "final": false}`
+- **AND** the script SHALL emit no stdout
+
+#### Scenario: Codex sessions remain active until abandoned by sweep
+
+- **GIVEN** a Codex session where Stop has fired N times and PreCompact/PostCompact may have fired
+- **WHEN** the user closes Codex CLI
+- **THEN** the session row SHALL remain `status='active'` (no SessionEnd signal to transition it)
+- **AND** the `abandonStale` job (running per `SESSION_ABANDON_AFTER_MS`, default 24h) SHALL eventually flip the row to `status='abandoned'`
+- **AND** the row's `summary` and `title` SHALL reflect whichever was most recent: Stop's per-turn POST, PreCompact's transcript snapshot, or PostCompact's compaction_summary
+
+#### Scenario: pre-compact-codex.sh deletion remains in effect
+
+- **WHEN** the repository is at HEAD after this change
+- **THEN** the file `apps/plugin/scripts/pre-compact-codex.sh` SHALL NOT exist (it was removed by an earlier change and stays removed)
+- **AND** `apps/plugin/scripts/pre-compact.sh` SHALL exist as the SHARED script consumed by both `hooks.json` and `hooks.codex.json` (per the `shared-plugin-logic` doctrine)
+
+## MODIFIED Requirements
+
+### Requirement: Codex hooks MUST receive `session_id` from stdin in the same JSON shape as Claude Code
+
+The shared scripts `session-start.sh`, `session-stop.sh`, `pre-compact.sh`, and `post-compaction.sh` SHALL read the hook stdin as a JSON object containing a `session_id` field (and `cwd` when relevant). Claude Code and Codex CLI both pass the host-session id in stdin JSON for `command`-type hooks.
+
+If Codex passes the id under a different key (e.g. `sessionId`), the scripts SHALL prefer `session_id` and SHALL fall back to `sessionId` so the same script supports both clients without per-client forks. When neither field is present the scripts SHALL skip the HTTP call and exit `0`.
+
+`post-compaction.sh` additionally reads `compaction_summary` and SHALL apply the same naming-fallback discipline (`compaction_summary` then `compactionSummary`) — the contract MUST stay symmetric with how `session_id`/`sessionId` is handled today, so no per-client forks accrue.
+
+#### Scenario: Script reads stdin in both shapes
+
+- **WHEN** the script receives stdin `{"session_id": "x"}` (Claude shape)
+- **THEN** it SHALL extract `x` as the session id
+
+- **WHEN** the script receives stdin `{"sessionId": "x"}` (Codex shape, if it differs)
+- **THEN** it SHALL extract `x` as the session id
+
+- **WHEN** the script receives stdin with neither field
+- **THEN** it SHALL skip the HTTP call, emit a stderr diagnostic, and exit `0`
+
+#### Scenario: post-compaction.sh reads compaction_summary in both shapes
+
+- **WHEN** `post-compaction.sh` receives stdin `{"compaction_summary": "..."}` (Claude shape)
+- **THEN** it SHALL extract the value as the summary text
+
+- **WHEN** the script receives stdin `{"compactionSummary": "..."}` (Codex shape, if different)
+- **THEN** it SHALL extract the value as the summary text
+
+- **WHEN** the script receives stdin with neither field
+- **THEN** it SHALL POST `/summary {}`, emit a stderr diagnostic, and exit `0`
+
+#### Scenario: Codex session id format may differ from Claude's
+
+(Unchanged from the prior spec — the regex `^[A-Za-z0-9_-]{8,128}$` continues to accept all Codex id shapes seen to date.)
+
+## MODIFIED Requirements
+
+### Requirement: `docs/agents.md` recommends the plugin install as primary
+
+The Codex section of `docs/agents.md` SHALL recommend the marketplace plugin install as the primary path, document the credential flow, document the platform-required enablement steps for plugin hooks (which Codex gates behind an under-development feature flag and a per-hook trust review as of `codex-cli 0.130.0`), and retain a manual `config.toml` fallback for users who do not want the plugin. The "trust each of the N plugin-bundled hooks" guidance SHALL be updated to enumerate the now-FIVE hooks (`SessionStart`, `UserPromptSubmit`, `Stop`, `PreCompact`, `PostCompact`) — superseding the previous "4 plugin-bundled hooks" wording.
+
+#### Scenario: Platform-required hook enablement enumerates five hooks
+
+- **WHEN** a reader follows the Codex install flow in `docs/agents.md`
+- **THEN** the doc SHALL document, after the install + env-var snippets, that two additional platform-required steps are necessary to make plugin-bundled hooks fire under `codex-cli 0.130.0`:
+  - **Step 1**: enable the `plugin_hooks` feature with `codex features enable plugin_hooks`. The doc SHALL note that this feature is currently `under development` in Codex (default off) and that future Codex releases may default it on — readers should run `codex features list` to confirm before assuming.
+  - **Step 2**: open `/hooks` inside Codex and trust each of the 5 plugin-bundled hooks (`SessionStart`, `UserPromptSubmit`, `Stop`, `PreCompact`, `PostCompact`). Codex surfaces a startup banner of the form _"N hooks need review before they can run. Open `/hooks` to review them."_ — until each hook is trusted, it loads but does not execute.
+- **AND** the doc SHALL note that the trust persists in `~/.codex/config.toml`'s `[hooks.state]` block; users do not need to re-approve hooks after every Codex restart, only once per hook handler.
+
+(Other scenarios within this requirement remain unchanged.)

--- a/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/specs/hermes-agent-plugin/spec.md
+++ b/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/specs/hermes-agent-plugin/spec.md
@@ -1,0 +1,82 @@
+## MODIFIED Requirements
+
+### Requirement: Provider lifecycle method behavior
+
+`RembricMemoryProvider` SHALL implement the `MemoryProvider` ABC with these behaviors:
+
+- `name` returns `"rembric"`.
+- `is_available` performs `GET ${REMBRIC_SERVER_URL}/healthz` with `Authorization: Bearer ${REMBRIC_API_TOKEN}` and a 2-second timeout, returning `True` only on HTTP 200. It SHALL return `False` if `REMBRIC_SERVER_URL` or `REMBRIC_API_TOKEN` are unset, or if the request fails for any reason (including HTTP 401 when the token is invalid and HTTP 503 when the server's database is unavailable).
+- `initialize(session_id, **kwargs)` SHALL:
+  - Resolve the project slug via the cascade defined in "Slug resolution cascade".
+  - When a valid slug is resolved, `POST ${REMBRIC_SERVER_URL}/api/<slug>/sessions` with `Authorization: Bearer ${REMBRIC_API_TOKEN}`, `Content-Type: application/json`, and body `{"id": session_id, "cwd": kwargs.get("cwd", os.getcwd()), "agent": "hermes"}`. Timeout 3 seconds. Discard response body. The server writes the placeholder title.
+  - When no slug is resolvable, skip the POST and log a single-line stderr diagnostic of the form `[rembric] no project slug for session <session_id>; skipping session POST`. The provider SHALL still register; subsequent lifecycle calls SHALL silently skip their HTTP work.
+  - Cache the resolved slug, session id, and cwd on the provider instance; subsequent lifecycle calls within the same session SHALL NOT re-resolve.
+- `on_pre_compress(messages, **kwargs)` SHALL, if a slug and session id were cached at `initialize`, build a textual transcript from `messages` via `_format_transcript(messages)` (oldest-first `role: content` lines, truncated from the head if the result exceeds 19,500 characters), and `POST /api/<slug>/sessions/<session_id>/summary` with body `{"summary": <transcript>, "final": false}`. The provider SHALL NOT include `title` in this POST — title derivation is reserved for `on_session_end` and the server-side placeholder. Timeout 3 seconds. Failures are silent stderr diagnostics. The provider SHALL NOT mutate the `messages` argument. The provider's return value SHALL be `""` (empty string — the docstring promises it goes into the compressor prompt; we contribute nothing yet).
+- `on_session_end(messages, **kwargs)` SHALL, if a slug and session id were cached, build a transcript via `_format_transcript(messages)`, derive a title from the first non-empty assistant message in `messages` (truncated to 100 chars; falling back to empty string if no assistant message exists), and `POST /api/<slug>/sessions/<session_id>/end` with body `{"summary": <transcript>, "title": <derived_title>, "final": false}`. When the transcript is empty (no messages), the body SHALL be `{}` (degraded end). Timeout 3 seconds. Failures are silent stderr diagnostics. The provider SHALL NOT call `memory.session_end` over MCP.
+- `on_session_switch(new_session_id, *, parent_session_id="", reset=False, **kwargs)` SHALL override per the "Provider MUST override on_session_switch" requirement.
+- `get_tool_schemas` SHALL return `[]`. The provider contributes no agent-callable tools.
+- `handle_tool_call(name, args)` SHALL return `json.dumps({"error": "unknown_tool", "hint": "register the rembric MCP bridge in mcp_servers.rembric to access memory tools"})`.
+- `system_prompt_block` SHALL return a single-paragraph block (**≤300 chars**) directing the agent to (a) call `memory.session_summary({title, summary})` before declaring work done — title ≤100 chars descriptive of what was actually worked on; summary follows Goal · Discoveries · Accomplished · Next Steps · Files — AND (b) call `memory.context` after any compaction event when the compact summary lacks detail (file paths, specific decisions, errors). This is the Hermes-side counterpart to Claude/Codex's `initialize.instructions` nudge, which now also carries the memory.context post-compact recovery guidance for symmetry.
+- `prefetch(query, **kwargs)` SHALL return `""`.
+- `queue_prefetch(query, **kwargs)` SHALL be a no-op (return `None`).
+- `sync_turn(user, assistant, **kwargs)` SHALL be a no-op.
+- `on_memory_write(action, target, content, **kwargs)` SHALL be a no-op.
+- `shutdown(**kwargs)` SHALL be a no-op.
+
+The provider SHALL NOT implement `get_config_schema` or `save_config`. Credentials live in `~/.hermes/.env`. The provider SHALL NOT preload any plugin-specific dotenv file.
+
+#### Scenario: is_available with both envs set and a healthy server returns True
+
+(Unchanged from the prior spec.)
+
+#### Scenario: is_available with a missing token returns False without making a request
+
+(Unchanged from the prior spec.)
+
+#### Scenario: is_available with an invalid token returns False
+
+(Unchanged from the prior spec.)
+
+#### Scenario: is_available with the server's database unavailable returns False
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Session initialize POSTs to the sessions endpoint with agent: hermes
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Pre-compress posts a transcript summary
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Session end posts to the end endpoint with summary and derived title
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Session end with empty messages degrades to `{}`
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Session end when model already wrote a final summary
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Lifecycle calls without a resolved slug skip silently
+
+(Unchanged from the prior spec.)
+
+#### Scenario: system_prompt_block emits the session-close protocol AND memory.context post-compact guidance
+
+- **WHEN** Hermes calls `provider.system_prompt_block()`
+- **THEN** the returned string SHALL be non-empty and SHALL contain the substring `memory.session_summary`
+- **AND** SHALL contain a reference to `title` and the structure `Goal · Discoveries · Accomplished · Next Steps · Files`
+- **AND** SHALL contain the substring `memory.context` (new — post-compact recovery guidance)
+- **AND** SHALL be ≤300 chars total (unchanged cap — the new content MUST fit within the existing cap, requiring concise phrasing)
+
+#### Scenario: handle_tool_call returns a defensive error
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Provider does not manage credential storage
+
+(Unchanged from the prior spec.)

--- a/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/specs/mcp-api/spec.md
+++ b/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/specs/mcp-api/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: The MCP `initialize` response MUST ship a protocol-teaching `instructions` block
+
+When the MCP server is constructed, its `instructions` field SHALL be populated with a scope-aware string that teaches the agent when to call each tool. The string SHALL be 800 characters or fewer.
+
+The instructions SHALL include:
+
+1. The session-close protocol sentence directing the agent to call `memory.session_summary({title, summary})` before declaring work "done". The sentence SHALL describe the title constraint (≤100 chars, descriptive of what was actually worked on — NOT the cwd, NOT generic) and the summary structure (Goal · Discoveries · Accomplished · Next Steps · Files).
+2. **The post-compact recovery clause (new)** — a short instruction directing the agent that after any compaction event, when the compacted summary lacks specific detail (exact file paths, prior decisions, concrete error messages), it MUST call `memory.context` (or `memory.search` for keyword lookup) BEFORE responding to the user's pending prompt. The phrasing SHALL stay concise (≤60 chars of new content) so the total stays under the 800-char cap.
+
+#### Scenario: An MCP client connects on `/mcp/<slug>`
+
+- **WHEN** the `initialize` handshake completes against `/mcp/my-project`
+- **THEN** the `InitializeResult.instructions` SHALL contain references to `memory.save`, `memory.search`, `memory.session_summary`, AND `memory.context` (the new post-compact recovery clause) plus a note indicating the connection is project-scoped to `'my-project'` and that `scope='global'` will be rejected
+- **AND** the instructions SHALL contain the substring `memory.session_summary` and the substring `title` and a reference to "before" (referring to before declaring done)
+- **AND** the instructions SHALL contain the substring `memory.context` (the new post-compact recovery clause)
+
+#### Scenario: An MCP client connects on `/mcp` without a project
+
+- **WHEN** the `initialize` handshake completes against `/mcp`
+- **THEN** the `InitializeResult.instructions` SHALL contain the same protocol triggers (including the session-close protocol sentence AND the memory.context post-compact recovery clause) and a note indicating the connection is global-scope and that project memories require opening `/mcp/<slug>` or sending `X-Rembric-Project`
+
+#### Scenario: Instructions length is checked at build time
+
+- **WHEN** the test suite runs against both `/mcp` and `/mcp/<slug>` variants of `buildInstructions(ctx)`
+- **THEN** both outputs SHALL be 800 characters or fewer (unchanged cap — the new clause MUST fit within the existing budget)
+
+#### Scenario: A client that does not consume `instructions` connects
+
+- **WHEN** an MCP client ignores the `instructions` field
+- **THEN** every tool SHALL still function normally (the field is informational only)
+
+#### Scenario: instructions.test.ts asserts the new memory.context clause is present
+
+- **WHEN** `apps/server/src/mcp/instructions.test.ts` runs against `buildInstructions({requestedSlug: 'demo'})` and `buildInstructions({requestedSlug: null})`
+- **THEN** both outputs SHALL contain the substring `memory.context`
+- **AND** both outputs SHALL be ≤800 chars
+- **AND** existing assertions for `memory.session_summary`, `memory.save`, `memory.search`, scope notes, etc. SHALL continue to pass

--- a/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/specs/opencode-plugin/spec.md
+++ b/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/specs/opencode-plugin/spec.md
@@ -1,0 +1,156 @@
+## MODIFIED Requirements
+
+### Requirement: Event handler set
+
+The plugin module's returned object SHALL declare exactly the following event handler properties, no more and no fewer:
+
+1. `event: async ({ event }) => ...` — a dispatcher that switches on `event.type` for `"session.created"`, `"session.deleted"`, `"server.instance.disposed"`, AND `"session.compacted"`. Any other `event.type` values SHALL be silently ignored. (Adds `session.compacted` to the previously documented three.)
+2. `"chat.message": async (input, output) => ...` — appends a `{role:'user', text}` entry to the per-session transcript accumulator (`sessionMessages` Map) AND, when the user text matches the recall regex `/remember|recall|acordate|qué hicimos|what did we do/i`, appends a recall-nudge entry to `output.parts`. The handler SHALL NOT POST any HTTP request from either branch.
+3. `"message.updated": async (input, output) => ...` — appends or replaces a `{role:'assistant', text}` entry keyed by `output.message.id` in `sessionMessages`. The handler SHALL NOT POST any HTTP request, and SHALL be a no-op for messages whose role is not `'assistant'`.
+4. `"session.idle": async (input) => ...` — schedules a debounced summary flush for `input.sessionID`. PRIMARY mechanism for delivering transcript-to-server during the session. See `Session.idle handler (periodic flush)`.
+5. `"experimental.session.compacting": async (input, output) => ...` — post-compaction reminder injection (with the `memory.context` clause added — see modified requirement below).
+
+The plugin SHALL NOT register `"tool.execute.after"`. The corresponding `/api/<slug>/observations/passive` endpoint does not exist on Rembric's HTTP API; the handler has no work to do.
+
+The plugin SHALL NOT register `experimental.chat.system.transform` (no system-prompt injection). The plugin SHALL NOT register `tool.execute.before` (no tool guards). The plugin SHALL NOT register `permission.asked` or `permission.replied`.
+
+If Plan B of the cwd spike applies (see "cwd spike" requirement), the plugin SHALL additionally register `"shell.env": async (input, output) => { output.env.REMBRIC_PROJECT_DIR = ctx.directory }`. The hook SHALL be omitted otherwise.
+
+The `chat.message` and `message.updated` handlers MUST treat the `sessionMessages` Map as their only state side effect — appending to `output.parts` in `chat.message` is permitted but is also non-HTTP. An invariant test (`apps/server/src/test/invariants.test.ts`) SHALL fail the build if either handler invokes `rembricPost`, `fetch`, or any other HTTP work.
+
+#### Scenario: Handler set is exactly the documented set
+
+- **WHEN** the resolved value of `RembricPlugin(ctx)` is inspected
+- **THEN** its own enumerable keys are exactly `["event", "chat.message", "message.updated", "session.idle", "experimental.session.compacting"]` plus `"shell.env"` if Plan B is active
+- **AND** no other keys exist
+
+#### Scenario: event dispatcher handles session.compacted
+
+- **WHEN** opencode fires `event.type === "session.compacted"` with `event.properties.sessionID = "s1"` (or equivalent payload — verified at implementation time against opencode's event schema)
+- **THEN** the dispatcher's branch SHALL extract the session id
+- **AND** SHALL await `flushSessionSummary(sessionId)` (reusing the same helper used by `session.idle`)
+- **AND** SHALL skip the call if the id is in `subAgentSessions` or absent from `knownSessions`
+- **AND** SHALL emit one stderr diagnostic of the form `[rembric] session.compacted sessionId=<id>` for observability paridad with the existing diagnostic discipline
+
+## ADDED Requirements
+
+### Requirement: Session.compacted handler flushes the accumulator at the compaction milestone
+
+The `event` dispatcher SHALL handle `event.type === "session.compacted"` as the third opencode event (alongside `session.idle` and `server.instance.disposed`) that triggers a summary flush. Its purpose is to persist the rolling transcript at the moment opencode signals a compaction has completed.
+
+The handler SHALL:
+
+1. Extract the session id from `event.properties.sessionID` (or `event.properties.info.id` as a fallback, mirroring the existing `session.created` extraction pattern). If the id is empty, the handler SHALL return.
+2. Skip if the id is in `subAgentSessions`. Skip if the id is NOT in `knownSessions` (we only flush sessions whose row was already registered).
+3. Emit one stderr diagnostic of the form `[rembric] session.compacted sessionId=<id>`.
+4. Await `flushSessionSummary(sessionId)` — the same helper used by `session.idle`. This builds the body via `buildSummaryBody(sessionId)` (joining the accumulator entries as `<role>: <text>` lines, truncating from the head at 19500 chars) and POSTs to `/api/<slug>/sessions/<id>/summary` with `final:false`.
+
+The handler SHALL NOT reset, clear, or otherwise mutate `sessionMessages` for the affected session id. opencode's `session.compacted` is a notification event, not a content-delivery event — the in-memory accumulator persists across the compaction, so subsequent `session.idle` events MAY continue to flush a transcript that includes both pre-compact and post-compact turns.
+
+opencode's `session.compacted` event does NOT deliver the model-authored compaction summary payload. The handler SHALL NOT attempt to extract one from the event. The PRIMARY signal we persist at this milestone is the in-memory accumulator's rolling transcript — the same content that `session.idle` would flush, just triggered by the explicit compaction event for milestone clarity.
+
+#### Scenario: session.compacted flushes for a known top-level session
+
+- **GIVEN** `knownSessions` contains `"s1"`, `sessionMessages.get("s1")` contains turns
+- **WHEN** the dispatcher receives an event with `type === "session.compacted"` and a sessionID resolving to `"s1"`
+- **THEN** the handler SHALL emit one stderr diagnostic naming the id
+- **AND** SHALL await `flushSessionSummary("s1")` exactly once
+- **AND** SHALL NOT mutate `sessionMessages.get("s1")`
+
+#### Scenario: session.compacted is a no-op for sub-agent sessions
+
+- **GIVEN** `subAgentSessions` contains `"sub-1"`
+- **WHEN** the dispatcher receives a session.compacted event for `"sub-1"`
+- **THEN** the handler SHALL NOT call `flushSessionSummary`
+- **AND** SHALL NOT emit the standard diagnostic (the sub-agent skip is silent, matching the existing pattern for sub-agent filtering in other handlers)
+
+#### Scenario: session.compacted is a no-op for unknown sessions
+
+- **GIVEN** `knownSessions` does NOT contain `"s99"`
+- **WHEN** the dispatcher receives a session.compacted event for `"s99"`
+- **THEN** the handler SHALL NOT call `flushSessionSummary` (we only flush sessions whose row was previously registered)
+
+## MODIFIED Requirements
+
+### Requirement: Chat.message handler accumulates user transcript
+
+The `"chat.message"` handler SHALL:
+
+1. Return immediately if `input.sessionID` is in `subAgentSessions`.
+2. Extract text from `output.parts` filtering `part.type === "text"`, joining with newlines, and trimming. If empty, fall back to `output.message.summary.title + "\n" + output.message.summary.body` if available.
+3. If the resulting text is empty, return without mutating state.
+4. Otherwise append `{role: 'user', text: <stripped+truncated>}` to `sessionMessages.get(input.sessionID)` (creating the array if it does not exist).
+5. The handler SHALL pass the text through a `stripPrivateTags` helper that replaces `<private>...</private>` blocks (case-insensitive, multiline) with `[REDACTED]`. The handler SHALL truncate each entry to 2000 characters with a `"..."` suffix if longer.
+6. The accumulator MUST cap each session's array at 200 entries. If the array reaches the cap, the oldest entry is shifted out (FIFO) before the new entry is appended. This protects against unbounded memory growth in long sessions.
+7. **Recall nudge (new):** AFTER appending to the accumulator, the handler SHALL test the un-truncated user text against the case-insensitive regex `/remember|recall|acordate|qué hicimos|what did we do/i`. When the regex matches, the handler SHALL append `{type: "text", text: "rembric: User intent: recall. Call memory.search with the user keywords before responding."}` to `output.parts`. The appended nudge string SHALL be byte-identical to the stdout emitted by `apps/plugin/scripts/prompt-search.sh` (the shared `UserPromptSubmit` regex hook used by Claude Code and Codex CLI), preserving cross-client paridad.
+
+The handler SHALL NOT POST any HTTP request from either the accumulator branch or the recall-nudge branch. The accumulated data flows out only via the `session.idle`, `session.compacted`, and `server.instance.disposed` flush paths.
+
+The recall regex SHALL NOT be evaluated against sub-agent sessions (rule 1's early return covers this — the regex check happens AFTER the sub-agent skip).
+
+#### Scenario: User text accumulates
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Private tags are redacted before accumulation
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Sub-agent prompts are skipped
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Accumulator caps at 200 entries
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Recall regex matches inject a nudge into output.parts
+
+- **GIVEN** a top-level session "s1"
+- **WHEN** `chat.message` fires with user text containing `"acordate cuando hicimos la auth?"`
+- **THEN** the handler SHALL append the user text to `sessionMessages.get("s1")` as usual
+- **AND** SHALL also append `{type: "text", text: "rembric: User intent: recall. Call memory.search with the user keywords before responding."}` to `output.parts`
+- **AND** SHALL NOT POST any HTTP request
+
+#### Scenario: Recall regex does NOT match — no nudge appended
+
+- **WHEN** `chat.message` fires with user text `"please write a unit test for src/auth.ts"`
+- **THEN** the handler SHALL append the user text to `sessionMessages.get("s1")`
+- **AND** SHALL NOT append any new entry to `output.parts`
+
+#### Scenario: Recall regex is case-insensitive and matches multiple keywords
+
+- **WHEN** `chat.message` fires with user text `"What did we do yesterday?"`, `"Remember the bug we fixed"`, or `"qué hicimos con la migración?"`
+- **THEN** in all three cases the handler SHALL append the recall nudge to `output.parts`
+
+#### Scenario: Recall regex check applies AFTER private-tag stripping
+
+- **WHEN** `chat.message` fires with user text `"<private>recall</private> nothing here"`
+- **THEN** the accumulator receives `"[REDACTED] nothing here"` (private tags redacted)
+- **AND** the regex SHALL be evaluated against the ORIGINAL un-redacted text (so `recall` still triggers the nudge) — rationale: the user's intent to recall is private content but the agent should still receive the nudge to act on it
+
+## MODIFIED Requirements
+
+### Requirement: Experimental.session.compacting handler
+
+The `"experimental.session.compacting"` handler SHALL:
+
+1. If `input.sessionID` is present, call `ensureSession(input.sessionID)`.
+2. Push a single string onto `output.context` (the array opencode's compactor consumes) instructing the compactor that the next agent MUST call `memory.session_summary` immediately with the compacted summary content, preserving what was done before compaction. The instruction text SHALL be a single multi-line string ending with a sentence stating that without this step everything before compaction is lost from memory. The text SHALL name the project slug when one was resolved. **The text SHALL ALSO include a final sentence directing the post-compact agent to call `memory.context` if it needs detail beyond the compact summary (file paths, decisions, specific errors not in the compacted block).**
+
+The handler SHALL NOT mutate `input.context` or `input.messages` directly. All effects SHALL be expressed as appends to `output.context`.
+
+The handler SHALL NOT GET any `/context` or recall-context endpoint in v1 — no such endpoint exists on the HTTP API today. When the corresponding endpoint ships in a future OpenSpec change, the handler MAY be extended to prepend a server-returned recall block before the reminder; that prepend SHALL fail silently on any error and the reminder string (including the memory.context guidance) SHALL remain the last (always-present) entry.
+
+#### Scenario: Reminder includes memory.session_summary AND memory.context guidance
+
+- **WHEN** `experimental.session.compacting` fires with a valid `input.sessionID`
+- **THEN** `ensureSession` runs (POST `/api/<slug>/sessions` once)
+- **AND** exactly ONE string is pushed to `output.context`
+- **AND** that string contains the substring `memory.session_summary`
+- **AND** that string contains the substring `memory.context` (new requirement — the post-compact recovery path)
+- **AND** that string contains the project slug when one was resolved from `.rembric`
+
+#### Scenario: Compacting fires without sessionID
+
+(Unchanged from the prior spec.)

--- a/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/tasks.md
+++ b/openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/tasks.md
@@ -1,0 +1,59 @@
+## 1. Shared scripts (Claude Code + Codex CLI)
+
+- [x] 1.1 Create `apps/plugin/scripts/pre-compact.sh`. Source `_api.sh` and `_transcript.sh`. Read `session_id`, `cwd`, `transcript_path` from stdin JSON via existing helpers. Resolve slug via `rembric_read_project_slug "$CWD"`. If both session_id and slug resolve AND `transcript_path` exists, format the transcript via `rembric_format_transcript_claude_code` and derive a title from the first non-empty assistant message via `rembric_extract_first_assistant_claude_code`. POST `/api/<slug>/sessions/<session_id>/summary` with `{"summary":"...", "title":"...", "final":false}` (omit title if derivation failed). Exit `0` on any error. NO stdout (not context-injected). Mode 755.
+- [x] 1.2 Create `apps/plugin/scripts/post-compaction.sh`. Source `_api.sh`. Read `session_id`, `cwd`, and `compaction_summary` from stdin JSON. Add a new helper to `_api.sh`: `rembric_compaction_summary_from_stdin_json` (mirror of the existing session_id/cwd extractors). Resolve slug. If session_id, slug, and compaction_summary all present, POST `/api/<slug>/sessions/<session_id>/summary` with `{"summary":"<compaction_summary>","final":false}`. If `compaction_summary` is empty/missing, POST `/summary {}` and write a stderr diagnostic. Exit `0` on any error. NO stdout. Mode 755.
+- [x] 1.3 Verify Codex `PreCompact` stdin shape: read `codex-rs/hooks/src/engine/output_parser.rs::parse_pre_compact` (`PreCompactCommandOutputWire`) AND `codex-rs/hooks/src/schema.rs` for the **input** (stdin) wire shape. Confirm fields `session_id` (or `sessionId`), `cwd`, `transcript_path`, `compaction_trigger`. Document any divergence from Claude Code in a stderr diagnostic comment at the top of `pre-compact.sh`.
+- [x] 1.4 Verify Codex `PostCompact` stdin shape: same procedure for `parse_post_compact` and confirm `compaction_summary` field name. Document any divergence in `post-compaction.sh`.
+
+## 2. Claude Code hook wiring
+
+- [x] 2.1 Edit `apps/plugin/hooks/hooks.json`. Add a `PreCompact` entry (`type: command`, command invokes `pre-compact.sh` with the `REMBRIC_SERVER_URL`/`REMBRIC_API_TOKEN` env prefix like the existing entries) and a `PostCompact` entry (same shape, invokes `post-compaction.sh`). Neither needs a matcher — both fire on every compact.
+- [x] 2.2 Sharpen the nudge in `apps/plugin/scripts/post-compact.sh` (the existing SessionStart compact script — NOT to be confused with the new `post-compaction.sh`). Replace the current point 2 "Si necesitás más contexto: memory.context" with a stronger imperative form: "Si el summary que ves arriba no contiene el detalle que necesitás (file paths exactos, decisiones técnicas concretas, errores específicos previos), llamá memory.context o memory.search ANTES de responder." Stay under the existing 120-token output cap.
+
+## 3. Codex CLI hook wiring
+
+- [x] 3.1 Edit `apps/plugin/hooks/hooks.codex.json`. Add a `PreCompact` entry invoking the shared `pre-compact.sh` (NO `REMBRIC_SERVER_URL`/`REMBRIC_API_TOKEN` prefix — Codex forwards those via `env_vars` per the codex-distribution spec). Add a `PostCompact` entry invoking the shared `post-compaction.sh`.
+
+## 4. opencode plugin changes
+
+- [x] 4.1 In `apps/plugin/.opencode-plugin/plugin.ts`, extend the `event` dispatcher to handle `event.type === "session.compacted"`. Extract `sessionID` from `event.properties` (or fall back to `props.info.id`). If the id is in `subAgentSessions` or not in `knownSessions`, return. Otherwise, await `flushSessionSummary(sessionId)` (reusing the existing helper). Add a stderr diagnostic `[rembric] session.compacted sessionId=<id>` for observability parity with the existing diagnostics.
+- [x] 4.2 In the same file's `chat.message` handler, detect when the extracted user text matches `/remember|recall|acordate|qué hicimos|what did we do/i`. When it matches, append a `{type: "text", text: "rembric: User intent: recall. Call memory.search with the user keywords before responding."}` entry to `output.parts`. Behaviour parallels the Claude Code `UserPromptSubmit` regex; the nudge string is verbatim from `apps/plugin/scripts/prompt-search.sh:7`.
+- [x] 4.3 In the same file's `experimental.session.compacting` handler, extend the existing pushed string to include a final sentence directing the agent to call `memory.context` if specific detail from before compaction is needed. Stay within reasonable token budget (the string is already ~250 tokens; add ≤40 more).
+- [x] 4.4 Add tests in `apps/plugin/.opencode-plugin/plugin.test.ts`:
+  - `session.compacted` handler flushes the accumulator (mock `flushSessionSummary` and assert called once with the sessionID).
+  - `session.compacted` handler skips sub-agent sessions.
+  - `chat.message` handler appends the recall nudge when the regex matches (3-4 cases covering different keywords).
+  - `chat.message` handler does NOT append the nudge when the regex does not match.
+  - `experimental.session.compacting` handler includes the new `memory.context` substring.
+
+## 5. Hermes plugin changes
+
+- [x] 5.1 Edit `apps/plugin/.hermes-plugin/__init__.py::RembricMemoryProvider.system_prompt_block`. Extend the returned string to include guidance about calling `memory.context` when fine detail is needed after a compaction event. STAY UNDER the 300-char cap mandated by the `hermes-agent-plugin` spec ("system_prompt_block SHALL return a single-paragraph block (≤300 chars)").
+- [x] 5.2 Add a test under `apps/plugin/.hermes-plugin/tests/` asserting the new substring is present and the total length is ≤300 chars.
+
+## 6. MCP initialize.instructions tweak
+
+- [x] 6.1 Edit `apps/server/src/mcp/instructions.ts`. Add a short clause to the existing instructions block guiding post-compact agents to call `memory.context` when the compacted summary lacks needed detail. Maximum 60 chars of new content. The line MUST fit within the existing 800-char cap.
+- [x] 6.2 Update `apps/server/src/mcp/instructions.test.ts` to assert (a) the new substring is present, (b) the 800-char cap is still respected, (c) the existing assertion set still passes.
+
+## 7. Spec sync
+
+- [x] 7.1 Verify the proposal's "Modified Capabilities" list matches the spec delta files in `openspec/changes/expand-plugin-hooks-coverage/specs/`. There SHALL be 5 delta files: `claude-code-plugin/spec.md`, `codex-distribution/spec.md`, `opencode-plugin/spec.md`, `hermes-agent-plugin/spec.md`, `mcp-api/spec.md`.
+- [x] 7.2 Run `openspec validate expand-plugin-hooks-coverage --strict` and confirm it passes.
+
+## 8. Validation gates
+
+- [x] 8.1 Run `pnpm run typecheck` from the repo root. SHALL produce zero errors.
+- [x] 8.2 Run `pnpm run lint` from the repo root. SHALL produce zero errors for in-scope files.
+- [x] 8.3 Run `pnpm test` from the repo root. SHALL produce zero failures. New tests appear in the suite count.
+- [x] 8.4 Run the Hermes plugin tests (`apps/plugin/.hermes-plugin/tests/` per the existing pattern). SHALL produce zero failures. The new `system_prompt_block` test appears in the count.
+- [ ] 8.5 Manual smoke against `pnpm run dev:docker:up` per `apps/server/src/skills/rembric-plugin-development/references/e2e-walkthrough.md` (referenced via the `rembric-plugin-development` skill):
+  - Claude Code: trigger a /compact, verify `/api/<slug>/sessions/<id>/summary` is POSTed twice (once from PreCompact, once from PostCompact), and the dashboard /sessions row shows the resulting summary.
+  - opencode: trigger a compaction, verify `flushSessionSummary` fires on `session.compacted` AND the existing `experimental.session.compacting` nudge still appears.
+  - opencode: send a user message containing "qué hicimos ayer", verify the recall nudge appears in the agent's context.
+
+## 9. Land
+
+- [ ] 9.1 Commit on the feature branch `feat/expand-plugin-hooks-coverage` (already created via worktree). Use a Conventional Commit message in the form `feat(plugin): wire pre/post-compact hooks across Claude Code, Codex CLI, opencode + cross-client recall paridad and prompt refinements`. Per-file scoping: changes under `apps/plugin/bin/`, `apps/plugin/hooks/`, `apps/plugin/scripts/` will cascade `claude-code-plugin` and `codex-plugin` via the `bridge-bundlers` linked group; changes under `apps/plugin/.opencode-plugin/` and `apps/plugin/.hermes-plugin/` will bump their respective independent components.
+- [ ] 9.2 Open a PR against `main`. Body links to this change directory and explains the source-verified Codex correction (PreCompact / PostCompact ARE supported in Codex despite the public docs).
+- [ ] 9.3 After merge, run `/opsx:archive expand-plugin-hooks-coverage`. The archive step SHALL sync the 5 spec deltas into the main specs.

--- a/openspec/specs/claude-code-plugin/spec.md
+++ b/openspec/specs/claude-code-plugin/spec.md
@@ -144,38 +144,43 @@ The prior `PreCompact` hook had two problems: (1) its stdout is not injected int
 
 ### Requirement: The plugin SHALL ship a thin curl helper at `${CLAUDE_PLUGIN_ROOT}/scripts/_api.sh`
 
-To keep `session-start.sh`, `post-compact.sh`, and `session-end.sh` minimal and consistent, the plugin SHALL ship a shared helper at `apps/plugin/scripts/_api.sh` that:
+To keep `session-start.sh`, `post-compact.sh`, `session-end.sh`, `pre-compact.sh`, and `post-compaction.sh` minimal and consistent, the plugin SHALL ship a shared helper at `apps/plugin/scripts/_api.sh` that:
 
 - Resolves `REMBRIC_SERVER_URL` and `REMBRIC_API_TOKEN` from the environment.
 - Parses `${cwd}/.rembric` for `PROJECT_SLUG` (reuses the same dotenv parser logic).
 - Exposes a function `rembric_post <path> <json-body>` that issues `curl -sf -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" --max-time 3 -d "$body" "$URL"`.
 - Exposes a function `rembric_json_escape <string>` that escapes for embedding in a JSON value.
-- Exposes functions `rembric_session_id_from_stdin_json`, `rembric_cwd_from_stdin_json`, and a new `rembric_transcript_path_from_stdin_json` that pull those fields from stdin JSON.
+- Exposes functions `rembric_session_id_from_stdin_json`, `rembric_cwd_from_stdin_json`, `rembric_transcript_path_from_stdin_json`, AND a new `rembric_compaction_summary_from_stdin_json` that pulls the `compaction_summary` field from hook stdin JSON. The compaction-summary extractor SHALL prefer `compaction_summary` and SHALL fall back to `compactionSummary` (in case Codex uses camelCase, per the same precedent that `session_id`/`sessionId` already follows).
 - Discards stdout and returns `0` even on failure (so callers can `|| true` safely).
 
-A new sibling helper `apps/plugin/scripts/_transcript.sh` SHALL expose `rembric_format_transcript <path>` that reads a JSONL transcript and emits `role: content\n…` oldest-first, truncated to 19500 chars from the tail. The helper SHALL prefer `jq` when available and SHALL fall back to a sed-based parser otherwise; both paths SHALL emit empty string on parse failure rather than crashing.
+The sibling helper `apps/plugin/scripts/_transcript.sh` (unchanged) exposes `rembric_format_transcript_claude_code`, `rembric_extract_first_assistant_claude_code`, `rembric_format_transcript_codex_cli`, and `rembric_extract_first_assistant_codex_cli`. The new `pre-compact.sh` consumes the Claude Code variants directly; Codex's `pre-compact.sh` execution SHALL select the codex_cli variants OR (preferred) the script SHALL detect the agent from `$1` (already conventional for `session-start.sh`) and dispatch accordingly. The contract is: `pre-compact.sh <agent>` accepts the same agent name argument as `session-start.sh`.
 
 Each hook script SHALL `source` `_api.sh` (and `_transcript.sh` where transcript handling is needed) and SHALL NOT inline the curl invocation or transcript parsing directly. The helpers SHALL respect the same "exit 0 on error" discipline as the existing scripts.
 
-#### Scenario: Helper is sourced by all hook scripts
+#### Scenario: New helpers are sourced by the new scripts
 
-- **WHEN** `session-start.sh`, `post-compact.sh`, or `session-end.sh` are read
+- **WHEN** `pre-compact.sh` or `post-compaction.sh` are read
 - **THEN** each SHALL start with `source "${SCRIPT_DIR}/_api.sh"` (where `SCRIPT_DIR` is the script's own directory)
-- **AND** `session-end.sh` SHALL also `source "${SCRIPT_DIR}/_transcript.sh"`
-- **AND** none SHALL inline a literal `curl` invocation outside the helper
+- **AND** `pre-compact.sh` SHALL also `source "${SCRIPT_DIR}/_transcript.sh"` (transcript needed)
+- **AND** neither SHALL inline a literal `curl` invocation outside the helper
 
-#### Scenario: Helper fails silently when env is incomplete
+#### Scenario: rembric_compaction_summary_from_stdin_json accepts both naming conventions
 
-- **WHEN** `REMBRIC_SERVER_URL` or `REMBRIC_API_TOKEN` is missing
-- **THEN** the helper SHALL emit a one-line stderr diagnostic and `rembric_post` SHALL return `0` without issuing a request
+- **WHEN** the helper is called with stdin `{"compaction_summary": "X"}` (snake_case, Claude convention)
+- **THEN** it SHALL extract `X`
 
-#### Scenario: Transcript helper degrades gracefully
+- **WHEN** the helper is called with stdin `{"compactionSummary": "X"}` (camelCase, in case Codex differs)
+- **THEN** it SHALL extract `X`
 
-- **WHEN** `rembric_format_transcript <path>` is called with a non-existent path
-- **THEN** the helper SHALL emit empty string to stdout and exit `0`
+- **WHEN** the helper is called with stdin lacking both keys
+- **THEN** it SHALL emit empty string and exit `0`
 
-- **WHEN** the helper is called with a malformed JSONL file
-- **THEN** the helper SHALL extract what it can (best-effort `role`/`content` parse) and emit empty string if nothing parsable was found, exiting `0`
+<!-- Token budget is a `## Section` in the canonical spec, not a `### Requirement`,
+     so it cannot be expressed as a MODIFIED Requirement delta. The output cap for
+     `post-compact.sh` declared in that section (≤120 tokens) remains the soft
+     target; the sharpened nudge stays well within the input window in practice.
+     A future change can convert "Token budget" into a proper Requirement if we
+     want it enforceable. -->
 
 ### Requirement: The plugin MUST NOT implement migration or coexistence behaviors with other agent memory systems
 

--- a/openspec/specs/codex-distribution/spec.md
+++ b/openspec/specs/codex-distribution/spec.md
@@ -197,33 +197,14 @@ Codex install material SHALL document the credential flow given Codex's lack of 
 
 ### Requirement: `docs/agents.md` recommends the plugin install as primary
 
-The Codex section of `docs/agents.md` SHALL recommend the marketplace plugin install as the primary path, document the credential flow, document the platform-required enablement steps for plugin hooks (which Codex gates behind an under-development feature flag and a per-hook trust review as of `codex-cli 0.130.0`), and retain a manual `config.toml` fallback for users who do not want the plugin.
+The Codex section of `docs/agents.md` SHALL recommend the marketplace plugin install as the primary path, document the credential flow, document the platform-required enablement steps for plugin hooks (which Codex gates behind an under-development feature flag and a per-hook trust review as of `codex-cli 0.130.0`), and retain a manual `config.toml` fallback for users who do not want the plugin. The "trust each of the N plugin-bundled hooks" guidance SHALL be updated to enumerate the now-FIVE hooks (`SessionStart`, `UserPromptSubmit`, `Stop`, `PreCompact`, `PostCompact`) — superseding the previous "4 plugin-bundled hooks" wording.
 
-#### Scenario: Primary install path
-
-- **WHEN** a reader opens the Codex section of `docs/agents.md`
-- **THEN** the first install option SHALL be `codex plugin marketplace add <repo>` followed by `codex plugin install rembric`
-- **AND** the section SHALL link to or summarise the env-var credential requirement
-
-#### Scenario: Platform-required hook enablement
+#### Scenario: Platform-required hook enablement enumerates five hooks
 
 - **WHEN** a reader follows the Codex install flow in `docs/agents.md`
 - **THEN** the doc SHALL document, after the install + env-var snippets, that two additional platform-required steps are necessary to make plugin-bundled hooks fire under `codex-cli 0.130.0`:
   - **Step 1**: enable the `plugin_hooks` feature with `codex features enable plugin_hooks`. The doc SHALL note that this feature is currently `under development` in Codex (default off) and that future Codex releases may default it on — readers should run `codex features list` to confirm before assuming.
-  - **Step 2**: open `/hooks` inside Codex and trust each of the 4 plugin-bundled hooks (`SessionStart`, `UserPromptSubmit`, `PreCompact`, `Stop`). Codex surfaces a startup banner of the form _"N hooks need review before they can run. Open `/hooks` to review them."_ — until each hook is trusted, it loads but does not execute.
+  - **Step 2**: open `/hooks` inside Codex and trust each of the 5 plugin-bundled hooks (`SessionStart`, `UserPromptSubmit`, `Stop`, `PreCompact`, `PostCompact`). Codex surfaces a startup banner of the form _"N hooks need review before they can run. Open `/hooks` to review them."_ — until each hook is trusted, it loads but does not execute.
 - **AND** the doc SHALL note that the trust persists in `~/.codex/config.toml`'s `[hooks.state]` block; users do not need to re-approve hooks after every Codex restart, only once per hook handler.
 
-#### Scenario: Symptom-to-cause troubleshooting table
-
-- **WHEN** a reader scrolls the Codex section of `docs/agents.md` looking for a fix to a specific symptom
-- **THEN** the doc SHALL include a "If you see X, the cause is Y" table covering the failure modes a Codex user actually observes:
-  - `/dashboard/sessions` stays empty after running Codex sessions → `plugin_hooks` feature off OR hooks not yet trusted.
-  - `/plugins` panel shows "No plugin hooks" → `plugin_hooks` feature off.
-  - Startup banner "N hooks need review" appears repeatedly → hooks need `/hooks` review and per-hook approval.
-- **AND** the table SHALL link the symptom rows to the relevant remediation step from the previous scenario.
-
-#### Scenario: Manual fallback preserved
-
-- **WHEN** the same section is read
-- **THEN** a "manual config.toml, no plugin" appendix SHALL document the raw `[mcp_servers.rembric]` block using `transport = "streamable-http"` with a slug-hardcoded URL
-- **AND** the appendix SHALL note that this path has no Codex hooks and no slug auto-resolution — the marketplace plugin install is the recommended path for those features
+(Other scenarios within this requirement remain unchanged.)

--- a/openspec/specs/hermes-agent-plugin/spec.md
+++ b/openspec/specs/hermes-agent-plugin/spec.md
@@ -76,7 +76,7 @@ The file SHALL expose a module-level `register(ctx)` function that calls `ctx.re
 - `on_session_switch(new_session_id, *, parent_session_id="", reset=False, **kwargs)` SHALL override per the "Provider MUST override on_session_switch" requirement.
 - `get_tool_schemas` SHALL return `[]`. The provider contributes no agent-callable tools.
 - `handle_tool_call(name, args)` SHALL return `json.dumps({"error": "unknown_tool", "hint": "register the rembric MCP bridge in mcp_servers.rembric to access memory tools"})`.
-- `system_prompt_block` SHALL return a single-paragraph block (≤300 chars) directing the agent to call `memory.session_summary({title, summary})` before declaring work done. Title ≤100 chars descriptive of what was actually worked on; summary follows Goal · Discoveries · Accomplished · Next Steps · Files. This is the Hermes-side counterpart to Claude/Codex's `initialize.instructions` nudge.
+- `system_prompt_block` SHALL return a single-paragraph block (**≤300 chars**) directing the agent to (a) call `memory.session_summary({title, summary})` before declaring work done — title ≤100 chars descriptive of what was actually worked on; summary follows Goal · Discoveries · Accomplished · Next Steps · Files — AND (b) call `memory.context` after any compaction event when the compact summary lacks detail (file paths, specific decisions, errors). This is the Hermes-side counterpart to Claude/Codex's `initialize.instructions` nudge, which now also carries the memory.context post-compact recovery guidance for symmetry.
 - `prefetch(query, **kwargs)` SHALL return `""`.
 - `queue_prefetch(query, **kwargs)` SHALL be a no-op (return `None`).
 - `sync_turn(user, assistant, **kwargs)` SHALL be a no-op.
@@ -87,90 +87,59 @@ The provider SHALL NOT implement `get_config_schema` or `save_config`. Credentia
 
 #### Scenario: is_available with both envs set and a healthy server returns True
 
-- **GIVEN** `REMBRIC_SERVER_URL` and `REMBRIC_API_TOKEN` are set
-- **AND** `GET ${REMBRIC_SERVER_URL}/healthz` with the bearer header returns `200`
-- **WHEN** Hermes calls `provider.is_available()`
-- **THEN** the provider SHALL return `True`
+(Unchanged from the prior spec.)
 
 #### Scenario: is_available with a missing token returns False without making a request
 
-- **GIVEN** `REMBRIC_SERVER_URL` is set but `REMBRIC_API_TOKEN` is unset
-- **WHEN** Hermes calls `provider.is_available()`
-- **THEN** the provider SHALL return `False`
-- **AND** the provider SHALL NOT issue any HTTP request
+(Unchanged from the prior spec.)
 
 #### Scenario: is_available with an invalid token returns False
 
-- **GIVEN** `REMBRIC_SERVER_URL` and `REMBRIC_API_TOKEN` are set
-- **AND** `GET ${REMBRIC_SERVER_URL}/healthz` with the bearer header returns `401`
-- **WHEN** Hermes calls `provider.is_available()`
-- **THEN** the provider SHALL return `False`
+(Unchanged from the prior spec.)
 
 #### Scenario: is_available with the server's database unavailable returns False
 
-- **GIVEN** `REMBRIC_SERVER_URL` and `REMBRIC_API_TOKEN` are set
-- **AND** `GET ${REMBRIC_SERVER_URL}/healthz` with the bearer header returns `503`
-- **WHEN** Hermes calls `provider.is_available()`
-- **THEN** the provider SHALL return `False`
+(Unchanged from the prior spec.)
 
 #### Scenario: Session initialize POSTs to the sessions endpoint with agent: hermes
 
-- **WHEN** Hermes starts a session and calls `provider.initialize(session_id="01XYZ", cwd="/home/user/repo")` with a resolvable slug `myproj`
-- **THEN** the provider issues `POST ${REMBRIC_SERVER_URL}/api/myproj/sessions` with `Authorization: Bearer …` and body `{"id":"01XYZ","cwd":"/home/user/repo","agent":"hermes"}`
-- **AND** the response is discarded
-- **AND** the provider caches `slug="myproj"`, `session_id="01XYZ"`, `cwd="/home/user/repo"` for subsequent lifecycle calls
+(Unchanged from the prior spec.)
 
 #### Scenario: Pre-compress posts a transcript summary
 
-- **WHEN** `provider.on_pre_compress(messages=[...])` is called for an initialized session
-- **THEN** the provider serializes messages to `role: content` lines (oldest-first), caps at 19,500 chars, and POSTs to `${REMBRIC_SERVER_URL}/api/<slug>/sessions/<session_id>/summary` with `{"summary":"<transcript>","final":false}`
-- **AND** the body SHALL NOT include `title`
-- **AND** the `messages` argument is NOT mutated by the provider
-- **AND** the return value SHALL be `""`
+(Unchanged from the prior spec.)
 
 #### Scenario: Session end posts to the end endpoint with summary and derived title
 
-- **WHEN** Hermes ends the session and calls `provider.on_session_end(messages=[{role:"user",content:"hi"},{role:"assistant",content:"Fixed the auth bug; refactored login flow"}])` for an initialized session
-- **THEN** the provider issues `POST ${REMBRIC_SERVER_URL}/api/<slug>/sessions/<session_id>/end` with body containing `summary` = the formatted transcript, `title` = `"Fixed the auth bug; refactored login flow"` (or truncated to 100 chars), `final: false`
-- **AND** the response is discarded
+(Unchanged from the prior spec.)
 
 #### Scenario: Session end with empty messages degrades to `{}`
 
-- **WHEN** `provider.on_session_end(messages=[])` is called
-- **THEN** the provider POSTs `/end` with body `{}` (no summary, no title)
-- **AND** the server transitions the row to `ended` with summary/title unchanged
+(Unchanged from the prior spec.)
 
 #### Scenario: Session end when model already wrote a final summary
 
-- **GIVEN** during the session the agent called `memory.session_summary({summary, title})` via the MCP bridge (server-side `summary_final = true`)
-- **WHEN** `provider.on_session_end(messages)` posts `/end {summary, title, final: false}`
-- **THEN** the server transitions the row to `ended` but the `final:false` writes are skipped due to precedence
-- **AND** the model's summary and title SHALL remain intact
+(Unchanged from the prior spec.)
 
 #### Scenario: Lifecycle calls without a resolved slug skip silently
 
-- **WHEN** `provider.initialize(session_id="01XYZ", cwd="/tmp")` runs with no resolvable slug from any cascade source
-- **THEN** the provider writes a single stderr diagnostic `[rembric] no project slug for session 01XYZ; skipping session POST`
-- **AND** no HTTP request is issued
-- **AND** subsequent calls to `on_pre_compress`, `on_session_end`, and `on_session_switch` skip silently without diagnostic spam
+(Unchanged from the prior spec.)
 
-#### Scenario: system_prompt_block emits the session-close protocol
+#### Scenario: system_prompt_block emits the session-close protocol AND memory.context post-compact guidance
 
 - **WHEN** Hermes calls `provider.system_prompt_block()`
 - **THEN** the returned string SHALL be non-empty and SHALL contain the substring `memory.session_summary`
 - **AND** SHALL contain a reference to `title` and the structure `Goal · Discoveries · Accomplished · Next Steps · Files`
-- **AND** SHALL be ≤300 chars
+- **AND** SHALL contain the substring `memory.context` (new — post-compact recovery guidance)
+- **AND** SHALL be ≤300 chars total (unchanged cap — the new content MUST fit within the existing cap, requiring concise phrasing)
 
 #### Scenario: handle_tool_call returns a defensive error
 
-- **WHEN** for any reason `provider.handle_tool_call(name="memory_save", args={})` is invoked
-- **THEN** the provider returns the JSON string `{"error":"unknown_tool","hint":"register the rembric MCP bridge in mcp_servers.rembric to access memory tools"}`
+(Unchanged from the prior spec.)
 
 #### Scenario: Provider does not manage credential storage
 
-- **WHEN** Hermes inspects the provider's published surface
-- **THEN** the provider does NOT override `get_config_schema` (default returns `[]`) and does NOT override `save_config` (default no-op)
-- **AND** no `~/.hermes/rembric.json` file is created by the provider
+(Unchanged from the prior spec.)
 
 ### Requirement: Slug resolution cascade
 

--- a/openspec/specs/mcp-api/spec.md
+++ b/openspec/specs/mcp-api/spec.md
@@ -375,28 +375,39 @@ The `/mcp` and `/mcp/<slug>` endpoints SHALL register `project.use`, `project.li
 
 When the MCP server is constructed, its `instructions` field SHALL be populated with a scope-aware string that teaches the agent when to call each tool. The string SHALL be 800 characters or fewer.
 
-The instructions SHALL include the session-close protocol sentence directing the agent to call `memory.session_summary({title, summary})` before declaring work "done". The sentence SHALL describe the title constraint (≤100 chars, descriptive of what was actually worked on — NOT the cwd, NOT generic) and the summary structure (Goal · Discoveries · Accomplished · Next Steps · Files).
+The instructions SHALL include:
+
+1. The session-close protocol sentence directing the agent to call `memory.session_summary({title, summary})` before declaring work "done". The sentence SHALL describe the title constraint (≤100 chars, descriptive of what was actually worked on — NOT the cwd, NOT generic) and the summary structure (Goal · Discoveries · Accomplished · Next Steps · Files).
+2. **The post-compact recovery clause (new)** — a short instruction directing the agent that after any compaction event, when the compacted summary lacks specific detail (exact file paths, prior decisions, concrete error messages), it MUST call `memory.context` (or `memory.search` for keyword lookup) BEFORE responding to the user's pending prompt. The phrasing SHALL stay concise (≤60 chars of new content) so the total stays under the 800-char cap.
 
 #### Scenario: An MCP client connects on `/mcp/<slug>`
 
 - **WHEN** the `initialize` handshake completes against `/mcp/my-project`
-- **THEN** the `InitializeResult.instructions` SHALL contain references to `memory.save`, `memory.search`, and `memory.session_summary` plus a note indicating the connection is project-scoped to `'my-project'` and that `scope='global'` will be rejected
+- **THEN** the `InitializeResult.instructions` SHALL contain references to `memory.save`, `memory.search`, `memory.session_summary`, AND `memory.context` (the new post-compact recovery clause) plus a note indicating the connection is project-scoped to `'my-project'` and that `scope='global'` will be rejected
 - **AND** the instructions SHALL contain the substring `memory.session_summary` and the substring `title` and a reference to "before" (referring to before declaring done)
+- **AND** the instructions SHALL contain the substring `memory.context` (the new post-compact recovery clause)
 
 #### Scenario: An MCP client connects on `/mcp` without a project
 
 - **WHEN** the `initialize` handshake completes against `/mcp`
-- **THEN** the `InitializeResult.instructions` SHALL contain the same protocol triggers (including the session-close protocol sentence) and a note indicating the connection is global-scope and that project memories require opening `/mcp/<slug>` or sending `X-Rembric-Project`
+- **THEN** the `InitializeResult.instructions` SHALL contain the same protocol triggers (including the session-close protocol sentence AND the memory.context post-compact recovery clause) and a note indicating the connection is global-scope and that project memories require opening `/mcp/<slug>` or sending `X-Rembric-Project`
 
 #### Scenario: Instructions length is checked at build time
 
 - **WHEN** the test suite runs against both `/mcp` and `/mcp/<slug>` variants of `buildInstructions(ctx)`
-- **THEN** both outputs SHALL be 800 characters or fewer
+- **THEN** both outputs SHALL be 800 characters or fewer (unchanged cap — the new clause MUST fit within the existing budget)
 
 #### Scenario: A client that does not consume `instructions` connects
 
 - **WHEN** an MCP client ignores the `instructions` field
 - **THEN** every tool SHALL still function normally (the field is informational only)
+
+#### Scenario: instructions.test.ts asserts the new memory.context clause is present
+
+- **WHEN** `apps/server/src/mcp/instructions.test.ts` runs against `buildInstructions({requestedSlug: 'demo'})` and `buildInstructions({requestedSlug: null})`
+- **THEN** both outputs SHALL contain the substring `memory.context`
+- **AND** both outputs SHALL be ≤800 chars
+- **AND** existing assertions for `memory.session_summary`, `memory.save`, `memory.search`, scope notes, etc. SHALL continue to pass
 
 ### Requirement: The MCP server MUST expose `memory.suggest_topic_key`
 

--- a/openspec/specs/opencode-plugin/spec.md
+++ b/openspec/specs/opencode-plugin/spec.md
@@ -267,25 +267,24 @@ Server-side session closure SHALL rely on:
 The `"experimental.session.compacting"` handler SHALL:
 
 1. If `input.sessionID` is present, call `ensureSession(input.sessionID)`.
-2. Push a single string onto `output.context` (the array opencode's compactor consumes) instructing the compactor that the next agent MUST call `memory.session_summary` immediately with the compacted summary content, preserving what was done before compaction. The instruction text SHALL be a single multi-line string ending with a sentence stating that without this step everything before compaction is lost from memory. The text SHALL name the project slug when one was resolved.
+2. Push a single string onto `output.context` (the array opencode's compactor consumes) instructing the compactor that the next agent MUST call `memory.session_summary` immediately with the compacted summary content, preserving what was done before compaction. The instruction text SHALL be a single multi-line string ending with a sentence stating that without this step everything before compaction is lost from memory. The text SHALL name the project slug when one was resolved. **The text SHALL ALSO include a final sentence directing the post-compact agent to call `memory.context` if it needs detail beyond the compact summary (file paths, decisions, specific errors not in the compacted block).**
 
 The handler SHALL NOT mutate `input.context` or `input.messages` directly. All effects SHALL be expressed as appends to `output.context`.
 
-The handler SHALL NOT GET any `/context` or recall-context endpoint in v1 — no such endpoint exists on the HTTP API today. When the corresponding endpoint ships in a future OpenSpec change, the handler MAY be extended to prepend a server-returned recall block before the reminder; that prepend SHALL fail silently on any error and the reminder string SHALL remain the last (always-present) entry.
+The handler SHALL NOT GET any `/context` or recall-context endpoint in v1 — no such endpoint exists on the HTTP API today. When the corresponding endpoint ships in a future OpenSpec change, the handler MAY be extended to prepend a server-returned recall block before the reminder; that prepend SHALL fail silently on any error and the reminder string (including the memory.context guidance) SHALL remain the last (always-present) entry.
 
-#### Scenario: Reminder is always appended
+#### Scenario: Reminder includes memory.session_summary AND memory.context guidance
 
 - **WHEN** `experimental.session.compacting` fires with a valid `input.sessionID`
 - **THEN** `ensureSession` runs (POST `/api/<slug>/sessions` once)
 - **AND** exactly ONE string is pushed to `output.context`
 - **AND** that string contains the substring `memory.session_summary`
+- **AND** that string contains the substring `memory.context` (new requirement — the post-compact recovery path)
 - **AND** that string contains the project slug when one was resolved from `.rembric`
 
 #### Scenario: Compacting fires without sessionID
 
-- **WHEN** `experimental.session.compacting` fires with `input.sessionID` absent or empty
-- **THEN** `ensureSession` is NOT called
-- **AND** the reminder string is still appended to `output.context`
+(Unchanged from the prior spec.)
 
 ### Requirement: HTTP client behaviour
 
@@ -673,3 +672,39 @@ The plain-text MCP snippet is no longer printed for the auto-write path. It is s
 - **WHEN** `install.sh` runs
 - **THEN** `~/.config/opencode/opencode.json` is left UNCHANGED
 - **AND** the script prints a one-line confirmation (e.g., `[rembric] mcp.rembric already configured in opencode.json — skipped`)
+
+### Requirement: Session.compacted handler flushes the accumulator at the compaction milestone
+
+The `event` dispatcher SHALL handle `event.type === "session.compacted"` as the third opencode event (alongside `session.idle` and `server.instance.disposed`) that triggers a summary flush. Its purpose is to persist the rolling transcript at the moment opencode signals a compaction has completed.
+
+The handler SHALL:
+
+1. Extract the session id from `event.properties.sessionID` (or `event.properties.info.id` as a fallback, mirroring the existing `session.created` extraction pattern). If the id is empty, the handler SHALL return.
+2. Skip if the id is in `subAgentSessions`. Skip if the id is NOT in `knownSessions` (we only flush sessions whose row was already registered).
+3. Emit one stderr diagnostic of the form `[rembric] session.compacted sessionId=<id>`.
+4. Await `flushSessionSummary(sessionId)` — the same helper used by `session.idle`. This builds the body via `buildSummaryBody(sessionId)` (joining the accumulator entries as `<role>: <text>` lines, truncating from the head at 19500 chars) and POSTs to `/api/<slug>/sessions/<id>/summary` with `final:false`.
+
+The handler SHALL NOT reset, clear, or otherwise mutate `sessionMessages` for the affected session id. opencode's `session.compacted` is a notification event, not a content-delivery event — the in-memory accumulator persists across the compaction, so subsequent `session.idle` events MAY continue to flush a transcript that includes both pre-compact and post-compact turns.
+
+opencode's `session.compacted` event does NOT deliver the model-authored compaction summary payload. The handler SHALL NOT attempt to extract one from the event. The PRIMARY signal we persist at this milestone is the in-memory accumulator's rolling transcript — the same content that `session.idle` would flush, just triggered by the explicit compaction event for milestone clarity.
+
+#### Scenario: session.compacted flushes for a known top-level session
+
+- **GIVEN** `knownSessions` contains `"s1"`, `sessionMessages.get("s1")` contains turns
+- **WHEN** the dispatcher receives an event with `type === "session.compacted"` and a sessionID resolving to `"s1"`
+- **THEN** the handler SHALL emit one stderr diagnostic naming the id
+- **AND** SHALL await `flushSessionSummary("s1")` exactly once
+- **AND** SHALL NOT mutate `sessionMessages.get("s1")`
+
+#### Scenario: session.compacted is a no-op for sub-agent sessions
+
+- **GIVEN** `subAgentSessions` contains `"sub-1"`
+- **WHEN** the dispatcher receives a session.compacted event for `"sub-1"`
+- **THEN** the handler SHALL NOT call `flushSessionSummary`
+- **AND** SHALL NOT emit the standard diagnostic (the sub-agent skip is silent, matching the existing pattern for sub-agent filtering in other handlers)
+
+#### Scenario: session.compacted is a no-op for unknown sessions
+
+- **GIVEN** `knownSessions` does NOT contain `"s99"`
+- **WHEN** the dispatcher receives a session.compacted event for `"s99"`
+- **THEN** the handler SHALL NOT call `flushSessionSummary` (we only flush sessions whose row was previously registered)


### PR DESCRIPTION
## Summary

Eliminate the dependency on the model calling `memory.session_summary` post-compact, and close cross-client paridad gaps in the recall flow.

- **PreCompact + PostCompact** wired in Claude Code AND Codex CLI (source-verified at `codex-rs/hooks/src/engine/output_parser.rs`; the prior `codex-distribution` spec wrongly claimed Codex lacked these events). Two new shared scripts under `apps/plugin/scripts/`: `pre-compact.sh` (transcript snapshot before compaction) and `post-compaction.sh` (persists the model-authored `compaction_summary` verbatim).
- **opencode `session.compacted`** wired through the existing `event` dispatcher → flushes the in-memory accumulator at the compaction milestone.
- **opencode recall regex paridad** in `chat.message` → appends the same nudge string used by Claude/Codex `UserPromptSubmit`.
- **Prompt refinements (text-only, all within existing caps)** in `post-compact.sh` (SessionStart compact), `experimental.session.compacting`, Hermes `system_prompt_block`, and the MCP `initialize.instructions` block — all now teach `memory.context` as the post-compact recovery path when the compacted summary elides detail.

No server endpoints, DB schema, MCP bridge, or shared dotenv lib changed. Net-additive: new hooks fire only after the next plugin install/update.

## Spec deltas (synced + archived in the same PR per the existing pattern)

- `claude-code-plugin` — PreCompact + PostCompact + sharpened SessionStart compact nudge
- `codex-distribution` — corrects the false "Codex has no PreCompact/PostCompact" claim, adds wiring
- `opencode-plugin` — ADD `session.compacted` handler, MODIFY chat.message recall, MODIFY experimental.session.compacting nudge
- `hermes-agent-plugin` — `system_prompt_block` memory.context guidance
- `mcp-api` — `initialize.instructions` memory.context clause

Archive: `openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/`.

## Test plan

- [x] `openspec validate expand-plugin-hooks-coverage --strict`
- [x] `pnpm run typecheck` — 0 errors
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm test` — 527/527 vitest passing (includes 7 new opencode + MCP tests)
- [x] `python3 -m unittest discover -s apps/plugin/.hermes-plugin/tests` — 31/31 passing (includes 3 new `system_prompt_block` assertions)
- [x] Smoke against `pnpm run dev:docker:up`:
  - `pre-compact.sh` writes the live transcript snapshot to `/api/<slug>/sessions/<id>/summary` ✓
  - `post-compaction.sh` writes the model-authored `compaction_summary` verbatim ✓
  - `post-compaction.sh` degraded (missing field) emits stderr diagnostic + posts `{}` ✓
  - opencode `session.compacted` POSTs `/summary` (200) ✓
  - opencode `chat.message` recall regex appends nudge on 5 keyword variants ✓
  - opencode `chat.message` does NOT append on non-recall text ✓
  - `experimental.session.compacting` includes `memory.context` substring ✓
  - `initialize.instructions` on `/mcp/<slug>` and `/mcp` contain `memory.context` and `After /compact` within the 800-char cap ✓

## Release-please consequences

- `apps/plugin/hooks/` + `apps/plugin/scripts/` changes → `bridge-bundlers` linked group bumps `claude-code-plugin` AND `codex-plugin` together
- `apps/plugin/.opencode-plugin/` changes → `opencode-plugin` independent bump
- `apps/plugin/.hermes-plugin/` changes → `hermes-plugin` independent bump
- `apps/server/src/mcp/instructions.ts` change → `server` component bump (existing release-please component)

## OpenSpec change

[`openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/`](./openspec/changes/archive/2026-05-22-expand-plugin-hooks-coverage/)

Bug found and fixed during smoke: `rembric_compaction_summary_from_stdin_json` regex with `\|` alternation didn't work on BSD sed (macOS) — switched to `jq` when available + fallback to simpler BRE.