### PR TITLE
ci: recalibrate image-size smoke gate for in-process embeddings

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -157,7 +157,8 @@ jobs:
             fail=1
           fi
 
-          MAX_MB=800
+          # Recalibrated 2026-06-05: in-process embeddings added ~340MB model + ~280MB onnxruntime (image measured 1263MB).
+          MAX_MB=1500
           if [ "$SIZE_MB" -gt "$MAX_MB" ]; then
             echo "::error::Signal 3 FAILED: image size ${SIZE_MB} MB exceeds ${MAX_MB} MB threshold." >&2
             fail=1


### PR DESCRIPTION
## Problem

The 0.21.1 publish ([run 27028197083](https://github.com/susomejias/rembric/actions/runs/27028197083)) got past the HF 429 (fix #101 verified: multi-arch bake + push completed with the token) but failed the post-publish smoke test on **signal 3 only**:

```
Signal 3 FAILED: image size 1263 MB exceeds 800 MB threshold.
```

Signals 1 and 2 passed (prod entrypoint, `rembric.stage=runtime` label) — the image is functionally correct. The 800MB gate predates in-process embeddings and was never exercised after them (the 0.21.0 publish died earlier, at the bake).

## Size sanity check — not a leak

| Component | Approx |
|---|---|
| Pre-embeddings runtime image | ~650 MB |
| gte-multilingual-base q8 (baked, offline-validated) | ~340 MB |
| onnxruntime-node + transformers.js closure | ~280 MB |
| **Measured** | **1263 MB** |

The specs' 800MB figure (`open-source-distribution` §hardware) is process **RSS** — a different metric, still honored (~710MB measured in e2e). The image-size gate is workflow implementation detail, no spec delta required.

## Fix

`MAX_MB` 800 → **1500**: passes the honest weight with ~19% headroom while still catching runaway bloat (a dev-stage-as-prod mistake is additionally caught by signals 1–2).

## Recovery for 0.21.1

Immutable tags `:0.21.1` / `sha-*` sit unpromoted in GHCR; the refuse-overwrite guard blocks a re-dispatch as-is. Plan: delete the never-promoted 0.21.1 package versions from GHCR, then `workflow_dispatch` docker-publish with tag `server-v0.21.1` (workflow definition from main carries the new gate; checkout builds the tagged source, which already contains the bake fix).
