### PR TITLE
feat(server): show server version in dashboard brand

### DIFF
--- a/apps/server/src/dashboard/components.test.ts
+++ b/apps/server/src/dashboard/components.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { REMBRIC_VERSION } from '../version.js';
+
 import {
   backLink,
   btn,
@@ -288,6 +290,8 @@ describe('renderSidebar', () => {
       csrf,
     });
     expect(out.__html).toContain('<a class="sb-brand" href="/dashboard"');
+    expect(out.__html).toContain(`v${REMBRIC_VERSION}`);
+    expect(out.__html).not.toContain('SELF-HOSTED');
   });
 
   it('renders the close button (visible only at ≤980 px via CSS)', () => {
@@ -302,10 +306,11 @@ describe('renderSidebar', () => {
 });
 
 describe('renderMobileBar', () => {
-  it('renders REMBRIC + SELF-HOSTED + the ☰ MENU toggle', () => {
+  it('renders REMBRIC + version + the ☰ MENU toggle', () => {
     const out = renderMobileBar('home');
     expect(out.__html).toContain('REMBRIC');
-    expect(out.__html).toContain('SELF-HOSTED');
+    expect(out.__html).toContain(`v${REMBRIC_VERSION}`);
+    expect(out.__html).not.toContain('SELF-HOSTED');
     expect(out.__html).toContain('☰ MENU');
     expect(out.__html).toContain('class="mob-toggle"');
   });

--- a/apps/server/src/dashboard/components.ts
+++ b/apps/server/src/dashboard/components.ts
@@ -12,6 +12,8 @@
  * demands it.
  */
 
+import { REMBRIC_VERSION } from '../version.js';
+
 import { escape, html, raw, type SafeHtml } from './templates.js';
 
 /* ── icons (sidebar) ───────────────────────────────────────────────── */
@@ -179,7 +181,7 @@ export function renderSidebar(opts: SidebarOpts): SafeHtml {
         <img class="brand-logo" src="/dashboard/assets/logo-transparent.png" alt="" />
         <div class="label-stack">
           <div>REMBRIC</div>
-          <small>SELF-HOSTED</small>
+          <small>v${REMBRIC_VERSION}</small>
         </div>
       </a>
       ${sections}
@@ -213,7 +215,7 @@ export function renderMobileBar(_active: NavKey | null): SafeHtml {
         <img class="brand-logo" src="/dashboard/assets/logo-transparent.png" alt="" />
         <div class="label-stack">
           <div>REMBRIC</div>
-          <small>SELF-HOSTED</small>
+          <small>v${REMBRIC_VERSION}</small>
         </div>
       </a>
       <a class="mob-toggle" href="#sidebar" aria-expanded="false">☰ MENU</a>

--- a/apps/server/src/server/dashboard-router.ts
+++ b/apps/server/src/server/dashboard-router.ts
@@ -44,6 +44,7 @@ import type { ProjectsService } from '../services/projects.js';
 import type { PromptsService } from '../services/prompts.js';
 import type { SessionsService } from '../services/sessions.js';
 import type { TokensService } from '../services/tokens.js';
+import { REMBRIC_VERSION } from '../version.js';
 
 const COOKIE_NAME = 'rembric_session';
 const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
@@ -666,7 +667,7 @@ function renderLogin(error: string | null): string {
           />
           <div>
             <div class="t-mono-up fg-dim">REMBRIC</div>
-            <div class="t-mono-up fg-dim" style="margin-top:6px">SELF-HOSTED</div>
+            <div class="t-mono-up fg-dim" style="margin-top:6px">v${REMBRIC_VERSION}</div>
           </div>
         </div>
         <div>

--- a/apps/server/src/test/dashboard-e2e.test.ts
+++ b/apps/server/src/test/dashboard-e2e.test.ts
@@ -3,6 +3,7 @@ import { createServer as createNetServer } from 'node:net';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { type BootstrappedServer, createServer } from '../server/index.js';
+import { REMBRIC_VERSION } from '../version.js';
 
 import { createTestDb } from './db.js';
 import { FakeEmbedder } from './embedder.js';
@@ -135,6 +136,7 @@ describe('dashboard E2E', () => {
     expect(res.status).toBe(200);
     const body = await res.text();
     expect(body).toContain('Admin token');
+    expect(body).toContain(`v${REMBRIC_VERSION}`);
   });
 
   it('home page redirects unauthenticated users to login', async () => {
@@ -154,6 +156,7 @@ describe('dashboard E2E', () => {
     expect(home.status).toBe(200);
     const homeBody = await home.text();
     expect(homeBody).toContain('Overview');
+    expect(homeBody).toContain(`v${REMBRIC_VERSION}`);
 
     // Logout invalidates the cookie.
     const logout = await postForm(baseUrl, '/dashboard/logout', jar, {});

--- a/openspec/changes/archive/2026-06-06-show-server-version-in-dashboard-brand/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-06-show-server-version-in-dashboard-brand/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/archive/2026-06-06-show-server-version-in-dashboard-brand/design.md
+++ b/openspec/changes/archive/2026-06-06-show-server-version-in-dashboard-brand/design.md
@@ -1,0 +1,31 @@
+# Design — show-server-version-in-dashboard-brand
+
+## Context
+
+The dashboard brand block renders `REMBRIC` + `SELF-HOSTED` in three places: the desktop sidebar (`renderSidebar`, stacked `<small>` lines), the mobile bar (`renderMobileBar`, inline `label-stack` where each `<small>` gets a `·` prefix via `.mob-bar .brand .label-stack small::before`), and the login page (`renderLogin` in `dashboard-router.ts`, two `t-mono-up fg-dim` lines). A boot-time version constant already exists: `REMBRIC_VERSION` in `apps/server/src/version.ts` (reads `apps/server/package.json`, falls back to `0.0.0`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Operator can read the running server version from any dashboard surface, desktop and mobile, including the login page.
+- Leaner brand: `SELF-HOSTED` removed everywhere; the version takes its row.
+- Zero new CSS, zero new dependencies, zero runtime cost beyond one already-existing constant.
+
+**Non-Goals:**
+
+- Update-available checks, changelog links, or remote version comparison.
+- Exposing version via a new HTTP endpoint (out of scope; this is SSR-only).
+
+## Decisions
+
+1. **Source: `REMBRIC_VERSION` constant** — already loaded at boot from `package.json`, already battle-tested elsewhere in the server. Alternatives considered: reading `package.json` inside `components.ts` (duplicates the loader), an env var (operator burden, drifts from the actual image), a `/health` fetch (client JS for static data — violates the no-framework rule).
+2. **Render: the version replaces the `SELF-HOSTED` line** — `<small>v${REMBRIC_VERSION}</small>` in sidebar/mob-bar `label-stack`s, a `t-mono-up fg-dim` line in the login brand. `text-transform: uppercase` renders it as `V0.21.1`. In the mobile bar the existing `::before` separator rule yields `REMBRIC · V0.21.1` with no CSS change. Alternative considered: keeping `SELF-HOSTED` and stacking the version as a third line — rejected by the operator (2026-06-06): `SELF-HOSTED` carries no information on an instance you are by definition self-hosting, and dropping it removes any mobile-overflow risk.
+3. **Version shown on the login page (pre-auth)** — initial design excluded it as version-disclosure hardening; the operator explicitly overrode (2026-06-06): deployments are VPN/LAN-fronted per docs/docker.md, the bearer token is the security boundary, and brand consistency wins. The delta spec modifies the existing login-brand requirement accordingly.
+4. **Collapsed sidebar hides the version** — `.sb.is-collapsed .sb-brand .label-stack { display: none }` already hides the whole stack; no special handling. Alternative (tooltip on the logo) rejected as unnecessary chrome.
+
+## Risks / Trade-offs
+
+- [Trade-off] Exact version visible pre-auth aids vulnerability fingerprinting → Accepted because Rembric's documented posture fronts the port with VPN/Tailscale/LAN trust and the bearer token is the real boundary; operator explicitly chose this.
+- [Trade-off] Version invisible in collapsed sidebar → Accepted because the mobile bar and any expanded view still show it, and collapsed mode is icons-only by design.
+- ~~[Risk] Mobile bar overflow on narrow viewports~~ — eliminated by dropping `SELF-HOSTED`; `REMBRIC · V0.21.1` fits comfortably at 360 px.

--- a/openspec/changes/archive/2026-06-06-show-server-version-in-dashboard-brand/proposal.md
+++ b/openspec/changes/archive/2026-06-06-show-server-version-in-dashboard-brand/proposal.md
@@ -1,0 +1,29 @@
+# Show server version in dashboard brand
+
+## Why
+
+Operators have no way to see which Rembric version their self-hosted instance is running without shelling into the container or inspecting the image tag. Surfacing the version in the dashboard brand block makes upgrade checks and bug reports a glance away.
+
+## What Changes
+
+- The brand block on all dashboard surfaces — desktop sidebar, mobile bar, and login page — renders the server version (e.g. `V0.21.1`) directly under `REMBRIC`, sourced from the existing `REMBRIC_VERSION` constant (`apps/server/src/version.ts`, read from `package.json` at boot).
+- The `SELF-HOSTED` line is removed from all three brand surfaces; the version takes its row. (Operator decision 2026-06-06: version on login is acceptable disclosure for a self-hosted, VPN-fronted deployment; the leaner brand wins.)
+- Zero new CSS: sidebar/mob-bar reuse `.label-stack small` styles (the mobile `·` separator comes from the existing `::before` rule); login reuses the existing `t-mono-up fg-dim` line styling.
+- Collapsed sidebar hides the version along with the rest of `.label-stack` (existing behavior, unchanged).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `dashboard`: new requirement — the sidebar and mobile-bar brand MUST display the running server version and MUST NOT render `SELF-HOSTED`; modified requirement — the login brand mark's second mono line changes from `SELF-HOSTED` to the version.
+
+## Impact
+
+- `apps/server/src/dashboard/components.ts` — `renderSidebar` and `renderMobileBar`: `SELF-HOSTED` small replaced by `v${REMBRIC_VERSION}`.
+- `apps/server/src/server/dashboard-router.ts` — `renderLogin`: `SELF-HOSTED` line replaced by the version line.
+- `apps/server/src/dashboard/components.test.ts` and `apps/server/src/test/dashboard-e2e.test.ts` — assertions updated (version present, `SELF-HOSTED` absent).
+- No DB, HTTP API, MCP, or plugin changes. No new dependencies. No load-bearing invariant touched.

--- a/openspec/changes/archive/2026-06-06-show-server-version-in-dashboard-brand/specs/dashboard/spec.md
+++ b/openspec/changes/archive/2026-06-06-show-server-version-in-dashboard-brand/specs/dashboard/spec.md
@@ -1,0 +1,55 @@
+# Delta — dashboard
+
+## ADDED Requirements
+
+### Requirement: The dashboard brand block MUST display the running server version
+
+The dashboard SHALL render the running server version (the `version` field of the server package, loaded at boot via `REMBRIC_VERSION` from `apps/server/src/version.ts`) inside the brand block of the desktop sidebar (`.sb-brand`) and the mobile bar (`.mob-bar .brand`), as the line directly under `REMBRIC`. The version SHALL be rendered as a `<small>` element with the text `v<version>` (displayed uppercased by the brand's existing `text-transform`). The brand SHALL NOT render a `SELF-HOSTED` line — the version takes that row. The rendering SHALL reuse the existing `.label-stack small` styles and SHALL NOT introduce new CSS rules.
+
+#### Scenario: Sidebar brand shows the version
+
+- **WHEN** an authenticated operator loads any dashboard page at a desktop viewport with the sidebar expanded
+- **THEN** the sidebar brand block SHALL contain, in order, the lines `REMBRIC` and `v<version>` where `<version>` equals the server package version, and SHALL NOT contain the text `SELF-HOSTED`
+
+#### Scenario: Mobile bar brand shows the version inline
+
+- **WHEN** an authenticated operator loads any dashboard page at a viewport ≤980 px
+- **THEN** the `.mob-bar` brand SHALL render `REMBRIC` and `v<version>` inline, with the existing `·` separator applied before the `<small>` by the established `.mob-bar .brand .label-stack small::before` rule
+
+#### Scenario: Collapsed sidebar hides the version with the rest of the label stack
+
+- **WHEN** the sidebar is in collapsed mode
+- **THEN** the version SHALL be hidden along with the entire `.label-stack` (existing collapse behavior, unchanged)
+
+## MODIFIED Requirements
+
+### Requirement: The dashboard login view MUST present a single canonical brand mark, headline, and client-support footer
+
+The `/dashboard/login` page SHALL render a single brand block in the top-left of the left pane containing the transparent Rembric logo (`/dashboard/assets/logo-transparent.png`) at 56 × 56 px on desktop, 48 × 48 px at viewports ≤ 980 px, and 40 × 40 px at viewports ≤ 640 px, followed by two lines of mono text (`REMBRIC` and `v<version>`, where `<version>` is the running server package version loaded via `REMBRIC_VERSION`). The main headline SHALL read `REMBRIC DASHBOARD.` with `REMBRIC` rendered via the `hl-lime` highlight pill and the trailing period rendered in `var(--lime)`. The headline `line-height` SHALL be at least `1.3` so the `hl-lime` background does not visually clip the next line.
+
+A footer SHALL list the supported plugin clients in the following order, separated visually by lime square bullets: `CLAUDE CODE`, `CODEX CLI`, `HERMES`, `MCP CLIENTS`. The right pane SHALL contain only the admin-token form (a labelled password input + a primary submit button) and SHALL NOT contain redundant section chips or security-disclosure copy that duplicates the `/tokens` documentation.
+
+#### Scenario: Login renders the canonical brand mark
+
+- **WHEN** an unauthenticated request hits `/dashboard/login`
+- **THEN** the response HTML SHALL contain exactly one `<img>` with `src="/dashboard/assets/logo-transparent.png"` inside an element with class `login-brand`, placed before any `<form>` element
+
+#### Scenario: Login brand shows the version instead of SELF-HOSTED
+
+- **WHEN** an unauthenticated request hits `/dashboard/login`
+- **THEN** the brand block SHALL contain the line `v<version>` directly under `REMBRIC` and SHALL NOT contain the text `SELF-HOSTED`
+
+#### Scenario: Headline is REMBRIC DASHBOARD
+
+- **WHEN** the login page is rendered
+- **THEN** the `<h1>` SHALL contain the text `REMBRIC` wrapped in a `<span class="hl-lime">` followed by the text `DASHBOARD` and a period rendered in `var(--lime)`
+
+#### Scenario: Footer lists all three plugin clients plus generic MCP
+
+- **WHEN** the login page is rendered at a viewport width greater than 640 px
+- **THEN** the `.login-stage .clients` element SHALL contain, in order, four labelled spans `CLAUDE CODE`, `CODEX CLI`, `HERMES`, `MCP CLIENTS`
+
+#### Scenario: Login form has no redundant chips or disclosure block
+
+- **WHEN** the login page is rendered
+- **THEN** the response HTML SHALL NOT contain the strings `§ 00 / ACCESS`, `OPERATOR DASHBOARD`, `APPEND-ONLY`, `ADMIN-SCOPED TOKENS ONLY`, `STORED IN HTTPONLY COOKIE`, or `PLAINTEXT SHOWN ONLY ONCE IN /TOKENS`

--- a/openspec/changes/archive/2026-06-06-show-server-version-in-dashboard-brand/tasks.md
+++ b/openspec/changes/archive/2026-06-06-show-server-version-in-dashboard-brand/tasks.md
@@ -1,0 +1,21 @@
+# Tasks — show-server-version-in-dashboard-brand
+
+## 1. Render version in brand surfaces
+
+- [x] 1.1 In `apps/server/src/dashboard/components.ts`, import `REMBRIC_VERSION` from `../version.js` and replace the `SELF-HOSTED` small with `<small>v${REMBRIC_VERSION}</small>` in `renderSidebar`'s `.label-stack`
+- [x] 1.2 Apply the same replacement in `renderMobileBar`'s `.label-stack`; confirm no CSS changes are needed (mobile `·` separator comes from the existing `.mob-bar .brand .label-stack small::before` rule)
+- [x] 1.3 In `apps/server/src/server/dashboard-router.ts` `renderLogin`, replace the `SELF-HOSTED` line with a `t-mono-up fg-dim` line rendering `v${REMBRIC_VERSION}`
+
+## 2. Tests
+
+- [x] 2.1 In `apps/server/src/dashboard/components.test.ts`, assert `renderSidebar` output contains `v${REMBRIC_VERSION}` and does NOT contain `SELF-HOSTED` (import the constant; do not hardcode the version)
+- [x] 2.2 Same assertions for `renderMobileBar`, alongside the existing REMBRIC / ☰ MENU assertions
+- [x] 2.3 In `apps/server/src/test/dashboard-e2e.test.ts`, assert the login page HTML contains `v${REMBRIC_VERSION}` and the authenticated home does too
+- [x] 2.4 `pnpm vitest run src/dashboard/components.test.ts src/test/dashboard-e2e.test.ts` (from `apps/server/`) passes
+
+## 3. Validation gates
+
+- [x] 3.1 `pnpm run typecheck` clean
+- [x] 3.2 `pnpm run lint` clean (watch import-group ordering for the new `../version.js` imports)
+- [x] 3.3 `pnpm test` full suite green
+- [x] 3.4 Visual smoke (operator-only): load login + dashboard at desktop, ≤980 px and ≤640 px viewports; confirm `REMBRIC` / `v<version>` renders in login brand, sidebar and mob-bar with no `SELF-HOSTED` remnants and no layout breakage

--- a/openspec/specs/dashboard/spec.md
+++ b/openspec/specs/dashboard/spec.md
@@ -555,7 +555,7 @@ The `verdict` column SHALL render via the shared `verdictPill(relation)` helper.
 
 ### Requirement: The dashboard login view MUST present a single canonical brand mark, headline, and client-support footer
 
-The `/dashboard/login` page SHALL render a single brand block in the top-left of the left pane containing the transparent Rembric logo (`/dashboard/assets/logo-transparent.png`) at 56 × 56 px on desktop, 48 × 48 px at viewports ≤ 980 px, and 40 × 40 px at viewports ≤ 640 px, followed by two lines of mono text (`REMBRIC` and `SELF-HOSTED`). The main headline SHALL read `REMBRIC DASHBOARD.` with `REMBRIC` rendered via the `hl-lime` highlight pill and the trailing period rendered in `var(--lime)`. The headline `line-height` SHALL be at least `1.3` so the `hl-lime` background does not visually clip the next line.
+The `/dashboard/login` page SHALL render a single brand block in the top-left of the left pane containing the transparent Rembric logo (`/dashboard/assets/logo-transparent.png`) at 56 × 56 px on desktop, 48 × 48 px at viewports ≤ 980 px, and 40 × 40 px at viewports ≤ 640 px, followed by two lines of mono text (`REMBRIC` and `v<version>`, where `<version>` is the running server package version loaded via `REMBRIC_VERSION`). The main headline SHALL read `REMBRIC DASHBOARD.` with `REMBRIC` rendered via the `hl-lime` highlight pill and the trailing period rendered in `var(--lime)`. The headline `line-height` SHALL be at least `1.3` so the `hl-lime` background does not visually clip the next line.
 
 A footer SHALL list the supported plugin clients in the following order, separated visually by lime square bullets: `CLAUDE CODE`, `CODEX CLI`, `HERMES`, `MCP CLIENTS`. The right pane SHALL contain only the admin-token form (a labelled password input + a primary submit button) and SHALL NOT contain redundant section chips or security-disclosure copy that duplicates the `/tokens` documentation.
 
@@ -563,6 +563,11 @@ A footer SHALL list the supported plugin clients in the following order, separat
 
 - **WHEN** an unauthenticated request hits `/dashboard/login`
 - **THEN** the response HTML SHALL contain exactly one `<img>` with `src="/dashboard/assets/logo-transparent.png"` inside an element with class `login-brand`, placed before any `<form>` element
+
+#### Scenario: Login brand shows the version instead of SELF-HOSTED
+
+- **WHEN** an unauthenticated request hits `/dashboard/login`
+- **THEN** the brand block SHALL contain the line `v<version>` directly under `REMBRIC` and SHALL NOT contain the text `SELF-HOSTED`
 
 #### Scenario: Headline is REMBRIC DASHBOARD
 
@@ -795,3 +800,22 @@ When the `:id` does not match any row, the page SHALL respond with `404 Not Foun
 
 - **WHEN** the operator navigates to `/dashboard/judgments` with at least one row present
 - **THEN** each row's leftmost `id` cell SHALL contain an `<a href="/dashboard/judgments/{id}">` anchor wrapping the short id, where `{id}` is that row's `memory_relations.id`
+
+### Requirement: The dashboard brand block MUST display the running server version
+
+The dashboard SHALL render the running server version (the `version` field of the server package, loaded at boot via `REMBRIC_VERSION` from `apps/server/src/version.ts`) inside the brand block of the desktop sidebar (`.sb-brand`) and the mobile bar (`.mob-bar .brand`), as the line directly under `REMBRIC`. The version SHALL be rendered as a `<small>` element with the text `v<version>` (displayed uppercased by the brand's existing `text-transform`). The brand SHALL NOT render a `SELF-HOSTED` line — the version takes that row. The rendering SHALL reuse the existing `.label-stack small` styles and SHALL NOT introduce new CSS rules.
+
+#### Scenario: Sidebar brand shows the version
+
+- **WHEN** an authenticated operator loads any dashboard page at a desktop viewport with the sidebar expanded
+- **THEN** the sidebar brand block SHALL contain, in order, the lines `REMBRIC` and `v<version>` where `<version>` equals the server package version, and SHALL NOT contain the text `SELF-HOSTED`
+
+#### Scenario: Mobile bar brand shows the version inline
+
+- **WHEN** an authenticated operator loads any dashboard page at a viewport ≤980 px
+- **THEN** the `.mob-bar` brand SHALL render `REMBRIC` and `v<version>` inline, with the existing `·` separator applied before the `<small>` by the established `.mob-bar .brand .label-stack small::before` rule
+
+#### Scenario: Collapsed sidebar hides the version with the rest of the label stack
+
+- **WHEN** the sidebar is in collapsed mode
+- **THEN** the version SHALL be hidden along with the entire `.label-stack` (existing collapse behavior, unchanged)


### PR DESCRIPTION
## Summary

- Show the running server version (`REMBRIC_VERSION`, e.g. `V0.21.1`) in the dashboard brand block: desktop sidebar, mobile bar and login page
- Remove the `SELF-HOSTED` line from all three brand surfaces — the version takes its row
- Zero new CSS: reuses `.label-stack small` (sidebar/mob-bar) and `t-mono-up fg-dim` (login); the mobile `·` separator comes from the existing `::before` rule

## OpenSpec

- Change `show-server-version-in-dashboard-brand` archived at `openspec/changes/archive/2026-06-06-show-server-version-in-dashboard-brand/`
- `dashboard` spec synced: 1 ADDED requirement (brand shows version) + 1 MODIFIED (login brand second mono line: `SELF-HOSTED` → version)
- Trade-off recorded in design.md: version visible pre-auth accepted by operator (VPN/LAN-fronted posture, bearer token is the boundary)

## Tests

- Component asserts: version present + `SELF-HOSTED` absent in `renderSidebar`/`renderMobileBar` (no hardcoded version)
- E2E asserts: login HTML and authenticated home both contain `v${REMBRIC_VERSION}`
- `pnpm run typecheck` / `pnpm run lint` / `pnpm test` green; visual smoke done against the dev docker stack at desktop / ≤980px / ≤640px