### PR TITLE
fix(server): retry model bake on HF 429 + optional hf_token build secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
           push: false
           cache-from: type=gha,scope=docker-build-check-runtime
           cache-to: type=gha,mode=max,scope=docker-build-check-runtime
+          # Empty on fork PRs (no secrets) → model bake falls back to anonymous + retry.
+          secrets: |
+            hf_token=${{ secrets.HF_TOKEN }}
 
       - name: Build dev target
         uses: docker/build-push-action@v7
@@ -90,3 +93,5 @@ jobs:
           push: false
           cache-from: type=gha,scope=docker-build-check-dev
           cache-to: type=gha,mode=max,scope=docker-build-check-dev
+          secrets: |
+            hf_token=${{ secrets.HF_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,6 +24,9 @@ on:
       gh_token:
         description: "Token with `packages: write`. Defaults to the caller workflow's GITHUB_TOKEN."
         required: false
+      hf_token:
+        description: 'Hugging Face read token for the model bake (avoids anonymous-IP 429s).'
+        required: false
 
 permissions:
   contents: read
@@ -109,6 +112,8 @@ jobs:
           labels: ${{ steps.meta_immutable.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            hf_token=${{ secrets.hf_token }}
 
       - name: Smoke test published image (three independent signals)
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,6 +48,8 @@ jobs:
     uses: ./.github/workflows/docker-publish.yml
     with:
       tag: ${{ needs.release-please.outputs.server_tag_name }}
+    secrets:
+      hf_token: ${{ secrets.HF_TOKEN }}
     permissions:
       contents: read
       packages: write

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.10
 
 # Stage order is load-bearing: `runtime` MUST be last so `docker build .`
 # without `--target` builds the prod image by default. See
@@ -30,7 +30,8 @@ RUN pnpm install --frozen-lockfile --filter @rembric/server...
 # functional validation: a drifted artifact fails the build.
 COPY apps/server/scripts/fetch-model.mjs ./apps/server/scripts/fetch-model.mjs
 WORKDIR /app/apps/server
-RUN node scripts/fetch-model.mjs /models
+# Optional hf_token secret avoids anonymous-IP 429s on CI runners.
+RUN --mount=type=secret,id=hf_token,env=HF_TOKEN node scripts/fetch-model.mjs /models
 
 # Copy the server source.
 WORKDIR /app
@@ -69,7 +70,7 @@ RUN pnpm install --frozen-lockfile --filter @rembric/server...
 # Bake the embedding model into the dev image too (same cache-friendly
 # ordering as the builder stage; dev parity with the runtime image).
 COPY --chown=rembric:rembric apps/server/scripts/fetch-model.mjs ./apps/server/scripts/fetch-model.mjs
-RUN cd /app/apps/server && node scripts/fetch-model.mjs /app/models
+RUN --mount=type=secret,id=hf_token,env=HF_TOKEN cd /app/apps/server && node scripts/fetch-model.mjs /app/models
 
 COPY --chown=rembric:rembric apps/server ./apps/server
 

--- a/apps/server/scripts/fetch-model.mjs
+++ b/apps/server/scripts/fetch-model.mjs
@@ -25,11 +25,31 @@ if (!target) {
 console.error(`fetch-model: ${MODEL_ID}@${REVISION.slice(0, 7)} dtype=${DTYPE} → ${target}`);
 
 // Phase 1 — download at the pinned revision into a throwaway cache.
+// Anonymous requests from shared CI runners get rate-limited by HF (429);
+// transformers.js sends Authorization automatically when HF_TOKEN is set
+// (wired as a Docker build secret), and transient failures retry with
+// backoff. A non-transient error (bad revision, 401) fails immediately.
 const tmpCache = join(target, '.cache-tmp');
 {
   const { env, pipeline } = await import('@huggingface/transformers');
   env.cacheDir = tmpCache;
-  await pipeline('feature-extraction', MODEL_ID, { dtype: DTYPE, revision: REVISION });
+  const ATTEMPTS = 5;
+  const TRANSIENT = /\((429|5\d{2})\)|fetch failed|ECONNRESET|ETIMEDOUT|EAI_AGAIN/;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await pipeline('feature-extraction', MODEL_ID, { dtype: DTYPE, revision: REVISION });
+      break;
+    } catch (err) {
+      const msg = String(err?.message ?? err);
+      if (attempt >= ATTEMPTS || !TRANSIENT.test(msg)) throw err;
+      rmSync(tmpCache, { recursive: true, force: true });
+      const waitMs = 5000 * 2 ** (attempt - 1);
+      console.error(
+        `fetch-model: transient download failure (attempt ${attempt}/${ATTEMPTS}, retrying in ${waitMs / 1000}s): ${msg}`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
+    }
+  }
 }
 
 // Phase 2 — flatten the revision-qualified cache into the local-model

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -13,6 +13,8 @@ Dockerfile (builder / dev stage)
 scripts/fetch-model.mjs
    │
    ├─ phase 1  download @ pinned revision into a throwaway cache
+   │           (transient 429/5xx retried with backoff; the optional
+   │           hf_token build secret authenticates on rate-limited CI)
    ├─ phase 2  flatten to the local-model layout transformers.js
    │           resolves offline:
    │           /models/onnx-community/gte-multilingual-base/{config,tokenizer,onnx/…}
@@ -100,6 +102,7 @@ lexical overlap). A pair missed by one is routinely caught by the other.
 | Single inference error at save  | Save succeeds, FTS-only detection for that save, drain retries |
 | Single inference error in drain | Row skipped, retried next tick                                 |
 | Model artifact drift at build   | Image build fails (phase-3 validation)                         |
+| HF rate limit (429) at build    | Retried with backoff; `hf_token` build secret authenticates    |
 | Model changed between versions  | Marker mismatch → vectors wiped once → drain re-embeds         |
 
 ## Engine constants (not configuration)


### PR DESCRIPTION
## Problem

The first release exercising the build-time model bake ([run 27026687626](https://github.com/susomejias/rembric/actions/runs/27026687626)) failed with:

```
Error (429) occurred while trying to load file:
"https://huggingface.co/onnx-community/gte-multilingual-base/resolve/main/config.json"
```

Anonymous requests from shared GitHub Actions runner IPs are aggressively rate-limited by Hugging Face. The 429 hit the very first request (0.27s in), before our own build generated any traffic — it is IP-level throttling, not burst. The multi-arch build doubles exposure (one download per platform), and any future deps-layer invalidation re-triggers the download even with the gha buildx cache.

(Side finding, no action: transformers.js `pipeline()` does not propagate `revision` to the file-listing pre-pass, so `config.json` always resolves at `main` regardless of our pin. Weight downloads honor the pin; phase-3 validation guards behavioral drift.)

## Fix

- **`fetch-model.mjs`**: phase-1 download retries transient failures (429/5xx/network) ×5 with exponential backoff (5s→80s), wiping the partial cache between attempts. Non-transient errors (bad revision, 401) still fail immediately. In-process retry is safe: transformers.js evicts rejected promises from its memoization cache.
- **`Dockerfile`**: optional `hf_token` build secret mounted as `HF_TOKEN` env on both bake layers (transformers.js 4.2.0 sends `Authorization: Bearer` automatically when set). Secret mounts never persist in image layers. Syntax bumped 1.7→1.10 for `env=` on secret mounts. Builds without the secret behave exactly as before (anonymous + retry).
- **Workflows**: `release-please.yml` passes `secrets.HF_TOKEN` to the reusable `docker-publish.yml` (workflow_call does **not** inherit secrets), which forwards it to buildx. Also resolves for `workflow_dispatch` recovery runs (secrets context lookups are case-insensitive).
- **`docs/embeddings.md`**: build-flow note + failure-modes row.

## Operator action (one-time)

1. Create a free Hugging Face account → Settings → Access Tokens → **fine-grained** token with only "Read access to contents of all public gated repos you can access" (or a plain `read` token — it can only read public content either way).
2. Add it as repo secret `HF_TOKEN` (Settings → Secrets and variables → Actions).

Without the secret the bake still works (anonymous + retry) — it is an availability hardening, not a requirement. Forks without the secret keep building.

## Release path

`fix(server)` → release-please cuts **0.21.1** → that release publishes with this fix baked into the tagged ref. v0.21.0 stays without an image (the `workflow_dispatch` recovery checks out the tag, which predates this fix — not worth recovering).

Verified: `node --check` on the script, `docker buildx build --call=check` clean on the Dockerfile, YAML parse on both workflows, pre-push test suite green.
