### PR TITLE
fix(release-please): include shared plugin paths so claude-code/codex bumps trigger

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -36,7 +36,14 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
-      "extra-files": ["plugin.json"]
+      "extra-files": ["plugin.json"],
+      "include-paths": [
+        "apps/plugin/.claude-plugin",
+        "apps/plugin/bin",
+        "apps/plugin/hooks/hooks.json",
+        "apps/plugin/commands",
+        "apps/plugin/scripts"
+      ]
     },
     "apps/plugin/.codex-plugin": {
       "release-type": "simple",
@@ -47,7 +54,14 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
-      "extra-files": ["plugin.json"]
+      "extra-files": ["plugin.json"],
+      "include-paths": [
+        "apps/plugin/.codex-plugin",
+        "apps/plugin/bin",
+        "apps/plugin/hooks/hooks.codex.json",
+        "apps/plugin/commands",
+        "apps/plugin/scripts"
+      ]
     },
     "apps/plugin/.hermes-plugin": {
       "release-type": "simple",
@@ -58,7 +72,8 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
-      "extra-files": ["plugin.yaml"]
+      "extra-files": ["plugin.yaml"],
+      "include-paths": ["apps/plugin/.hermes-plugin"]
     },
     "apps/plugin/.opencode-plugin": {
       "release-type": "node",
@@ -69,7 +84,8 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
-      "extra-files": [{ "type": "generic", "path": "plugin.ts" }]
+      "extra-files": [{ "type": "generic", "path": "plugin.ts" }],
+      "include-paths": ["apps/plugin/.opencode-plugin", "apps/plugin/bin"]
     }
   },
   "plugins": [


### PR DESCRIPTION
## Summary

PRs #87 (`feat(sessions)!: cap session.summary at 2000 chars`) and #88 (`feat(plugin): wire pre/post-compact hooks + opencode recall paridad`) modified the functional surface of the Claude Code and Codex plugins — `hooks/`, `commands/`, `scripts/`, the shared bridge in `bin/` — yet release-please opened release PRs **only** for `server`, `hermes-plugin`, and `opencode-plugin`. The Claude Code and Codex plugins are stuck on `0.9.0` despite shipping new behavior.

Root cause: release-please attributes a commit to a component only when the commit touches a file inside the component's `path` (its manifest dir). The per-client manifest dirs `apps/plugin/.{claude,codex,hermes,opencode}-plugin/` are tiny — the consumed assets live in sibling shared directories that no per-client `path` covers. Neither #87 nor #88 happened to touch a file inside `.claude-plugin/` or `.codex-plugin/`, so release-please saw nothing to bump. The `bridge-bundlers` linked-versions group can't help: it cascades versions only when at least one of its components already has a detected change.

This declares each component's true consumption surface via `include-paths`:

| Component | Added paths | Why |
| --- | --- | --- |
| `claude-code-plugin` | `bin`, `hooks/hooks.json`, `commands`, `scripts` | Plugin manifest points to all four |
| `codex-plugin` | `bin`, `hooks/hooks.codex.json`, `commands`, `scripts` | Same — different hooks file |
| `hermes-plugin` | (none — self-contained) | `install.sh` only fetches `plugin.yaml`, `__init__.py`, `README.md` from `.hermes-plugin/` |
| `opencode-plugin` | `bin` | `plugin.ts` imports `../bin/rembric-dotenv.mjs`; install.sh copies from `bin/` |

After merge, release-please re-walks commits since each component's last tag against the new `include-paths` set, so claude-code-plugin and codex-plugin should retroactively get `0.9.0 → 0.10.0` release PRs picking up #75, #87, and #88. The `bridge-bundlers` linked-versions cascade keeps the two bridge-bundling plugins in version lock-step.

## Test plan

- [x] `release-please-config.json` is valid JSON (`node -e "JSON.parse(...)"`)
- [x] Pre-commit hooks pass (lint-staged + `tsc --noEmit`)
- [x] After merge, observe new release-please runs open **two additional PRs**: `claude-code-plugin-v0.10.0` and `codex-plugin-v0.10.0`, both citing #75/#87/#88.
- [x] Verify the already-open release PRs (#76, #77, #78) get refreshed by release-please without losing their commits — in particular, `hermes-plugin`'s changelog should drop entries that no longer belong (now that its `include-paths` is just `.hermes-plugin/`).
- [x] Confirm `bridge-bundlers` linked-versions keeps claude-code and codex at the same number once they cascade.

## Out of scope

- Adopting the same `include-paths` discipline for `opencode-plugin`'s consumption of any future shared scripts/hooks — current install.sh and `plugin.ts` only reach into `bin/`, so leaving `scripts`/`hooks` out keeps its surface tight.
- Backfilling the missing `claude-code-plugin-v0.9.0` and `codex-plugin-v0.9.0` GitHub releases (they exist as tags; only the GH release surface is missing, per the cleanup note in #65).