### PR TITLE
fix(server): disable foreign_keys around migrations to unblock parent-table rebuilds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,12 @@ Single Node process, single SQLite file. Server layers at `apps/server/src/{serv
 
 Path-scoping contract (in `apps/server/src/mcp/tools.ts`): `/mcp/<slug>` rejects `scope='global'` with `scope_locked`; `/mcp` rejects `scope='project'` with `project_required` unless an active project exists.
 
+### Table-rebuild migrations (SQLite)
+
+SQLite has no `ALTER TABLE … ADD CONSTRAINT`, `ALTER COLUMN`, or change-nullability. To add a `CHECK`, change a type, or flip NOT NULL you have to do the rebuild dance (`CREATE TABLE x_new (…)` → `INSERT … SELECT *` → `DROP TABLE x` → `ALTER TABLE x_new RENAME TO x` → recreate indexes/triggers). With `foreign_keys = ON` (the default set by `db/client.ts`), `DROP TABLE` on a parent of any populated child table fails with `FOREIGN KEY constraint failed`. `PRAGMA foreign_keys` cannot be changed inside a transaction, and `PRAGMA defer_foreign_keys` does **not** defer the DROP-TABLE check (it only defers per-row FK violations).
+
+The migration runner (`apps/server/src/db/migrate.ts`) therefore wraps every migration in `PRAGMA foreign_keys = OFF` → `BEGIN IMMEDIATE` → migration body → `PRAGMA foreign_key_check` (pre-commit gate) → `COMMIT` → `PRAGMA foreign_keys = ON`. Migration authors do not need to add any pragma. The integrity gate runs `foreign_key_check` before COMMIT and aborts the transaction on any dangling reference, so disabling FKs around the body is safe. Enforced by `apps/server/src/test/invariants.test.ts::"migration runner FK-safety invariant"`.
+
 ## OpenSpec workflow
 
 Behavioral changes are spec-driven. Specs in `openspec/specs/<area>/`; active proposals in `openspec/changes/<name>/`; archived in `openspec/changes/archive/`. **Before changing a load-bearing invariant or adding a new MCP tool, open an OpenSpec change first.**

--- a/apps/server/src/db/migrate.ts
+++ b/apps/server/src/db/migrate.ts
@@ -13,6 +13,18 @@ import type { Database } from 'better-sqlite3';
  *
  * The transaction acts as a per-file lock: if two processes attempt to
  * migrate concurrently, SQLite serializes them via BEGIN IMMEDIATE.
+ *
+ * FK-safety dance: SQLite refuses `DROP TABLE` on a parent table whose
+ * children reference live rows when `foreign_keys=ON` (the default set
+ * by `db/client.ts`). `PRAGMA foreign_keys` cannot be changed inside an
+ * open transaction, and `PRAGMA defer_foreign_keys` does NOT defer the
+ * DROP-TABLE check (verified empirically: SQLite's DROP-TABLE FK check
+ * is independent of the per-row deferral mechanism). The canonical
+ * recipe — and the one we follow here — is: disable FKs outside the
+ * transaction, BEGIN IMMEDIATE, apply the migration, run
+ * `PRAGMA foreign_key_check` as the final pre-commit step, COMMIT, then
+ * re-enable FKs. Any FK violation introduced by the migration surfaces
+ * as a non-empty `foreign_key_check` result and aborts the transaction.
  */
 
 const MIGRATIONS_TABLE = `
@@ -67,15 +79,40 @@ export function migrate(db: Database, opts: MigrateOptions): MigrateResult {
       .map((s) => s.trim())
       .filter((s) => s.length > 0 && !isCommentOnly(s));
 
-    const apply = db.transaction(() => {
-      for (const stmt of statements) {
-        db.exec(stmt);
-      }
-      recordStmt.run(file, Date.now());
-    });
+    // Snapshot FK enforcement, disable around the migration (see note above),
+    // restore afterwards. Setting pragmas outside a transaction is what SQLite
+    // requires for `foreign_keys`.
+    const fkRow = db.prepare<[], { foreign_keys: number }>('PRAGMA foreign_keys').get();
+    const fkWasOn = fkRow?.foreign_keys === 1;
+    if (fkWasOn) db.exec('PRAGMA foreign_keys = OFF');
 
-    apply.immediate();
-    applied.push(file);
+    try {
+      const apply = db.transaction(() => {
+        for (const stmt of statements) {
+          db.exec(stmt);
+        }
+        // Pre-commit FK integrity gate. `foreign_key_check` returns one
+        // row per dangling reference; non-empty means the migration left
+        // the DB in an inconsistent state and we abort the transaction.
+        const violations = db
+          .prepare<
+            [],
+            { table: string; rowid: number | bigint; parent: string; fkid: number }
+          >('PRAGMA foreign_key_check')
+          .all();
+        if (violations.length > 0) {
+          throw new Error(
+            `Migration ${file} left foreign key violations: ${JSON.stringify(violations)}`,
+          );
+        }
+        recordStmt.run(file, Date.now());
+      });
+
+      apply.immediate();
+      applied.push(file);
+    } finally {
+      if (fkWasOn) db.exec('PRAGMA foreign_keys = ON');
+    }
   }
 
   return { applied, skipped };

