### PR TITLE
chore(release-please): enable patch bumps for server pre-1.0 fixes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,7 @@
       "include-v-in-tag": true,
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
       "changelog-sections": [


### PR DESCRIPTION
## Summary

Flip `apps/server :: bump-patch-for-minor-pre-major` from `false` to `true` in `release-please-config.json` so future `fix(server):` commits automatically open release PRs without needing an empty `Release-As` override.

## Motivation

The FK migration runner crash in #93 was a hot-fix blocking production startup, but release-please ignored it because the current config says: *while pre-1.0, only `feat:` commits trigger releases; `fix:` ones accumulate until the next feature drop*. We had to ship 0.20.1 via the empty-commit `Release-As: 0.20.1` workaround in #94.

That policy made sense when the server was a personal-use prototype. It does not make sense now that there are deployed environments that need patch releases to land promptly. Flipping the flag aligns release cadence with the operator reality: a `fix(server):` commit becomes a release PR.

## What changes

- `release-please-config.json`: one line, `false` → `true` under `apps/server`. Other packages (`plugin-shared`, `claude-code-plugin`, `codex-plugin`, `hermes-plugin`, `opencode-plugin`) keep the old `false` — fix cadence for plugins is much less urgent and their consumers tolerate batching.

## Behavior after merge

| Commit | Before | After |
|---|---|---|
| `feat(server): …` | minor bump (0.20.0 → 0.21.0) | unchanged |
| `fix(server): …` | **no release** | patch bump (0.21.0 → 0.21.1) |
| `feat(server)!: …` | minor bump (`bump-minor-pre-major` policy) | unchanged |
| `chore(server): …` | no release | unchanged |

## Test plan

- [x] Diff verified: one-line change, no other configs touched.
- [x] Commit lints + typechecks (pre-commit ran).
- [ ] After merge + the next `fix(server):` commit, verify release-please opens a `chore(main): release server …` PR automatically.

## Out of scope

- Repeating the same flip for plugins. Open a separate PR if desired.
- Migrating to `1.x` versioning (which would render the `pre-major` flags moot).

Refs: #93 (the fix), #94 (the one-shot release that this PR makes future-proof).