--- a/apps/server/src/db/migrations.test.ts
+++ b/apps/server/src/db/migrations.test.ts
@@ -1,6 +1,17 @@
+import { copyFileSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import * as sqliteVec from 'sqlite-vec';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createTestDb, type TestDb } from '../test/index.js';
+
+import { migrate } from './migrate.js';
+
+const fullMigrationsDir = join(dirname(fileURLToPath(import.meta.url)), 'migrations');
 
 describe('migration 0011_summary_length_check', () => {
   let db: TestDb;
@@ -83,5 +94,122 @@ describe('migration 0011_summary_length_check', () => {
     expect(names).toContain('sessions_token_status_idx');
     expect(names).toContain('sessions_project_started_idx');
     expect(names).toContain('sessions_status_started_idx');
+  });
+});
+
+// Regression for the production incident where 0011 failed with
+// `FOREIGN KEY constraint failed` because `sessions` is a FK parent
+// (prompts/memory/confirmations all reference it) and the table-rebuild
+// dance dropped a populated parent under `foreign_keys=ON`. The fix is
+// `PRAGMA defer_foreign_keys = ON` at the top of the migration.
+describe('migration 0011 with referencing children', () => {
+  let dataDir: string;
+  let slicedDir: string;
+  let raw: Database.Database;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'rembric-mig11-data-'));
+    slicedDir = mkdtempSync(join(tmpdir(), 'rembric-mig11-slice-'));
+
+    const all = readdirSync(fullMigrationsDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort();
+    for (const f of all) {
+      if (f.startsWith('0011_')) break;
+      copyFileSync(join(fullMigrationsDir, f), join(slicedDir, f));
+    }
+
+    raw = new Database(join(dataDir, 'data.db'));
+    sqliteVec.load(raw);
+    raw.pragma('journal_mode = WAL');
+    raw.pragma('synchronous = NORMAL');
+    raw.pragma('foreign_keys = ON');
+    raw.pragma('busy_timeout = 5000');
+
+    migrate(raw, { migrationsDir: slicedDir });
+  });
+
+  afterEach(() => {
+    try {
+      raw.close();
+    } catch {
+      // ignore
+    }
+    rmSync(dataDir, { recursive: true, force: true });
+    rmSync(slicedDir, { recursive: true, force: true });
+  });
+
+  it('rebuilds sessions cleanly when prompts/memory/confirmations reference it', () => {
+    raw
+      .prepare(
+        "INSERT INTO tokens (id, name, hash, scope, created_at) VALUES ('tok1', 'tok1-name', 'h', '*', 0)",
+      )
+      .run();
+    raw
+      .prepare(
+        "INSERT INTO projects (id, slug, display_name, created_at) VALUES ('proj1', 'proj1', 'proj1', 0)",
+      )
+      .run();
+    raw
+      .prepare(
+        "INSERT INTO sessions (id, token_id, project_id, agent, started_at, summary, status) VALUES ('sess1', 'tok1', 'proj1', 'claude', 0, 'short', 'active')",
+      )
+      .run();
+
+    // FK children referencing sess1
+    raw
+      .prepare(
+        "INSERT INTO prompts (id, session_id, project_id, title, content, tags, replaces, created_at) VALUES ('p1', 'sess1', 'proj1', 'untitled', 'body', '[]', '[]', 0)",
+      )
+      .run();
+    raw
+      .prepare(
+        "INSERT INTO memory (id, scope, project_id, type, content, created_at, session_id) VALUES ('m1', 'project', 'proj1', 'fact', 'body', 0, 'sess1')",
+      )
+      .run();
+    raw
+      .prepare(
+        "INSERT INTO confirmations (id, memory_id, event_ts, session_id) VALUES ('c1', 'm1', 0, 'sess1')",
+      )
+      .run();
+
+    const before = raw
+      .prepare<[], { filename: string }>('SELECT filename FROM _migrations')
+      .all()
+      .map((r) => r.filename);
+    expect(before).not.toContain('0011_summary_length_check.sql');
+
+    // Re-run migrations against the FULL dir → only 0011 is new and runs.
+    const result = migrate(raw, { migrationsDir: fullMigrationsDir });
+    expect(result.applied).toEqual(['0011_summary_length_check.sql']);
+
+    // FK integrity after the rebuild.
+    const fkViolations = raw.prepare('PRAGMA foreign_key_check').all();
+    expect(fkViolations).toEqual([]);
+
+    // Children still point at the rebuilt session row.
+    const session = raw
+      .prepare<
+        [],
+        { id: string; summary: string | null }
+      >("SELECT id, summary FROM sessions WHERE id = 'sess1'")
+      .get();
+    expect(session).toEqual({ id: 'sess1', summary: 'short' });
+
+    const childSessIds = raw
+      .prepare<[], { src: string; sid: string | null }>(
+        `SELECT 'prompts' AS src, session_id AS sid FROM prompts WHERE id = 'p1'
+         UNION ALL SELECT 'memory', session_id FROM memory WHERE id = 'm1'
+         UNION ALL SELECT 'confirmations', session_id FROM confirmations WHERE id = 'c1'`,
+      )
+      .all();
+    for (const row of childSessIds) {
+      expect(row.sid).toBe('sess1');
+    }
+
+    // CHECK constraint is now in effect.
+    expect(() =>
+      raw.prepare("UPDATE sessions SET summary = ? WHERE id = 'sess1'").run('a'.repeat(2001)),
+    ).toThrow(/CHECK constraint failed/);
   });
 });

--- a/apps/server/src/db/migrations/0011_summary_length_check.sql
+++ b/apps/server/src/db/migrations/0011_summary_length_check.sql
@@ -25,6 +25,12 @@
 -- (`agent`, `token_id`, `project_id`, `started_at`) is touched and no row
 -- is deleted. Truncation is one-way; operators wanting to preserve
 -- pre-cap content SHOULD take a `sqlite3 .backup` before the upgrade.
+--
+-- FK safety: this rebuild DROPs `sessions`, which is the parent of
+-- prompts.session_id / memory.session_id / confirmations.session_id. The
+-- migration runner (`apps/server/src/db/migrate.ts`) wraps every migration
+-- in `PRAGMA foreign_keys=OFF` … `PRAGMA foreign_key_check` … `COMMIT`
+-- so the DROP succeeds and the post-rebuild integrity is still validated.
 
 UPDATE sessions
    SET summary = substr(summary, 1, 1987) || '…[truncated]'

--- a/apps/server/src/test/invariants.test.ts
+++ b/apps/server/src/test/invariants.test.ts
@@ -503,3 +503,37 @@ describe('install URL drift invariant', () => {
     }
   });
 });
+
+// SQLite migration FK-safety: SQLite refuses `DROP TABLE` on a parent
+// table whose children reference live rows when `foreign_keys=ON`, and
+// `db/client.ts` enables FKs before running migrations. `PRAGMA foreign_keys`
+// cannot be changed inside a transaction and `defer_foreign_keys` does NOT
+// defer the DROP-TABLE check (verified empirically). The migration runner
+// therefore MUST disable FKs around each migration transaction and run
+// `PRAGMA foreign_key_check` as the final pre-commit step. Without this
+// dance, any rebuild of a populated parent table fails at startup with
+// `rembric: FOREIGN KEY constraint failed` (the production incident that
+// motivated openspec/changes/fix-sessions-rebuild-fk-safety/).
+describe('migration runner FK-safety invariant', () => {
+  const migrateSrc = readFileSync(join(srcRoot, 'db/migrate.ts'), 'utf8');
+
+  it('migrate.ts disables foreign_keys around each migration transaction', () => {
+    expect(/PRAGMA\s+foreign_keys\s*=\s*OFF/i.test(migrateSrc)).toBe(true);
+    expect(/PRAGMA\s+foreign_keys\s*=\s*ON/i.test(migrateSrc)).toBe(true);
+  });
+
+  it('migrate.ts runs PRAGMA foreign_key_check before commit', () => {
+    expect(/PRAGMA\s+foreign_key_check/i.test(migrateSrc)).toBe(true);
+  });
+
+  it('migrate.ts restores foreign_keys via a finally block', () => {
+    // Belt-and-suspenders: a thrown migration must not leave FKs disabled
+    // for the rest of the process. The check below is intentionally loose
+    // (greps for `finally` near a `PRAGMA foreign_keys = ON`) so a refactor
+    // that keeps the semantics passes.
+    const finallyBlock = migrateSrc.match(
+      /finally\s*\{[\s\S]{0,200}?PRAGMA\s+foreign_keys\s*=\s*ON/i,
+    );
+    expect(finallyBlock, 'expected a finally block that re-enables foreign_keys').not.toBeNull();
+  });
+});

--- a/openspec/changes/archive/2026-05-22-fix-sessions-rebuild-fk-safety/design.md
+++ b/openspec/changes/archive/2026-05-22-fix-sessions-rebuild-fk-safety/design.md
@@ -1,0 +1,91 @@
+## Context
+
+`apps/server/src/db/client.ts:50` enables `PRAGMA foreign_keys = ON` before running migrations. This is correct for runtime safety but interacts badly with the SQLite table-rebuild pattern. Migration `0011_summary_length_check.sql` rebuilds `sessions` to add a `CHECK` constraint to `sessions.summary`; `sessions` is a parent table for `prompts.session_id`, `memory.session_id`, and `confirmations.session_id`. With FKs enabled and any child row present, `DROP TABLE sessions` raises `FOREIGN KEY constraint failed`.
+
+The migration runner (`apps/server/src/db/migrate.ts`) wraps every file in `db.transaction(...).immediate()`. SQLite forbids changing `PRAGMA foreign_keys` mid-transaction (the pragma is silently ignored). The deferred variant — `PRAGMA defer_foreign_keys = ON` — does honor in-transaction setting, but we verified empirically that it only defers per-row FK violations, NOT the DROP-TABLE check, which fires independently:
+
+```sql
+PRAGMA foreign_keys = ON;
+CREATE TABLE parent (id INTEGER PRIMARY KEY);
+CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id));
+INSERT INTO parent VALUES (1);
+INSERT INTO child VALUES (10, 1);
+BEGIN;
+  PRAGMA defer_foreign_keys = ON;
+  -- ... rebuild ...
+  DROP TABLE parent;   -- ➜ FOREIGN KEY constraint failed
+COMMIT;
+```
+
+Replacing `defer_foreign_keys = ON` with `PRAGMA foreign_keys = OFF` outside the BEGIN, then running `PRAGMA foreign_key_check` before COMMIT, succeeds.
+
+## Goals / Non-Goals
+
+Goals:
+
+- Unblock production servers that are currently stuck on `rembric: FOREIGN KEY constraint failed` at startup.
+- Preserve every existing migration body (no `.sql` file changes).
+- Make future migrations FK-safe by default. The next person adding a table-rebuild migration should not have to remember anything about FKs.
+- Catch any future FK violation a migration accidentally introduces — not just for rebuilds, but for any kind of FK-affecting change.
+
+Non-goals:
+
+- Per-file directive support (e.g., `-- migrate:fk-safe`). Rejected: every migration we ship is FK-affecting somewhere, and explicit opt-in is just deferred ignorance. Always-on with a `foreign_key_check` gate is simpler and safer.
+- Rolling out a "repair 0012" migration. The runner is atomic; if 0011 failed it rolled back without recording, so the corrected runner re-applies it cleanly. Adding a 0012 would duplicate state-tracking work that `_migrations` already does.
+
+## Decisions
+
+### Decision 1 · Fix lives in the runner, not in the `.sql`
+
+We considered three locations:
+
+| Where                                         | Pros                             | Cons                                                                              |
+| --------------------------------------------- | -------------------------------- | --------------------------------------------------------------------------------- |
+| Per-file `PRAGMA defer_foreign_keys = ON`     | Minimal surface; explicit        | **Doesn't actually work** (verified empirically)                                  |
+| Per-file `PRAGMA foreign_keys = OFF`          | Canonical SQLite recipe          | Impossible: pragma ignored mid-transaction; runner wraps in `db.transaction(...)` |
+| Runner: pragma toggle around each transaction | Works; centralized; future-proof | Changes runner semantics for ALL migrations                                       |
+
+The runner change is the only viable option once the empirical test ruled out `defer_foreign_keys`. Changing runner semantics globally is acceptable because the alternative — invoking custom statements to BEGIN/COMMIT manually per migration — is more invasive (requires splitting better-sqlite3's transaction abstraction) and harder to reason about.
+
+### Decision 2 · Always disable FKs around every migration, not just rebuilds
+
+We could detect the table-rebuild pattern (DROP TABLE + RENAME TO same identifier) and only toggle FKs for those files. We chose blanket disable because:
+
+- Detection is heuristic; future migrations could use other DDL patterns that also trip the FK check.
+- Even non-rebuild migrations occasionally need temporary FK-violating state mid-flight (e.g., when batch-renumbering rows). Always-OFF removes a class of pitfall.
+- The `foreign_key_check` pre-commit gate makes always-OFF safe: any inconsistency the migration leaves behind aborts the transaction.
+- Migration authors don't have to think about this. Less load-bearing knowledge to pass forward.
+
+### Decision 3 · `PRAGMA foreign_key_check` is the integrity gate
+
+`foreign_key_check` returns one row per dangling reference currently in the schema. With FKs disabled during the migration body, this is the _only_ safety net for accidental FK violations. We run it as the last statement inside the transaction, before recording `_migrations` and before COMMIT. A non-empty result throws and rolls back.
+
+This is mildly stricter than runtime: at runtime, FK violations are caught per-INSERT/UPDATE. During a migration, an intermediate state that violates FKs is acceptable as long as the _final_ state is consistent.
+
+### Decision 4 · `finally` restoration so a thrown migration cannot leave FKs disabled
+
+If a migration throws (CHECK violation, syntax error, FK violation surfaced by the gate), the surrounding `try` body unwinds and the `finally` block re-enables `foreign_keys`. Without this, a failed startup would leave the connection (long-lived after migration) with FKs disabled, weakening runtime safety. The invariant test asserts the `finally` block exists.
+
+### Decision 5 · No `.sql` migration changes
+
+The migration files stay byte-identical (modulo a comment update in `0011` explaining the runner contract). Any servers where 0011 already applied skip the file by `_migrations` row. Servers where 0011 failed (no `_migrations` row, transaction rolled back) re-apply the unchanged SQL under the corrected runner and succeed. Fresh installs use the same path as failed-prod servers.
+
+## Risks / Trade-offs
+
+- **Risk**: A migration that _depends on_ row-level FK enforcement (e.g., relies on an INSERT failing with FK violation as a guard) now silently succeeds. _Mitigation_: such a migration is anti-pattern (schema-level guards belong in CHECK constraints, not in observed INSERT failures); the `foreign_key_check` gate catches the final-state inconsistency.
+- **Risk**: `PRAGMA foreign_keys` toggle adds a few microseconds per migration application. _Mitigation_: irrelevant — migrations are startup-only and rare.
+- **Trade-off**: We diverge from "the .sql is the entire story for a migration". The runner now contributes load-bearing behavior. Documented in CLAUDE.md and enforced by the invariant test.
+
+## Migration Plan
+
+1. Update `migrate.ts` (the runner change).
+2. Add regression test in `migrations.test.ts`.
+3. Add invariant test in `invariants.test.ts`.
+4. Add convention subsection to `CLAUDE.md`.
+5. Update `0011_summary_length_check.sql` comment header to reference the runner contract (no executable change).
+6. CI green → bump server (release-please picks up the conventional commit).
+7. Operators with the failing image pull the new tag; next restart re-runs 0011 under the corrected runner and is recorded in `_migrations`.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-05-22-fix-sessions-rebuild-fk-safety/proposal.md
+++ b/openspec/changes/archive/2026-05-22-fix-sessions-rebuild-fk-safety/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+Migration `0011_summary_length_check.sql` performs the SQLite table-rebuild dance on `sessions` — a parent table referenced by `prompts.session_id`, `memory.session_id`, and `confirmations.session_id`. With `PRAGMA foreign_keys = ON` (set by `apps/server/src/db/client.ts:50` before migrations run), the `DROP TABLE sessions` step fails on any database that already holds child rows referencing a session:
+
+```
+rembric: FOREIGN KEY constraint failed
+```
+
+The bug shipped through CI because the only test for 0011 (`apps/server/src/db/migrations.test.ts`) exercised a fresh DB, and the dev stack wipes/reseeds before testing — neither path holds child rows when 0011 first applies. Production (with months of `memory` and `prompts` accumulated) does, and the server refused to boot after pulling the image.
+
+The first instinct (and the one prescribed in the original `summary-length-cap` change task 4.2) was `PRAGMA foreign_keys = OFF` around the rebuild — but the migration runner wraps every file in `db.transaction(...).immediate()`, and `PRAGMA foreign_keys` is silently ignored mid-transaction. The second instinct (`PRAGMA defer_foreign_keys = ON`) does honor in-transaction setting, but an empirical test confirms it does NOT defer SQLite's DROP-TABLE FK check — that check fires independently of the per-row deferral mechanism. The only working approach is the canonical SQLite recipe: disable FKs _outside_ the transaction, do the rebuild, run `PRAGMA foreign_key_check` as the final pre-commit step, COMMIT, then re-enable FKs. Since this dance is needed for any table-rebuild migration on any FK parent, the fix belongs in the migration runner — not in each `.sql` file.
+
+## What Changes
+
+- **BREAKING (runner semantics)** Modify `apps/server/src/db/migrate.ts` so each migration is wrapped in: snapshot `foreign_keys` pragma → set OFF → `BEGIN IMMEDIATE` → apply statements → `PRAGMA foreign_key_check` (abort transaction on any non-empty result) → record in `_migrations` → COMMIT → restore `foreign_keys` to its prior value. The pragma flip happens outside the transaction (required by SQLite); the integrity gate inside the transaction prevents FK violations from being committed.
+- Add a regression test in `apps/server/src/db/migrations.test.ts` that exercises the production scenario: apply migrations up to and including 0010 against a DB pre-populated with token + project + session + `prompts`/`memory`/`confirmations` rows referencing the session; assert the runner applies 0011 successfully and all FK references still resolve via `PRAGMA foreign_key_check`.
+- Add a structural invariant in `apps/server/src/test/invariants.test.ts` that asserts `migrate.ts` keeps the FK-toggling dance: presence of `PRAGMA foreign_keys = OFF`, `PRAGMA foreign_keys = ON` in a `finally` block, and `PRAGMA foreign_key_check`. If a future refactor breaks any of these, CI fails.
+- Document the SQLite table-rebuild + runner contract in `CLAUDE.md` under a new subsection so future migration authors don't have to rediscover this.
+- Add a new requirement to `openspec/specs/persistence/spec.md` (via this change's spec delta) codifying the runner-level FK-safety contract.
+
+No migration `.sql` files change. The fix is centralized in the runner.
+
+## Capabilities
+
+### New Capabilities
+
+_None._ This change reinforces existing requirements in `persistence`.
+
+### Modified Capabilities
+
+- `persistence`: new requirement that the migration runner MUST disable `foreign_keys` around each migration transaction and validate via `foreign_key_check` before commit. Migration `.sql` files MAY assume FKs are off during their execution and MUST NOT rely on row-level FK enforcement during the migration body.
+
+## Impact
+
+Affected code:
+
+- `apps/server/src/db/migrate.ts` (runner: pragma toggle + foreign_key_check gate, ~25 lines added)
+- `apps/server/src/db/migrations.test.ts` (new regression test)
+- `apps/server/src/test/invariants.test.ts` (new structural check on migrate.ts)
+- `CLAUDE.md` (new convention subsection)
+- `openspec/specs/persistence/spec.md` (new requirement, via this change's delta)
+
+Affected operators:
+
+- Production servers stuck on `rembric: FOREIGN KEY constraint failed` recover by pulling the image with this fix and restarting. The next startup re-runs 0011 (still missing from `_migrations` because the prior transaction rolled back) and succeeds.
+- Servers where 0011 already applied are untouched (the runner skips by `_migrations` row, same as before).
+- Fresh installs apply 0011 directly under the new runner; no observable difference.
+
+No data loss, no schema divergence, no manual operator step required.

--- a/openspec/changes/archive/2026-05-22-fix-sessions-rebuild-fk-safety/specs/persistence/spec.md
+++ b/openspec/changes/archive/2026-05-22-fix-sessions-rebuild-fk-safety/specs/persistence/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: The migration runner MUST disable `foreign_keys` around each migration transaction
+
+The migration runner at `apps/server/src/db/migrate.ts` SHALL execute each pending migration with the following structure:
+
+1. Snapshot the current value of `PRAGMA foreign_keys`.
+2. If FKs were enabled, execute `PRAGMA foreign_keys = OFF` *outside* the transaction. (SQLite ignores changes to this pragma inside an open transaction.)
+3. `BEGIN IMMEDIATE` and apply the migration's statements.
+4. As the final statement inside the transaction, execute `PRAGMA foreign_key_check`. If the result is non-empty, throw an error naming the migration file and including the violation rows; the transaction SHALL roll back.
+5. Record the migration filename in `_migrations` and `COMMIT`.
+6. Restore the original `PRAGMA foreign_keys` value via a `finally` block, so a thrown migration does not leave the long-lived connection with FKs disabled.
+
+This dance is required because:
+
+- SQLite refuses `DROP TABLE` on a parent table with live child references when `foreign_keys = ON`. The DROP-TABLE check fires independently of the per-row deferral mechanism (`PRAGMA defer_foreign_keys`).
+- `PRAGMA foreign_keys` is silently ignored inside an open transaction, so the disable must precede `BEGIN`.
+- `PRAGMA foreign_key_check` is the pre-commit integrity gate that compensates for the disabled enforcement during the migration body.
+
+Migration `.sql` files MAY assume FKs are off during their execution and MUST NOT rely on row-level FK enforcement during the migration body.
+
+#### Scenario: Table-rebuild migration on a parent table with live child rows
+
+- **GIVEN** a populated database where `sessions` is referenced by rows in `prompts.session_id`, `memory.session_id`, and `confirmations.session_id`
+- **AND** `PRAGMA foreign_keys = ON` (set by `db/client.ts` on startup)
+- **WHEN** a migration runs that rebuilds `sessions` via `CREATE TABLE sessions_new …; INSERT INTO sessions_new SELECT * FROM sessions; DROP TABLE sessions; ALTER TABLE sessions_new RENAME TO sessions;`
+- **THEN** the runner SHALL disable `foreign_keys` outside the transaction
+- **AND** the migration SHALL succeed
+- **AND** `PRAGMA foreign_key_check` inside the transaction SHALL return zero rows
+- **AND** `foreign_keys` SHALL be restored to `ON` after COMMIT
+- **AND** all child rows in `prompts` / `memory` / `confirmations` SHALL continue to reference valid `sessions.id` values
+
+#### Scenario: Migration that introduces a foreign-key violation is rolled back
+
+- **GIVEN** a migration whose body inserts a row into a child table referencing a non-existent parent row
+- **WHEN** the runner reaches the `PRAGMA foreign_key_check` pre-commit gate
+- **THEN** the check SHALL return one row identifying the dangling reference
+- **AND** the runner SHALL throw with a message naming the migration file
+- **AND** the transaction SHALL roll back, leaving `_migrations` unchanged
+- **AND** `foreign_keys` SHALL be restored to `ON` by the `finally` block
+
+#### Scenario: Migration 0011 re-applies cleanly on a previously-failed server
+
+- **GIVEN** a server where `0011_summary_length_check.sql` previously failed with `FOREIGN KEY constraint failed` (so `_migrations` has no row for `0011_*`, and the schema is in the pre-rebuild state)
+- **WHEN** the server starts with the corrected migration runner
+- **THEN** the runner SHALL apply `0011_summary_length_check.sql` successfully
+- **AND** the resulting `sessions` table SHALL carry the `CHECK (summary IS NULL OR length(summary) <= 2000)` constraint
+- **AND** all pre-existing child rows in `prompts` / `memory` / `confirmations` SHALL still reference the rebuilt `sessions` rows
+
+#### Scenario: Migration 0011 is a no-op on servers where it already applied
+
+- **GIVEN** a server where `0011_summary_length_check.sql` previously applied successfully (so `_migrations` has a row for `0011_*`)
+- **WHEN** the server starts with the corrected migration runner
+- **THEN** the runner SHALL detect the existing `_migrations` entry by filename and SHALL skip the file entirely
+- **AND** the database schema SHALL be unchanged
+- **AND** the startup SHALL proceed without error
+
+#### Scenario: Static invariant guards against future regression
+
+- **GIVEN** the test suite in `apps/server/src/test/invariants.test.ts`
+- **WHEN** CI runs
+- **THEN** the suite SHALL assert that `migrate.ts` contains `PRAGMA foreign_keys = OFF`, `PRAGMA foreign_keys = ON` in a `finally` block, and `PRAGMA foreign_key_check`
+- **AND** any future refactor that removes the FK-toggling dance SHALL fail CI

--- a/openspec/changes/archive/2026-05-22-fix-sessions-rebuild-fk-safety/tasks.md
+++ b/openspec/changes/archive/2026-05-22-fix-sessions-rebuild-fk-safety/tasks.md
@@ -1,0 +1,32 @@
+## 1. Migration runner fix
+
+- [x] 1.1 In `apps/server/src/db/migrate.ts`, wrap each migration application in: snapshot `PRAGMA foreign_keys`, `PRAGMA foreign_keys = OFF` (outside transaction), `BEGIN IMMEDIATE` (via `db.transaction(...).immediate()`), apply statements, run `PRAGMA foreign_key_check` and throw on non-empty result, record `_migrations`, COMMIT, restore `foreign_keys` in a `finally` block.
+- [x] 1.2 Update the top-of-file docstring to document the FK-safety dance and reference the production incident and the invariant test.
+
+## 2. Migration file comment
+
+- [x] 2.1 Update the comment header of `apps/server/src/db/migrations/0011_summary_length_check.sql` to reference the runner contract (no executable change to the SQL).
+
+## 3. Regression test
+
+- [x] 3.1 In `apps/server/src/db/migrations.test.ts`, add a new `describe('migration 0011 with referencing children')` block that opens a fresh DB, applies migrations 0000…0010, populates token + project + session + child rows in `prompts`/`memory`/`confirmations` referencing the session, then re-runs `migrate(...)` against the full migrations dir.
+- [x] 3.2 Assert: no throw; `PRAGMA foreign_key_check` returns zero rows; child rows still reference the rebuilt session; the new CHECK constraint rejects oversized summaries.
+- [x] 3.3 Clean up temp DB and sliced migrations dir in `afterEach`.
+
+## 4. Structural invariant
+
+- [x] 4.1 In `apps/server/src/test/invariants.test.ts`, add a `describe('migration runner FK-safety invariant')` block.
+- [x] 4.2 Assert `migrate.ts` contains `PRAGMA foreign_keys = OFF`, `PRAGMA foreign_keys = ON` in a `finally` block, and `PRAGMA foreign_key_check`.
+
+## 5. Convention doc
+
+- [x] 5.1 Add a `### Table-rebuild migrations (SQLite)` subsection to `CLAUDE.md` under `## Architecture`, explaining the SQLite gotchas (FKs ignored mid-transaction, `defer_foreign_keys` doesn't defer DROP TABLE) and pointing at the invariant test.
+
+## 6. Validation
+
+- [x] 6.1 `pnpm run typecheck` — green.
+- [x] 6.2 `pnpm test` — green (including the new regression and invariant).
+
+## 7. Archive
+
+- [x] 7.1 After merge, archive this change with `/opsx:archive fix-sessions-rebuild-fk-safety`.

--- a/openspec/specs/persistence/spec.md
+++ b/openspec/specs/persistence/spec.md
@@ -527,3 +527,65 @@ The migration SHALL be one-way: truncation is lossy and SHALL NOT be reversed by
 - **WHEN** migration `0010_summary_length_check.sql` completes
 - **THEN** every index that existed on the original `sessions` table (project lookup, token lookup, status filter, started_at/ended_at ordering, deleted_at filter) SHALL exist on the rebuilt table
 - **AND** any trigger or foreign-key declaration declared in `0003_sessions_and_slugs.sql` and subsequent migrations SHALL continue to be enforced after the rebuild (verified by a follow-up insert/delete cycle in the integration test)
+
+### Requirement: The migration runner MUST disable `foreign_keys` around each migration transaction
+
+The migration runner at `apps/server/src/db/migrate.ts` SHALL execute each pending migration with the following structure:
+
+1. Snapshot the current value of `PRAGMA foreign_keys`.
+2. If FKs were enabled, execute `PRAGMA foreign_keys = OFF` _outside_ the transaction. (SQLite ignores changes to this pragma inside an open transaction.)
+3. `BEGIN IMMEDIATE` and apply the migration's statements.
+4. As the final statement inside the transaction, execute `PRAGMA foreign_key_check`. If the result is non-empty, throw an error naming the migration file and including the violation rows; the transaction SHALL roll back.
+5. Record the migration filename in `_migrations` and `COMMIT`.
+6. Restore the original `PRAGMA foreign_keys` value via a `finally` block, so a thrown migration does not leave the long-lived connection with FKs disabled.
+
+This dance is required because:
+
+- SQLite refuses `DROP TABLE` on a parent table with live child references when `foreign_keys = ON`. The DROP-TABLE check fires independently of the per-row deferral mechanism (`PRAGMA defer_foreign_keys`).
+- `PRAGMA foreign_keys` is silently ignored inside an open transaction, so the disable must precede `BEGIN`.
+- `PRAGMA foreign_key_check` is the pre-commit integrity gate that compensates for the disabled enforcement during the migration body.
+
+Migration `.sql` files MAY assume FKs are off during their execution and MUST NOT rely on row-level FK enforcement during the migration body.
+
+#### Scenario: Table-rebuild migration on a parent table with live child rows
+
+- **GIVEN** a populated database where `sessions` is referenced by rows in `prompts.session_id`, `memory.session_id`, and `confirmations.session_id`
+- **AND** `PRAGMA foreign_keys = ON` (set by `db/client.ts` on startup)
+- **WHEN** a migration runs that rebuilds `sessions` via `CREATE TABLE sessions_new …; INSERT INTO sessions_new SELECT * FROM sessions; DROP TABLE sessions; ALTER TABLE sessions_new RENAME TO sessions;`
+- **THEN** the runner SHALL disable `foreign_keys` outside the transaction
+- **AND** the migration SHALL succeed
+- **AND** `PRAGMA foreign_key_check` inside the transaction SHALL return zero rows
+- **AND** `foreign_keys` SHALL be restored to `ON` after COMMIT
+- **AND** all child rows in `prompts` / `memory` / `confirmations` SHALL continue to reference valid `sessions.id` values
+
+#### Scenario: Migration that introduces a foreign-key violation is rolled back
+
+- **GIVEN** a migration whose body inserts a row into a child table referencing a non-existent parent row
+- **WHEN** the runner reaches the `PRAGMA foreign_key_check` pre-commit gate
+- **THEN** the check SHALL return one row identifying the dangling reference
+- **AND** the runner SHALL throw with a message naming the migration file
+- **AND** the transaction SHALL roll back, leaving `_migrations` unchanged
+- **AND** `foreign_keys` SHALL be restored to `ON` by the `finally` block
+
+#### Scenario: Migration 0011 re-applies cleanly on a previously-failed server
+
+- **GIVEN** a server where `0011_summary_length_check.sql` previously failed with `FOREIGN KEY constraint failed` (so `_migrations` has no row for `0011_*`, and the schema is in the pre-rebuild state)
+- **WHEN** the server starts with the corrected migration runner
+- **THEN** the runner SHALL apply `0011_summary_length_check.sql` successfully
+- **AND** the resulting `sessions` table SHALL carry the `CHECK (summary IS NULL OR length(summary) <= 2000)` constraint
+- **AND** all pre-existing child rows in `prompts` / `memory` / `confirmations` SHALL still reference the rebuilt `sessions` rows
+
+#### Scenario: Migration 0011 is a no-op on servers where it already applied
+
+- **GIVEN** a server where `0011_summary_length_check.sql` previously applied successfully (so `_migrations` has a row for `0011_*`)
+- **WHEN** the server starts with the corrected migration runner
+- **THEN** the runner SHALL detect the existing `_migrations` entry by filename and SHALL skip the file entirely
+- **AND** the database schema SHALL be unchanged
+- **AND** the startup SHALL proceed without error
+
+#### Scenario: Static invariant guards against future regression
+
+- **GIVEN** the test suite in `apps/server/src/test/invariants.test.ts`
+- **WHEN** CI runs
+- **THEN** the suite SHALL assert that `migrate.ts` contains `PRAGMA foreign_keys = OFF`, `PRAGMA foreign_keys = ON` in a `finally` block, and `PRAGMA foreign_key_check`
+- **AND** any future refactor that removes the FK-toggling dance SHALL fail CI


### PR DESCRIPTION
## Summary

- Fixes `rembric: FOREIGN KEY constraint failed` at server startup when migration 0011 rebuilds the `sessions` table on a populated DB.
- Root cause: `sessions` is the FK parent of `prompts` / `memory` / `confirmations`; with `PRAGMA foreign_keys = ON` (set by `db/client.ts:50`), `DROP TABLE sessions` raises FK violation. `PRAGMA foreign_keys` is silently ignored mid-transaction; `PRAGMA defer_foreign_keys` does **not** defer the DROP-TABLE check (verified empirically with sqlite3 CLI).
- Fix lives in the **migration runner**, not in any `.sql` file. The runner now disables `foreign_keys` outside the transaction, runs the migration, runs `PRAGMA foreign_key_check` as the pre-commit integrity gate, COMMITs, then restores `foreign_keys` via `finally`. Migration files stay byte-identical.

## Why the runner-level fix

Production servers (where 0011 rolled back) re-apply the unchanged SQL under the corrected runner and succeed. Servers where 0011 already applied skip the file by `_migrations` row, unchanged. Fresh installs: same path as failed-prod. Zero `.sql` migration churn.

The integrity gate (`foreign_key_check` inside the transaction) catches any FK violation a migration accidentally introduces and aborts the transaction.

## What's added

- `apps/server/src/db/migrate.ts` — pragma toggle + `foreign_key_check` gate + `finally` restoration.
- `apps/server/src/db/migrations.test.ts` — regression test: populate `prompts` / `memory` / `confirmations` rows referencing a session before applying 0011, assert it succeeds and FK integrity is preserved.
- `apps/server/src/test/invariants.test.ts` — 3 structural invariants asserting `migrate.ts` keeps the FK-toggling dance (`OFF`, `ON` in `finally`, `foreign_key_check`).
- `CLAUDE.md` — new "Table-rebuild migrations (SQLite)" subsection documenting the gotcha so future authors don't re-litigate.
- `openspec/specs/persistence/spec.md` — new requirement with 5 scenarios (synced from `openspec/changes/archive/2026-05-22-fix-sessions-rebuild-fk-safety/`).

## Test plan

- [x] `pnpm run typecheck` — green.
- [x] `pnpm test` — 545/545 passing, including the new regression test (`migration 0011 with referencing children > rebuilds sessions cleanly when prompts/memory/confirmations reference it`) and the 3 new invariants.
- [ ] Manual verification on the affected production server: pull the image built from this branch, restart, confirm startup succeeds, confirm `0011_summary_length_check.sql` is now in `_migrations`, confirm child row counts unchanged.

## OpenSpec

Change archived at `openspec/changes/archive/2026-05-22-fix-sessions-rebuild-fk-safety/` with proposal, design (incl. empirical disproof of `defer_foreign_keys`), tasks, and spec delta.