### PR TITLE
feat(server): one-click self-update from the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ Compose auto-merges the override on every `up`. Point your agent at `http://127.
 
 ### Upgrading
 
+**Auto-updater from the UI.** The dashboard checks for new releases (once a day, [opt-out](./docs/updates.md)) and shows a badge + changelog modal when one is out. Mount the Docker socket and the same modal gains a one-click **Update** button that backs up the database, pulls the new image, swaps the container with health-check and rollback, and reloads the page on the new version — see [docs/updates.md](./docs/updates.md) for setup and the security trade-off. Without the socket nothing breaks: you get the notification plus the manual flow below.
+
 Docker manages versions for you. With `REMBRIC_VERSION` unset in `.env`, the compose file pulls `:latest`:
 
 ```bash
@@ -259,7 +261,7 @@ docker compose pull
 docker compose up -d
 ```
 
-Portainer / Arcane detect the new digest automatically and offer a "Recreate container" button — one click. For reproducible deploys, pin a specific version in `.env`:
+Portainer / Arcane detect the new digest automatically and offer a "Recreate container" button — one click. For reproducible deploys, pin a specific version in `.env` (this also disables the one-click updater — the dashboard explains why):
 
 ```ini
 REMBRIC_VERSION=0.13.0
@@ -308,12 +310,13 @@ All config via environment variables. With Docker, these live in `.env` and are 
 
 ### Server
 
-| Variable           | Default                           | Description                                                                                                   |
-| ------------------ | --------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `REMBRIC_HOST`     | `127.0.0.1` (`0.0.0.0` in Docker) | Bind address. Pinned to `0.0.0.0` inside the container so the published port works; never override in Docker. |
-| `REMBRIC_PORT`     | `8787`                            | Bind port.                                                                                                    |
-| `REMBRIC_DATA_DIR` | `~/.rembric` (`/data` in Docker)  | Where the SQLite file lives. Pinned to `/data` inside the container; bind-mount `./data:/data` in compose.    |
-| `LOG_LEVEL`        | `info`                            | `debug` / `info` / `warn` / `error`.                                                                          |
+| Variable               | Default                           | Description                                                                                                                |
+| ---------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `REMBRIC_HOST`         | `127.0.0.1` (`0.0.0.0` in Docker) | Bind address. Pinned to `0.0.0.0` inside the container so the published port works; never override in Docker.              |
+| `REMBRIC_PORT`         | `8787`                            | Bind port.                                                                                                                 |
+| `REMBRIC_DATA_DIR`     | `~/.rembric` (`/data` in Docker)  | Where the SQLite file lives. Pinned to `/data` inside the container; bind-mount `./data:/data` in compose.                 |
+| `LOG_LEVEL`            | `info`                            | `debug` / `info` / `warn` / `error`.                                                                                       |
+| `REMBRIC_UPDATE_CHECK` | `on`                              | `off` disables the daily release check (no badge, no modal, no GitHub API call). See [docs/updates.md](./docs/updates.md). |
 
 ### Hardware requirements
 
@@ -379,6 +382,7 @@ docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
 - [docs/docker.md](./docs/docker.md) — Docker operator guide (topologies, GHCR auth, upgrade/rollback, troubleshooting).
 - [docs/agents.md](./docs/agents.md) — per-client MCP config (Codex, Cursor, Windsurf, VS Code, Gemini, …).
 - [docs/backup.md](./docs/backup.md) — backup strategies and restore recipes for the SQLite data file.
+- [docs/updates.md](./docs/updates.md) — update notifications and the opt-in one-click auto-updater from the dashboard.
 - [docs/troubleshooting.md](./docs/troubleshooting.md) — common errors and recovery.
 
 ## Project status

--- a/apps/server/src/dashboard/components.test.ts
+++ b/apps/server/src/dashboard/components.test.ts
@@ -303,6 +303,23 @@ describe('renderSidebar', () => {
     });
     expect(out.__html).toContain('class="sb-mob-close"');
   });
+
+  it('renders the update badge next to the brand when provided', () => {
+    const out = renderSidebar({
+      active: 'home',
+      counters: {},
+      collapsed: false,
+      csrf,
+      update: raw('<a class="sb-update" href="/dashboard/update">UPDATE v0.22.0</a>'),
+    });
+    expect(out.__html).toMatch(/sb-brand[\s\S]*?sb-update[\s\S]*?sb-section/);
+    expect(out.__html).toContain('UPDATE v0.22.0');
+  });
+
+  it('renders no update badge by default', () => {
+    const out = renderSidebar({ active: 'home', counters: {}, collapsed: false, csrf });
+    expect(out.__html).not.toContain('sb-update');
+  });
 });
 
 describe('renderMobileBar', () => {
@@ -313,5 +330,11 @@ describe('renderMobileBar', () => {
     expect(out.__html).not.toContain('SELF-HOSTED');
     expect(out.__html).toContain('☰ MENU');
     expect(out.__html).toContain('class="mob-toggle"');
+  });
+
+  it('renders the update badge when provided, none by default', () => {
+    const withBadge = renderMobileBar('home', raw('<a class="sb-update" href="/x">UPD</a>'));
+    expect(withBadge.__html).toContain('sb-update');
+    expect(renderMobileBar('home').__html).not.toContain('sb-update');
   });
 });

--- a/apps/server/src/dashboard/components.ts
+++ b/apps/server/src/dashboard/components.ts
@@ -146,6 +146,8 @@ export interface SidebarOpts {
   counters: { pendingJudgments?: number };
   collapsed: boolean;
   csrf: SafeHtml;
+  /** Pre-rendered update badge (see `update-modal.ts::updateBadge`). */
+  update?: SafeHtml | null;
 }
 
 export function renderSidebar(opts: SidebarOpts): SafeHtml {
@@ -184,7 +186,7 @@ export function renderSidebar(opts: SidebarOpts): SafeHtml {
           <small>v${REMBRIC_VERSION}</small>
         </div>
       </a>
-      ${sections}
+      ${opts.update ?? raw('')} ${sections}
       <div class="sb-foot">
         <div class="sb-foot-text">
           <form action="/dashboard/logout" method="post" style="margin:0">
@@ -208,7 +210,7 @@ export function renderSidebar(opts: SidebarOpts): SafeHtml {
   `;
 }
 
-export function renderMobileBar(_active: NavKey | null): SafeHtml {
+export function renderMobileBar(_active: NavKey | null, update?: SafeHtml | null): SafeHtml {
   return html`
     <div class="mob-bar">
       <a class="brand" href="/dashboard">
@@ -218,6 +220,7 @@ export function renderMobileBar(_active: NavKey | null): SafeHtml {
           <small>v${REMBRIC_VERSION}</small>
         </div>
       </a>
+      ${update ?? raw('')}
       <a class="mob-toggle" href="#sidebar" aria-expanded="false">☰ MENU</a>
     </div>
   `;

--- a/apps/server/src/dashboard/page-shell.ts
+++ b/apps/server/src/dashboard/page-shell.ts
@@ -4,7 +4,9 @@
  *
  * Per-route handlers call `renderPage(c, deps.sessions, body, opts)` and
  * get back the full HTML string — sidebar, mobile bar, view-head wrapper,
- * cookie-driven collapse state, and CSRF-protected toggle button included.
+ * cookie-driven collapse state, CSRF-protected toggle button, and the
+ * update badge/modal (when the auth middleware found a newer release)
+ * included.
  */
 
 import type { Context } from 'hono';
@@ -16,6 +18,7 @@ import { renderSidebar, type NavKey } from './components.js';
 import { csrfInput } from './csrf.js';
 import { raw, shell, type SafeHtml } from './templates.js';
 import type { ResolvedSession } from './types.js';
+import { updateShellExtras, type UpdateViewState } from './update-modal.js';
 
 const SIDEBAR_COOKIE = 'rbr-sb-collapsed';
 
@@ -36,11 +39,18 @@ export function renderPage(
   const resolved = c.get('session' as never) as ResolvedSession | undefined;
   const collapsed = getCookie(c, SIDEBAR_COOKIE) === '1';
   const csrf = resolved ? csrfInput(resolved.session, sessionsService, 'sidebar.toggle') : raw('');
+  const updateState = (c.get('update' as never) as UpdateViewState | undefined | null) ?? null;
+  const { badge, modal } = updateShellExtras(
+    updateState,
+    resolved?.session ?? null,
+    sessionsService,
+  );
   const sidebar = renderSidebar({
     active: opts.activeNav,
     counters: opts.counters ?? {},
     collapsed,
     csrf,
+    update: badge,
   });
   return shell(body, {
     title: opts.title,
@@ -50,5 +60,7 @@ export function renderPage(
     collapsed,
     flash: opts.flash,
     counters: opts.counters,
+    updateBadge: badge,
+    updateModal: modal,
   });
 }

--- a/apps/server/src/dashboard/styles/core/patterns.css
+++ b/apps/server/src/dashboard/styles/core/patterns.css
@@ -941,3 +941,155 @@ form .field label {
     flex-wrap: wrap;
   }
 }
+
+/* ─────────────────────────────────────────────────────────────────
+   UPDATE AVAILABILITY — brand badge + global modal (self-update).
+   ───────────────────────────────────────────────────────────────── */
+.sb-update {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  margin: var(--s-2) var(--s-4) 0;
+  padding: 6px var(--s-3);
+  border: 1px solid var(--lime);
+  color: var(--lime);
+  font-family: var(--f-mono);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-weight: 600;
+  text-decoration: none;
+}
+.sb-update:hover {
+  background: var(--lime);
+  color: var(--lime-ink);
+}
+.sb-update .bn {
+  width: 6px;
+  height: 6px;
+  background: var(--lime);
+  display: inline-block;
+  flex-shrink: 0;
+}
+.sb-update:hover .bn {
+  background: var(--lime-ink);
+}
+.sb.is-collapsed .sb-update .label {
+  display: none;
+}
+.mob-bar .sb-update {
+  margin: 0;
+  flex-shrink: 0;
+}
+.mob-bar .sb-update .label {
+  display: none;
+}
+
+dialog.upd-modal {
+  width: min(640px, calc(100vw - 2 * var(--s-4)));
+}
+.upd-versions {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  font-family: var(--f-mono);
+  font-size: 0.85rem;
+  margin-bottom: var(--s-4);
+}
+.upd-versions code {
+  border: 1px solid var(--fg-faint);
+  padding: 2px 8px;
+  color: var(--fg-dim);
+}
+.upd-versions code.new {
+  border-color: var(--lime);
+  color: var(--lime);
+}
+.upd-versions .when {
+  color: var(--fg-dim);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.upd-changelog-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--f-mono);
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--fg-dim);
+  margin-bottom: var(--s-2);
+}
+.upd-changelog-head a {
+  color: var(--lime);
+  text-decoration: none;
+}
+.upd-changelog {
+  font-family: var(--f-mono);
+  font-size: 0.78rem;
+  line-height: 1.6;
+  color: var(--fg);
+  border: 1px solid var(--fg-faint);
+  background: var(--bg);
+  padding: var(--s-4);
+  margin: 0 0 var(--s-4);
+  max-height: 280px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.upd-action {
+  margin: 0;
+}
+.upd-note {
+  border: 1px solid var(--fg-faint);
+  padding: var(--s-4);
+}
+.upd-note.warn {
+  border-color: var(--warn);
+}
+.upd-note .lab {
+  display: block;
+  font-family: var(--f-mono);
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--lime);
+  margin-bottom: var(--s-2);
+}
+.upd-note.warn .lab {
+  color: var(--warn);
+}
+.upd-note p {
+  margin: 0 0 var(--s-3);
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+.upd-cmd {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  border: 1px solid var(--fg-faint);
+  background: var(--bg);
+  padding: var(--s-3) var(--s-4);
+}
+.upd-cmd code {
+  font-family: var(--f-mono);
+  font-size: 0.8rem;
+  color: var(--lime);
+  flex: 1 1 auto;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+.upd-docs-link {
+  display: inline-block;
+  margin-top: var(--s-3);
+  font-family: var(--f-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--lime);
+  text-decoration: none;
+}

--- a/apps/server/src/dashboard/styles/views/update.css
+++ b/apps/server/src/dashboard/styles/views/update.css
@@ -1,0 +1,76 @@
+/* ─────────────────────────────────────────────────────────────────
+   UPDATE VIEW — offer page + install progress steps.
+   ───────────────────────────────────────────────────────────────── */
+.upd-page {
+  max-width: 760px;
+}
+
+.upd-progress {
+  max-width: 560px;
+  border: 1px solid var(--fg-faint);
+  padding: var(--s-5);
+}
+.upd-progress-title {
+  font-family: var(--f-mono);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  color: var(--fg);
+  margin-bottom: var(--s-5);
+}
+.upd-progress-title .sub {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.62rem;
+  font-weight: 400;
+  color: var(--fg-dim);
+}
+
+.upd-step {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  padding: var(--s-3) 0;
+  border-bottom: 1px solid var(--fg-faint);
+  font-family: var(--f-mono);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--fg-dim);
+}
+.upd-step:last-of-type {
+  border-bottom: 0;
+}
+.upd-step .dot {
+  width: 10px;
+  height: 10px;
+  border: 1px solid var(--fg-faint);
+  flex-shrink: 0;
+}
+.upd-step[data-state='active'] {
+  color: var(--fg);
+}
+.upd-step[data-state='active'] .dot {
+  border-color: var(--lime);
+  background: var(--lime);
+  animation: upd-blink 1s steps(2, start) infinite;
+}
+.upd-step[data-state='done'] {
+  color: var(--fg);
+}
+.upd-step[data-state='done'] .dot {
+  border-color: var(--lime);
+  background: var(--lime);
+}
+.upd-step .meta {
+  margin-left: auto;
+  color: var(--fg-dim);
+  font-size: 0.66rem;
+}
+
+@keyframes upd-blink {
+  50% {
+    opacity: 0.35;
+  }
+}

--- a/apps/server/src/dashboard/templates.ts
+++ b/apps/server/src/dashboard/templates.ts
@@ -329,6 +329,10 @@ export interface ShellOptions {
   /** Pre-rendered sidebar (with CSRF). When omitted, the shell renders
    *  without a sidebar — used for the login page. */
   sidebar?: SafeHtml;
+  /** Pre-rendered update badge for the mobile bar (sidebar embeds its own). */
+  updateBadge?: SafeHtml | null;
+  /** Pre-rendered update-available dialog + script (see `update-modal.ts`). */
+  updateModal?: SafeHtml;
 }
 
 export function shell(body: SafeHtml, opts: ShellOptions): string {
@@ -353,7 +357,7 @@ export function shell(body: SafeHtml, opts: ShellOptions): string {
   const shellBody = opts.sidebar
     ? `<div class="app${collapsed ? ' is-collapsed' : ''}">
 ${opts.sidebar.__html}
-${renderMobileBar(opts.activeNav ?? null).__html}
+${renderMobileBar(opts.activeNav ?? null, opts.updateBadge ?? null).__html}
 <main class="main">
 ${flashHtml}
 ${body.__html}
@@ -383,6 +387,7 @@ ${links.join('\n')}
 </head>
 <body>
 ${shellBody}
+${opts.updateModal ? opts.updateModal.__html : ''}
 <dialog id="rbr-confirm" class="modal" data-tone="danger">
   <form method="dialog">
     <div class="modal-head">

--- a/apps/server/src/dashboard/update-modal.ts
+++ b/apps/server/src/dashboard/update-modal.ts
@@ -1,0 +1,206 @@
+/**
+ * Update-availability UI shared between the global dashboard modal
+ * (injected by `page-shell.ts` on every authenticated page) and the
+ * `/dashboard/update` view. Pure renderers — the router lives in
+ * `update.ts`.
+ */
+
+import type { DashboardSession } from '../db/schema/sessions.js';
+import type { SelfUpdateCapability } from '../services/self-update/capability.js';
+import type { SessionsService } from '../services/sessions.js';
+import type { UpdateInfo } from '../services/update-check.js';
+
+import { btn } from './components.js';
+import { csrfInput } from './csrf.js';
+import { formatTs, html, raw, type SafeHtml } from './templates.js';
+
+export const UPDATE_DOCS_URL = 'https://github.com/susomejias/rembric/blob/main/docs/updates.md';
+export const MANUAL_UPDATE_COMMAND = 'docker compose pull && docker compose up -d';
+
+/** Per-request update view state threaded through Hono context. */
+export interface UpdateViewState {
+  info: UpdateInfo;
+  capability: SelfUpdateCapability;
+  /** True while an update run is in flight (progress view takes over). */
+  running: boolean;
+}
+
+/** Capability-dependent primary action block (modal and update page). */
+export function updateActionBlock(
+  state: UpdateViewState,
+  session: DashboardSession,
+  sessions: SessionsService,
+): SafeHtml {
+  const { info, capability } = state;
+  if (capability.state === 'available') {
+    return html`
+      <form
+        action="/dashboard/update/start"
+        method="post"
+        class="upd-action"
+        data-confirm="Rembric will back up the database, stop, replace its container with v${info.latestVersion} and restart. Your data and configuration are preserved."
+        data-confirm-label="UPDATE NOW"
+        data-confirm-tone="danger"
+      >
+        ${csrfInput(session, sessions, 'update.start')}
+        ${btn({ variant: 'primary', label: `UPDATE TO v${info.latestVersion} →`, type: 'submit' })}
+      </form>
+    `;
+  }
+  if (capability.state === 'pinned') {
+    return html`
+      <div class="upd-note warn">
+        <span class="lab">ONE-CLICK DISABLED · IMAGE TAG PINNED</span>
+        <p>
+          This deployment pins the image to <code>:${capability.imageTag ?? ''}</code> (the
+          <code>REMBRIC_VERSION</code> variable in your <code>.env</code>). Self-updating would be
+          silently reverted by the next <code>docker compose up</code>. Remove the pin and run
+          <code>docker compose up -d</code> once to enable one-click updates, or update manually:
+        </p>
+        ${commandBlock()}
+      </div>
+    `;
+  }
+  return html`
+    <div class="upd-note">
+      <span class="lab">MANUAL UPDATE</span>
+      <p>Run this on the host, then this page will reload on the new version:</p>
+      ${commandBlock()}
+      <a href="${UPDATE_DOCS_URL}" target="_blank" rel="noopener" class="upd-docs-link"
+        >HOW TO ENABLE ONE-CLICK UPDATES ›</a
+      >
+    </div>
+  `;
+}
+
+function commandBlock(): SafeHtml {
+  return html`
+    <div class="upd-cmd">
+      <code data-upd-cmd>${MANUAL_UPDATE_COMMAND}</code>
+      <button type="button" class="btn secondary sm" data-upd-copy>COPY</button>
+    </div>
+  `;
+}
+
+export function updateSummary(info: UpdateInfo): SafeHtml {
+  return html`
+    <div class="upd-versions">
+      <code>v${info.currentVersion}</code>
+      <span class="arrow">→</span>
+      <code class="new">v${info.latestVersion}</code>
+      ${info.publishedAt
+        ? html`<span class="when">· published ${formatTs(info.publishedAt)}</span>`
+        : raw('')}
+    </div>
+  `;
+}
+
+export function updateChangelog(info: UpdateInfo): SafeHtml {
+  return html`
+    <div class="upd-changelog-head">
+      <span>WHAT'S NEW</span>
+      ${info.releaseUrl
+        ? html`<a href="${info.releaseUrl}" target="_blank" rel="noopener"
+            >VIEW RELEASE ON GITHUB ›</a
+          >`
+        : raw('')}
+    </div>
+    <pre class="upd-changelog">${info.changelog || '(no changelog provided)'}</pre>
+  `;
+}
+
+// Auto-show unless this exact version was dismissed; LATER persists the
+// dismissal per version; COPY feeds the manual command to the clipboard.
+const MODAL_SCRIPT = `
+(function(){
+  function bind(){
+    var dlg = document.getElementById('rbr-update');
+    if (!dlg || typeof dlg.showModal !== 'function') return;
+    var version = dlg.getAttribute('data-version') || '';
+    var KEY = 'rbr-upd-dismissed';
+    var copyBtns = dlg.querySelectorAll('[data-upd-copy]');
+    for (var i = 0; i < copyBtns.length; i++) {
+      copyBtns[i].addEventListener('click', function(e){
+        var code = dlg.querySelector('[data-upd-cmd]');
+        if (code && navigator.clipboard) {
+          navigator.clipboard.writeText(code.textContent || '');
+          e.target.textContent = 'COPIED';
+        }
+      });
+    }
+    var later = dlg.querySelector('[data-upd-later]');
+    if (later) {
+      later.addEventListener('click', function(){
+        try { localStorage.setItem(KEY, version); } catch (_) {}
+        dlg.close();
+      });
+    }
+    var dismissed = null;
+    try { dismissed = localStorage.getItem(KEY); } catch (_) {}
+    if (dismissed !== version && !dlg.open) dlg.showModal();
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bind);
+  } else {
+    bind();
+  }
+})();
+`;
+
+/**
+ * The global per-version dismissable modal. Returns empty when there is
+ * nothing to announce or while an update run is already in progress.
+ */
+export function renderUpdateModal(
+  state: UpdateViewState | null,
+  session: DashboardSession,
+  sessions: SessionsService,
+): SafeHtml {
+  if (!state || state.running) return raw('');
+  const { info } = state;
+  return html`
+    <dialog id="rbr-update" class="modal upd-modal" data-version="${info.latestVersion}">
+      <div class="modal-head">
+        <span class="bn"></span>
+        <span class="lab">UPDATE AVAILABLE</span>
+      </div>
+      <div class="modal-body">
+        ${updateSummary(info)} ${updateChangelog(info)}
+        ${updateActionBlock(state, session, sessions)}
+      </div>
+      <div class="modal-foot">
+        <button type="button" data-upd-later>LATER</button>
+        <a class="btn secondary" href="/dashboard/update">OPEN UPDATE PAGE →</a>
+      </div>
+    </dialog>
+    <script>
+      ${raw(MODAL_SCRIPT)};
+    </script>
+  `;
+}
+
+/** Brand-block badge (sidebar + mobile bar). */
+export function updateBadge(latestVersion: string): SafeHtml {
+  return html`
+    <a class="sb-update" href="/dashboard/update" title="Update available">
+      <span class="bn"></span>
+      <span class="label">UPDATE v${latestVersion}</span>
+    </a>
+  `;
+}
+
+/**
+ * Badge + modal pair for the page shell, derived from the per-request
+ * update state set by the dashboard auth middleware.
+ */
+export function updateShellExtras(
+  state: UpdateViewState | null,
+  session: DashboardSession | null,
+  sessions: SessionsService,
+): { badge: SafeHtml | null; modal: SafeHtml | undefined } {
+  if (!state || !session) return { badge: null, modal: undefined };
+  return {
+    badge: updateBadge(state.info.latestVersion),
+    modal: renderUpdateModal(state, session, sessions),
+  };
+}

--- a/apps/server/src/dashboard/update.ts
+++ b/apps/server/src/dashboard/update.ts
@@ -1,0 +1,279 @@
+/**
+ * `/dashboard/update` — update offer page, one-click trigger, progress
+ * view with post-restart polling, and the JSON endpoints the progress
+ * script consumes.
+ */
+
+import { Hono, type Context } from 'hono';
+
+import type { SelfUpdateOrchestrator } from '../services/self-update/orchestrator.js';
+import type { SessionsService } from '../services/sessions.js';
+import type { UpdateCheckService } from '../services/update-check.js';
+import { REMBRIC_VERSION } from '../version.js';
+
+import { viewHead } from './components.js';
+import { readFormAndVerifyCsrf } from './csrf.js';
+import { renderPage } from './page-shell.js';
+import { html, raw, type SafeHtml } from './templates.js';
+import type { ResolvedSession } from './types.js';
+import { updateActionBlock, updateChangelog, updateSummary } from './update-modal.js';
+import type { UpdateViewState } from './update-modal.js';
+
+export interface UpdateDeps {
+  updates: UpdateCheckService;
+  selfUpdate: SelfUpdateOrchestrator;
+  sessions: SessionsService;
+}
+
+function getSession(c: Context): ResolvedSession | null {
+  return (c.get('session') as ResolvedSession | undefined) ?? null;
+}
+
+function getUpdateState(c: Context): UpdateViewState | null {
+  return (c.get('update') as UpdateViewState | undefined) ?? null;
+}
+
+// Polls /dashboard/update/status while this process is alive; once the
+// swap starts (phase=restarting or the server stops answering) it flips
+// to probing /dashboard/update/version and reloads when the version
+// changes. Connection errors render as the restart step, not as errors.
+const PROGRESS_SCRIPT = `
+(function(){
+  var root = document.querySelector('[data-upd-progress]');
+  if (!root) return;
+  var initial = root.getAttribute('data-initial-version') || '';
+  var verifying = false;
+  function setStep(key, state){
+    var el = root.querySelector('[data-step="' + key + '"]');
+    if (!el) return;
+    el.setAttribute('data-state', state);
+  }
+  function setSteps(states){
+    for (var k in states) setStep(k, states[k]);
+  }
+  function fail(message){
+    var el = root.querySelector('[data-upd-error]');
+    if (el) { el.textContent = message; el.style.display = ''; }
+  }
+  var sawDown = false;
+  var sameVersionAfterDown = 0;
+  function probeOpts(){
+    var o = { credentials: 'same-origin' };
+    // Docker Desktop port-forwards can hang instead of refusing while the
+    // backend is down — never let a probe wait forever.
+    if (typeof AbortSignal !== 'undefined' && AbortSignal.timeout) o.signal = AbortSignal.timeout(4000);
+    return o;
+  }
+  function verifyTick(){
+    fetch('/dashboard/update/version', probeOpts())
+      .then(function(r){ return r.json(); })
+      .then(function(v){
+        if (v.version && v.version !== initial) {
+          setSteps({ restart: 'done', verify: 'done' });
+          window.location.replace('/dashboard');
+          return;
+        }
+        // Same version AFTER the server went down and came back = the
+        // upgrader rolled back (the old container was restarted).
+        if (sawDown && ++sameVersionAfterDown >= 2) {
+          setSteps({ restart: 'done', verify: 'idle' });
+          fail('The update did not complete — the server is still on v' + initial +
+            ' (the upgrader rolled back). Check the upgrader container logs on the host.');
+          return;
+        }
+        setTimeout(verifyTick, 2000);
+      })
+      .catch(function(){ sawDown = true; setTimeout(verifyTick, 2000); });
+  }
+  function statusTick(){
+    if (verifying) return;
+    fetch('/dashboard/update/status', probeOpts())
+      .then(function(r){ return r.json(); })
+      .then(function(s){
+        if (s.phase === 'failed') {
+          fail(s.error || 'update failed');
+          setSteps({ backup: 'idle', pull: 'idle', restart: 'idle', verify: 'idle' });
+          return;
+        }
+        if (s.phase === 'backup') setSteps({ backup: 'active' });
+        if (s.phase === 'pull') {
+          setSteps({ backup: 'done', pull: 'active' });
+          var pullEl = root.querySelector('[data-pull-progress]');
+          if (pullEl && s.pull) pullEl.textContent = s.pull.done + '/' + s.pull.total + ' LAYERS';
+        }
+        if (s.phase === 'launch' || s.phase === 'restarting') {
+          setSteps({ backup: 'done', pull: 'done', restart: 'active' });
+          if (s.phase === 'restarting') {
+            verifying = true;
+            setSteps({ verify: 'active' });
+            verifyTick();
+            return;
+          }
+        }
+        setTimeout(statusTick, 1500);
+      })
+      .catch(function(){
+        // Server going down mid-swap is the expected path.
+        verifying = true;
+        setSteps({ backup: 'done', pull: 'done', restart: 'active', verify: 'active' });
+        verifyTick();
+      });
+  }
+  statusTick();
+})();
+`;
+
+// Manual quadrant helper: while an update is available, watch for the
+// operator running the compose commands out-of-band and reload when the
+// server comes back on the new version.
+const WATCH_SCRIPT = `
+(function(){
+  var el = document.querySelector('[data-upd-watch]');
+  if (!el) return;
+  var initial = el.getAttribute('data-initial-version') || '';
+  function tick(){
+    var o = { credentials: 'same-origin' };
+    if (typeof AbortSignal !== 'undefined' && AbortSignal.timeout) o.signal = AbortSignal.timeout(4000);
+    fetch('/dashboard/update/version', o)
+      .then(function(r){ return r.json(); })
+      .then(function(v){
+        if (v.version && v.version !== initial) window.location.reload();
+        else setTimeout(tick, 5000);
+      })
+      .catch(function(){ setTimeout(tick, 5000); });
+  }
+  setTimeout(tick, 5000);
+})();
+`;
+
+function progressStep(key: string, label: string): SafeHtml {
+  return html`
+    <div class="upd-step" data-step="${key}" data-state="idle">
+      <span class="dot"></span>
+      <span class="label">${label}</span>
+      ${key === 'pull' ? html`<span class="meta" data-pull-progress></span>` : raw('')}
+    </div>
+  `;
+}
+
+export function createUpdateRouter(deps: UpdateDeps): Hono {
+  const app = new Hono();
+
+  app.get('/', (c) => {
+    const session = getSession(c);
+    if (!session) return c.redirect('/dashboard/login');
+
+    const status = deps.selfUpdate.status();
+    const running =
+      status.phase === 'backup' ||
+      status.phase === 'pull' ||
+      status.phase === 'launch' ||
+      status.phase === 'restarting';
+
+    if (running) {
+      const body = html`
+        ${viewHead({ num: '09', title: 'Updating Rembric.', hl: 'Updating' })}
+        <div class="upd-progress" data-upd-progress data-initial-version="${REMBRIC_VERSION}">
+          <div class="upd-progress-title">
+            INSTALLING v${status.targetVersion ?? ''}
+            <span class="sub">USUALLY TAKES UNDER A MINUTE</span>
+          </div>
+          ${progressStep('backup', 'BACK UP DATABASE')} ${progressStep('pull', 'PULL NEW IMAGE')}
+          ${progressStep('restart', 'RESTART SERVICE')}
+          ${progressStep('verify', 'VERIFY NEW VERSION')}
+          <div class="flash error" data-upd-error style="display:none"></div>
+        </div>
+        <script>
+          ${raw(PROGRESS_SCRIPT)};
+        </script>
+      `;
+      return c.html(
+        renderPage(c, deps.sessions, body, { title: 'Update', activeNav: 'home', view: 'update' }),
+      );
+    }
+
+    const state = getUpdateState(c);
+    const err = c.req.query('err');
+    const flash = err
+      ? ({ kind: 'error', text: updateErrorText(err) } as const)
+      : status.phase === 'failed' && status.error
+        ? ({ kind: 'error', text: `Last update attempt failed: ${status.error}` } as const)
+        : undefined;
+
+    const body = state
+      ? html`
+          ${viewHead({ num: '09', title: 'Update Available.', hl: 'Update' })}
+          <div class="upd-page" data-upd-watch data-initial-version="${REMBRIC_VERSION}">
+            ${updateSummary(state.info)} ${updateChangelog(state.info)}
+            ${updateActionBlock(state, session.session, deps.sessions)}
+          </div>
+          <script>
+            ${raw(WATCH_SCRIPT)};
+          </script>
+        `
+      : html`
+          ${viewHead({ num: '09', title: 'Updates.', hl: 'Updates' })}
+          <div class="upd-page">
+            <div class="upd-note">
+              <span class="lab">UP TO DATE</span>
+              <p>
+                You are running <code>v${REMBRIC_VERSION}</code> — no newer release is known. The
+                check runs at most once a day and can be disabled with
+                <code>REMBRIC_UPDATE_CHECK=off</code>.
+              </p>
+            </div>
+          </div>
+        `;
+
+    return c.html(
+      renderPage(c, deps.sessions, body, {
+        title: 'Update',
+        activeNav: 'home',
+        view: 'update',
+        flash,
+      }),
+    );
+  });
+
+  app.post('/start', async (c) => {
+    const session = getSession(c);
+    if (!session) return c.redirect('/dashboard/login');
+    const form = await readFormAndVerifyCsrf(c, session.session, deps.sessions, 'update.start');
+    if (form instanceof Response) return form;
+
+    const info = deps.updates.peek();
+    if (!info) return c.redirect('/dashboard/update?err=no_update');
+    const result = await deps.selfUpdate.start(info.latestVersion);
+    if (!result.ok) return c.redirect(`/dashboard/update?err=${result.code}`);
+    return c.redirect('/dashboard/update');
+  });
+
+  app.get('/status', (c) => {
+    const session = getSession(c);
+    if (!session) return c.json({ ok: false }, 401);
+    return c.json(deps.selfUpdate.status());
+  });
+
+  app.get('/version', (c) => {
+    const session = getSession(c);
+    if (!session) return c.json({ ok: false }, 401);
+    return c.json({ version: REMBRIC_VERSION });
+  });
+
+  return app;
+}
+
+function updateErrorText(code: string): string {
+  switch (code) {
+    case 'not_available':
+      return 'One-click update is not available on this deployment (no usable Docker socket or pinned image tag).';
+    case 'already_running':
+      return 'An update is already in progress.';
+    case 'backup_failed':
+      return 'The pre-update database backup failed; the update was aborted before touching any container.';
+    case 'no_update':
+      return 'No update is currently known.';
+    default:
+      return 'The update could not be started.';
+  }
+}

--- a/apps/server/src/scripts/upgrade-helper.test.ts
+++ b/apps/server/src/scripts/upgrade-helper.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ContainerInspect } from '../services/self-update/engine-api.js';
+
+import { deriveCreatePayload, runUpgrade, type EngineLike } from './upgrade-helper.js';
+
+function oldContainer(over: Partial<ContainerInspect> = {}): ContainerInspect {
+  return {
+    Id: 'abc123def456',
+    Name: '/rembric',
+    State: { Running: true },
+    Config: {
+      Image: 'ghcr.io/susomejias/rembric:latest',
+      Env: ['REMBRIC_PORT=8787', 'REMBRIC_ADMIN_TOKEN=<token>'],
+      Labels: { 'com.docker.compose.project': 'rembric', 'com.docker.compose.service': 'rembric' },
+      ExposedPorts: { '8787/tcp': {} },
+      User: 'rembric',
+    },
+    HostConfig: {
+      Binds: ['/srv/rembric/data:/data'],
+      PortBindings: { '8787/tcp': [{ HostPort: '8787' }] },
+      RestartPolicy: { Name: 'unless-stopped' },
+    },
+    NetworkSettings: {
+      Networks: { rembric_default: { Aliases: ['rembric', 'abc123def456'.slice(0, 12)] } },
+    },
+    ...over,
+  };
+}
+
+describe('deriveCreatePayload', () => {
+  it('preserves env, labels, ports, volumes, restart policy; swaps the image', () => {
+    const { name, payload } = deriveCreatePayload(
+      oldContainer(),
+      'ghcr.io/susomejias/rembric:0.22.0',
+    );
+    expect(name).toBe('rembric');
+    expect(payload['Image']).toBe('ghcr.io/susomejias/rembric:0.22.0');
+    expect(payload['Env']).toContain('REMBRIC_PORT=8787');
+    expect((payload['Labels'] as Record<string, string>)['com.docker.compose.project']).toBe(
+      'rembric',
+    );
+    const hostConfig = payload['HostConfig'] as Record<string, unknown>;
+    expect((hostConfig['Binds'] as string[])[0]).toBe('/srv/rembric/data:/data');
+    expect((hostConfig['RestartPolicy'] as { Name: string }).Name).toBe('unless-stopped');
+  });
+
+  it('does not pin the old Entrypoint/Cmd (new image defaults win)', () => {
+    const { payload } = deriveCreatePayload(oldContainer(), 'img:new');
+    expect('Entrypoint' in payload).toBe(false);
+    expect('Cmd' in payload).toBe(false);
+  });
+
+  it('drops the old container-id network alias, keeps real ones', () => {
+    const { payload } = deriveCreatePayload(oldContainer(), 'img:new');
+    const networking = payload['NetworkingConfig'] as {
+      EndpointsConfig: Record<string, { Aliases?: string[] }>;
+    };
+    expect(networking.EndpointsConfig['rembric_default']?.Aliases).toEqual(['rembric']);
+  });
+});
+
+interface Calls {
+  log: string[];
+  ops: string[];
+}
+
+function fakeEngine(opts: {
+  healthSequence?: Array<string | undefined>;
+  failCreate?: boolean;
+  failStartNew?: boolean;
+  /** Old container never comes back up after the rollback restart. */
+  oldDeadAfterRollback?: boolean;
+}): { engine: EngineLike; calls: Calls; names: Map<string, string> } {
+  const calls: Calls = { log: [], ops: [] };
+  const names = new Map<string, string>([['abc123def456', 'rembric']]);
+  let healthIdx = 0;
+  let oldRestarted = false;
+  const engine: EngineLike = {
+    inspectContainer: (id) => {
+      calls.ops.push(`inspect:${id}`);
+      if (id === 'abc123def456' || id === names.get('abc123def456')) {
+        if (opts.oldDeadAfterRollback && oldRestarted) {
+          return Promise.resolve(
+            oldContainer({ State: { Running: false, Health: { Status: 'unhealthy' } } }),
+          );
+        }
+        return Promise.resolve(oldContainer());
+      }
+      if (id === 'new789') {
+        const seq = opts.healthSequence ?? ['healthy'];
+        const status = seq[Math.min(healthIdx++, seq.length - 1)];
+        return Promise.resolve(
+          oldContainer({
+            Id: 'new789',
+            Name: '/rembric',
+            State: { Running: true, Health: status ? { Status: status } : undefined },
+          }),
+        );
+      }
+      return Promise.reject(new Error('no such container'));
+    },
+    createContainer: (name) => {
+      calls.ops.push(`create:${name}`);
+      if (opts.failCreate) return Promise.reject(new Error('image not found'));
+      names.set('new789', name);
+      return Promise.resolve({ Id: 'new789' });
+    },
+    startContainer: (id) => {
+      calls.ops.push(`start:${id}`);
+      if (id === 'new789' && opts.failStartNew) return Promise.reject(new Error('boom'));
+      if (id === 'abc123def456') oldRestarted = true;
+      return Promise.resolve();
+    },
+    stopContainer: (id) => {
+      calls.ops.push(`stop:${id}`);
+      return Promise.resolve();
+    },
+    renameContainer: (id, name) => {
+      calls.ops.push(`rename:${id}→${name}`);
+      names.set(id, name);
+      return Promise.resolve();
+    },
+    removeContainer: (id, force) => {
+      calls.ops.push(`remove:${id}${force ? ':force' : ''}`);
+      return Promise.resolve();
+    },
+  };
+  return { engine, calls, names };
+}
+
+const FAST = { healthTimeoutMs: 500, pollIntervalMs: 1, noHealthcheckGraceMs: 5, log: () => {} };
+
+describe('runUpgrade', () => {
+  it('happy path: stop → rename → create → start → healthy → remove old', async () => {
+    const { engine, calls } = fakeEngine({ healthSequence: ['starting', 'healthy'] });
+    const outcome = await runUpgrade(engine, {
+      oldId: 'abc123def456',
+      targetImage: 'img:0.22.0',
+      ...FAST,
+    });
+    expect(outcome).toBe('ok');
+    const ops = calls.ops.join(' ');
+    expect(ops).toMatch(
+      /stop:abc123def456.*rename:abc123def456→rembric-old-.*create:rembric.*start:new789.*remove:abc123def456:force/,
+    );
+  });
+
+  it('rolls back when the replacement never becomes healthy', async () => {
+    const { engine, calls } = fakeEngine({ healthSequence: ['starting'] });
+    const outcome = await runUpgrade(engine, {
+      oldId: 'abc123def456',
+      targetImage: 'img:0.22.0',
+      ...FAST,
+      healthTimeoutMs: 20,
+    });
+    expect(outcome).toBe('rolled-back');
+    const ops = calls.ops.join(' ');
+    expect(ops).toContain('remove:new789:force');
+    // rename-back then restart, followed by the post-rollback health probe
+    expect(ops).toMatch(/rename:abc123def456→rembric .*start:abc123def456/);
+  });
+
+  it('rolls back when create fails (old container restored, nothing removed)', async () => {
+    const { engine, calls } = fakeEngine({ failCreate: true });
+    const outcome = await runUpgrade(engine, {
+      oldId: 'abc123def456',
+      targetImage: 'img:0.22.0',
+      ...FAST,
+    });
+    expect(outcome).toBe('rolled-back');
+    const ops = calls.ops.join(' ');
+    expect(ops).not.toContain('remove:new789');
+    expect(ops).toMatch(/rename:abc123def456→rembric .*start:abc123def456/);
+  });
+
+  it('old container failing to recover post-rollback names the backup to restore', async () => {
+    const { engine } = fakeEngine({
+      healthSequence: ['starting'],
+      oldDeadAfterRollback: true,
+    });
+    const lines: string[] = [];
+    const outcome = await runUpgrade(engine, {
+      oldId: 'abc123def456',
+      targetImage: 'img:0.22.0',
+      ...FAST,
+      healthTimeoutMs: 20,
+      backupPath: '/data/backups/pre-update-v0.22.0-123.sqlite',
+      log: (l) => lines.push(l),
+    });
+    expect(outcome).toBe('rolled-back-unhealthy');
+    expect(lines.some((l) => l.includes('migrated the database forward'))).toBe(true);
+    const recovery = lines.find((l) => l.startsWith('MANUAL RECOVERY'));
+    expect(recovery).toContain('/data/backups/pre-update-v0.22.0-123.sqlite');
+    expect(recovery).toContain('Writes that landed during the failed update window will be lost');
+  });
+
+  it('double fault: rollback failure logs manual recovery and rethrows', async () => {
+    const { engine, calls } = fakeEngine({ failCreate: true });
+    const lines: string[] = [];
+    const original = engine.renameContainer.bind(engine);
+    let renames = 0;
+    engine.renameContainer = (id, name) => {
+      // First rename (parking the old container) succeeds; the rename-back
+      // during rollback fails.
+      renames++;
+      if (renames > 1) return Promise.reject(new Error('daemon hung'));
+      return original(id, name);
+    };
+    await expect(
+      runUpgrade(engine, {
+        oldId: 'abc123def456',
+        targetImage: 'img:0.22.0',
+        ...FAST,
+        log: (l) => lines.push(l),
+      }),
+    ).rejects.toThrow('daemon hung');
+    expect(lines.some((l) => l.startsWith('ROLLBACK FAILED'))).toBe(true);
+    const recovery = lines.find((l) => l.startsWith('MANUAL RECOVERY'));
+    expect(recovery).toContain('docker rename rembric-old-');
+    expect(recovery).toContain('docker start rembric');
+    // The old container was never removed — the data and config are intact.
+    expect(calls.ops.join(' ')).not.toContain('remove:abc123def456');
+  });
+
+  it('treats a healthcheck-less running replacement as healthy after the grace window', async () => {
+    const { engine } = fakeEngine({ healthSequence: [undefined] });
+    const outcome = await runUpgrade(engine, {
+      oldId: 'abc123def456',
+      targetImage: 'img:0.22.0',
+      ...FAST,
+      noHealthcheckGraceMs: 10,
+    });
+    expect(outcome).toBe('ok');
+  });
+});

--- a/apps/server/src/scripts/upgrade-helper.ts
+++ b/apps/server/src/scripts/upgrade-helper.ts
@@ -1,0 +1,220 @@
+/**
+ * Ephemeral upgrader — entrypoint of the one-shot container the
+ * orchestrator launches from the freshly pulled image. Performs the swap
+ * the running server cannot survive:
+ *
+ *   inspect old → stop → rename away → create+start replacement under the
+ *   original name → wait healthy → remove old (or roll back).
+ *
+ * On failure the exited upgrader container is left in place so its logs
+ * remain inspectable (`docker logs rembric-upgrader-*`).
+ */
+
+import { hostname } from 'node:os';
+
+import {
+  DockerEngineApi,
+  type ContainerInspect,
+  type PullProgressEvent,
+} from '../services/self-update/engine-api.js';
+
+export interface EngineLike {
+  inspectContainer(idOrName: string): Promise<ContainerInspect>;
+  createContainer(name: string, payload: unknown): Promise<{ Id: string }>;
+  startContainer(id: string): Promise<void>;
+  stopContainer(id: string, timeoutSec?: number): Promise<void>;
+  renameContainer(id: string, name: string): Promise<void>;
+  removeContainer(id: string, force?: boolean): Promise<void>;
+  pullImage?(
+    repo: string,
+    tag: string,
+    onProgress?: (ev: PullProgressEvent) => void,
+  ): Promise<void>;
+}
+
+/**
+ * Clone the old container's creation config, swapping only the image.
+ * Compose labels ride along so `docker compose` keeps recognizing the
+ * replacement as its own service container.
+ */
+export function deriveCreatePayload(
+  old: ContainerInspect,
+  targetImage: string,
+): { name: string; payload: Record<string, unknown> } {
+  const name = old.Name.replace(/^\//, '');
+  const networks = old.NetworkSettings?.Networks ?? {};
+  const endpoints: Record<string, unknown> = {};
+  for (const [netName, net] of Object.entries(networks)) {
+    // Aliases include the old container's short id — drop it; the daemon
+    // re-adds the new container's own id alias automatically.
+    const aliases = (net.Aliases ?? []).filter((a) => !old.Id.startsWith(a));
+    endpoints[netName] = aliases.length > 0 ? { Aliases: aliases } : {};
+  }
+  const payload: Record<string, unknown> = {
+    Image: targetImage,
+    Env: old.Config.Env ?? [],
+    Labels: old.Config.Labels ?? {},
+    ExposedPorts: old.Config.ExposedPorts ?? {},
+    User: old.Config.User || undefined,
+    WorkingDir: old.Config.WorkingDir || undefined,
+    HostConfig: old.HostConfig,
+    NetworkingConfig: { EndpointsConfig: endpoints },
+  };
+  // Entrypoint/Cmd are deliberately NOT copied: the new image's defaults
+  // must win (an entrypoint rename between versions would otherwise brick).
+  return { name, payload };
+}
+
+export interface UpgradeOptions {
+  oldId: string;
+  targetImage: string;
+  healthTimeoutMs?: number;
+  pollIntervalMs?: number;
+  /** Continuous-Running window that counts as healthy when the image has no HEALTHCHECK. */
+  noHealthcheckGraceMs?: number;
+  /** Pre-update snapshot path, named in recovery messages. */
+  backupPath?: string;
+  log?: (line: string) => void;
+}
+
+export type UpgradeOutcome = 'ok' | 'rolled-back' | 'rolled-back-unhealthy';
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitHealthy(
+  engine: EngineLike,
+  id: string,
+  timeoutMs: number,
+  pollMs: number,
+  graceMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  let runningSince = 0;
+  while (Date.now() < deadline) {
+    try {
+      const c = await engine.inspectContainer(id);
+      const health = c.State?.Health?.Status;
+      if (health === 'healthy') return true;
+      if (health === undefined && c.State?.Running) {
+        // No HEALTHCHECK in the image: continuous Running for the grace
+        // window counts as healthy.
+        if (runningSince === 0) runningSince = Date.now();
+        if (Date.now() - runningSince >= graceMs) return true;
+      } else if (!c.State?.Running && health !== 'starting') {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+    await sleep(pollMs);
+  }
+  return false;
+}
+
+export async function runUpgrade(
+  engine: EngineLike,
+  opts: UpgradeOptions,
+): Promise<UpgradeOutcome> {
+  const log = opts.log ?? ((line: string) => console.error(line));
+  const healthTimeoutMs = opts.healthTimeoutMs ?? 150_000;
+  const pollMs = opts.pollIntervalMs ?? 2_000;
+  const graceMs = opts.noHealthcheckGraceMs ?? 10_000;
+
+  const old = await engine.inspectContainer(opts.oldId);
+  const { name, payload } = deriveCreatePayload(old, opts.targetImage);
+  const parkedName = `${name}-old-${Date.now()}`;
+
+  log(`upgrading ${name} (${old.Id.slice(0, 12)}) to ${opts.targetImage}`);
+  await engine.stopContainer(old.Id);
+  await engine.renameContainer(old.Id, parkedName);
+
+  let newId: string | null = null;
+  try {
+    const created = await engine.createContainer(name, payload);
+    newId = created.Id;
+    await engine.startContainer(newId);
+    const healthy = await waitHealthy(engine, newId, healthTimeoutMs, pollMs, graceMs);
+    if (!healthy) throw new Error('replacement container did not become healthy in time');
+  } catch (err) {
+    log(`upgrade failed: ${err instanceof Error ? err.message : String(err)} — rolling back`);
+    if (newId) {
+      try {
+        await engine.removeContainer(newId, true);
+      } catch {
+        /* nothing left to remove */
+      }
+    }
+    try {
+      await engine.renameContainer(old.Id, name);
+      await engine.startContainer(old.Id);
+    } catch (rollbackErr) {
+      // Double fault: the rollback itself failed. Never die silently —
+      // print the exact manual recovery so the operator can restore.
+      log(
+        `ROLLBACK FAILED: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
+      );
+      log(
+        `MANUAL RECOVERY: docker rename ${parkedName} ${name} && docker start ${name}  (data volume is untouched)`,
+      );
+      throw rollbackErr;
+    }
+    // The failed version may have migrated the database forward before
+    // dying; the restored old code could then refuse to boot. Verify, and
+    // if it never recovers, name the exact snapshot to restore.
+    const oldRecovered = await waitHealthy(engine, old.Id, healthTimeoutMs, pollMs, graceMs);
+    if (!oldRecovered) {
+      log(
+        `ROLLED BACK BUT ${name} DID NOT BECOME HEALTHY — the failed update may have migrated the database forward.`,
+      );
+      log(
+        `MANUAL RECOVERY: docker stop ${name}, restore the pre-update snapshot${opts.backupPath ? ` (${opts.backupPath})` : ''} over data.db in the data volume (remove data.db-wal / data.db-shm), then docker start ${name}. Writes that landed during the failed update window will be lost — that is why this step is yours, not automatic.`,
+      );
+      return 'rolled-back-unhealthy';
+    }
+    log(`rollback complete: ${name} is back on the previous version`);
+    return 'rolled-back';
+  }
+
+  await engine.removeContainer(old.Id, true);
+  log(`upgrade complete: ${name} is now running ${opts.targetImage}`);
+  return 'ok';
+}
+
+async function main(): Promise<void> {
+  const oldId = process.env['REMBRIC_UPGRADE_TARGET_CONTAINER'];
+  const targetImage = process.env['REMBRIC_UPGRADE_IMAGE'];
+  if (!oldId || !targetImage) {
+    console.error(
+      'upgrade-helper: REMBRIC_UPGRADE_TARGET_CONTAINER and REMBRIC_UPGRADE_IMAGE are required',
+    );
+    process.exit(2);
+  }
+  const engine = new DockerEngineApi();
+  const outcome = await runUpgrade(engine, {
+    oldId,
+    targetImage,
+    backupPath: process.env['REMBRIC_UPGRADE_BACKUP'],
+  });
+  if (outcome === 'ok') {
+    // Best-effort self-removal: the daemon force-kills this container as
+    // the call lands, which is exactly the intent. Failure is harmless —
+    // it just leaves an exited helper behind.
+    try {
+      await engine.removeContainer(hostname(), true);
+    } catch {
+      /* see above */
+    }
+    process.exit(0);
+  }
+  process.exit(1);
+}
+
+const invokedDirectly = process.argv[1]?.endsWith('upgrade-helper.js') === true;
+if (invokedDirectly) {
+  main().catch((err: unknown) => {
+    console.error(`upgrade-helper: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/apps/server/src/server/bootstrap.ts
+++ b/apps/server/src/server/bootstrap.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path';
+
 import { sql } from 'drizzle-orm';
 
 import { findStaleEnvVars, loadConfig, redactConfig, type Config } from '../config.js';
@@ -17,8 +19,15 @@ import { MemoryService } from '../services/memory.js';
 import { ProjectsService } from '../services/projects.js';
 import { PromptsService } from '../services/prompts.js';
 import { RelationsService } from '../services/relations.js';
+import { CapabilityDetector } from '../services/self-update/capability.js';
+import { DockerEngineApi } from '../services/self-update/engine-api.js';
+import {
+  createPreUpdateBackup,
+  SelfUpdateOrchestrator,
+} from '../services/self-update/orchestrator.js';
 import { SessionsService } from '../services/sessions.js';
 import { deriveSessionKey, TokensService } from '../services/tokens.js';
+import { UpdateCheckService } from '../services/update-check.js';
 import { REMBRIC_VERSION } from '../version.js';
 
 import type { DashboardStats } from './dashboard-router.js';
@@ -49,6 +58,10 @@ export interface BootstrappedServer {
 export interface BootstrapOverrides {
   /** Test-only seam: replace the in-process embedder (never operator config). */
   embedder?: Embedder;
+  /** Test-only seam: replace the release update check. */
+  updates?: UpdateCheckService;
+  /** Test-only seam: replace the self-update orchestrator. */
+  selfUpdate?: SelfUpdateOrchestrator;
 }
 
 export async function bootstrap(
@@ -195,6 +208,26 @@ export async function bootstrap(
     }),
   );
 
+  const updates =
+    overrides.updates ??
+    new UpdateCheckService({
+      enabled: env['REMBRIC_UPDATE_CHECK'] !== 'off',
+      // Test/smoke seam: point the release feed at a stub (docs/updates.md).
+      releasesUrl: env['REMBRIC_UPDATE_CHECK_URL'],
+    });
+  const selfUpdate =
+    overrides.selfUpdate ??
+    new SelfUpdateOrchestrator({
+      capability: new CapabilityDetector({ env }),
+      engineFactory: (socketPath) => new DockerEngineApi(socketPath),
+      backup: createPreUpdateBackup({
+        vacuumInto: (dest) => {
+          dbHandle.raw.prepare('VACUUM INTO ?').run(dest);
+        },
+        backupsDir: join(config.dataDir, 'backups'),
+      }),
+    });
+
   const rateLimiter = config.rateLimit.enabled
     ? new RateLimiter({
         ratePerSecond: config.rateLimit.ratePerSecond,
@@ -247,6 +280,8 @@ export async function bootstrap(
       memory: memorySvc,
       getStats: () => collectStats(dbHandle, agentSessionsSvc, relationsSvc),
       dataDir: config.dataDir,
+      updates,
+      selfUpdate,
     },
   });
 

--- a/apps/server/src/server/dashboard-router.ts
+++ b/apps/server/src/server/dashboard-router.ts
@@ -36,14 +36,18 @@ import {
 } from '../dashboard/templates.js';
 import { createTokensRouter } from '../dashboard/tokens.js';
 import type { ResolvedSession } from '../dashboard/types.js';
+import { updateShellExtras, type UpdateViewState } from '../dashboard/update-modal.js';
+import { createUpdateRouter } from '../dashboard/update.js';
 import type { Db } from '../db/client.js';
 import type { AgentSessionsService } from '../services/agent-sessions.js';
 import { DomainError } from '../services/errors.js';
 import type { MemoryService } from '../services/memory.js';
 import type { ProjectsService } from '../services/projects.js';
 import type { PromptsService } from '../services/prompts.js';
+import type { SelfUpdateOrchestrator } from '../services/self-update/orchestrator.js';
 import type { SessionsService } from '../services/sessions.js';
 import type { TokensService } from '../services/tokens.js';
+import type { UpdateCheckService } from '../services/update-check.js';
 import { REMBRIC_VERSION } from '../version.js';
 
 const COOKIE_NAME = 'rembric_session';
@@ -61,6 +65,8 @@ export interface DashboardDeps {
   getStats: () => DashboardStats;
   /** Resolved data directory (from `config.dataDir`). */
   dataDir: string;
+  updates: UpdateCheckService;
+  selfUpdate: SelfUpdateOrchestrator;
 }
 
 export interface DashboardStats {
@@ -153,6 +159,21 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
       tokenId: ctx.tokenId,
     };
     c.set('session', resolved);
+
+    // Update-availability state for the shell (badge + modal). With no
+    // newer release known, this is a sync cache read and the capability
+    // probe (which may touch the Docker socket) is never reached.
+    let update: UpdateViewState | null = null;
+    const info = deps.updates.peek();
+    if (info) {
+      const phase = deps.selfUpdate.status().phase;
+      update = {
+        info,
+        capability: await deps.selfUpdate.capability(),
+        running: phase !== 'idle' && phase !== 'failed',
+      };
+    }
+    c.set('update', update);
     return next();
   });
 
@@ -179,7 +200,15 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
     const collapsed = sidebarCollapsed(c);
     const counters = { pendingJudgments: stats.pendingJudgments };
     const csrf = csrfInput(session.session, deps.sessions, 'sidebar.toggle');
-    const sidebar = renderSidebar({ active: 'home', counters, collapsed, csrf });
+    const updateState = (c.get('update' as never) as UpdateViewState | undefined | null) ?? null;
+    const updateExtras = updateShellExtras(updateState, session.session, deps.sessions);
+    const sidebar = renderSidebar({
+      active: 'home',
+      counters,
+      collapsed,
+      csrf,
+      update: updateExtras.badge,
+    });
 
     const supersededMemories = Math.max(
       0,
@@ -494,6 +523,8 @@ ${ascBars(activity)}</pre
         sidebar,
         collapsed,
         counters,
+        updateBadge: updateExtras.badge,
+        updateModal: updateExtras.modal,
       }),
     );
   });
@@ -524,6 +555,14 @@ ${ascBars(activity)}</pre
   app.route(
     '/tokens',
     createTokensRouter({ tokens: deps.tokens, projects: deps.projects, sessions: deps.sessions }),
+  );
+  app.route(
+    '/update',
+    createUpdateRouter({
+      updates: deps.updates,
+      selfUpdate: deps.selfUpdate,
+      sessions: deps.sessions,
+    }),
   );
   app.route(
     '/maintenance',

--- a/apps/server/src/services/self-update/capability.test.ts
+++ b/apps/server/src/services/self-update/capability.test.ts
@@ -1,0 +1,171 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { CapabilityDetector, isPinnedTag, splitImageRef } from './capability.js';
+import type { ContainerInspect } from './engine-api.js';
+
+let dir: string;
+let presentSocket: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'rembric-cap-'));
+  presentSocket = join(dir, 'docker.sock');
+  // existsSync is the only check before ping; a plain file stands in.
+  writeFileSync(presentSocket, '');
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function inspectOf(image: string): ContainerInspect {
+  return { Id: 'abc123', Name: '/rembric', Config: { Image: image }, HostConfig: {} };
+}
+
+interface FakeEngineOpts {
+  pingOk?: boolean;
+  containers?: Record<string, ContainerInspect>;
+}
+
+function fakeEngine(opts: FakeEngineOpts) {
+  return {
+    ping: () => Promise.resolve(opts.pingOk ?? true),
+    inspectContainer: (id: string) => {
+      const c = opts.containers?.[id];
+      if (!c) return Promise.reject(new Error('no such container'));
+      return Promise.resolve(c);
+    },
+  };
+}
+
+function detector(
+  engineOpts: FakeEngineOpts,
+  over: Partial<ConstructorParameters<typeof CapabilityDetector>[0]> = {},
+): CapabilityDetector {
+  return new CapabilityDetector({
+    socketPath: presentSocket,
+    engineFactory: () => fakeEngine(engineOpts),
+    env: {},
+    hostnameFn: () => 'abc123',
+    log: () => {},
+    ...over,
+  });
+}
+
+describe('splitImageRef / isPinnedTag', () => {
+  it('splits repo and tag, defaulting to latest', () => {
+    expect(splitImageRef('ghcr.io/susomejias/rembric:0.21.1')).toEqual({
+      repo: 'ghcr.io/susomejias/rembric',
+      tag: '0.21.1',
+    });
+    expect(splitImageRef('ghcr.io/susomejias/rembric')).toEqual({
+      repo: 'ghcr.io/susomejias/rembric',
+      tag: 'latest',
+    });
+    expect(splitImageRef('registry:5000/rembric')).toEqual({
+      repo: 'registry:5000/rembric',
+      tag: 'latest',
+    });
+  });
+
+  it('recognizes pinned semver tags', () => {
+    expect(isPinnedTag('0.21.1')).toBe(true);
+    expect(isPinnedTag('v0.21.1')).toBe(true);
+    expect(isPinnedTag('latest')).toBe(false);
+    expect(isPinnedTag('')).toBe(false);
+  });
+});
+
+describe('CapabilityDetector', () => {
+  it('no socket → manual/no-socket without touching the engine', async () => {
+    let engineBuilt = false;
+    const d = new CapabilityDetector({
+      socketPath: join(dir, 'absent.sock'),
+      engineFactory: () => {
+        engineBuilt = true;
+        return fakeEngine({});
+      },
+      log: () => {},
+    });
+    expect(await d.detect()).toEqual({ state: 'manual', reason: 'no-socket' });
+    expect(engineBuilt).toBe(false);
+  });
+
+  it('socket present but ping fails → manual/socket-unusable, logs once', async () => {
+    const lines: string[] = [];
+    const d = detector({ pingOk: false }, { log: (l) => lines.push(l) });
+    expect((await d.detect()).reason).toBe('socket-unusable');
+    expect((await d.detect()).reason).toBe('socket-unusable');
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain('group_add');
+  });
+
+  it('self container not found → manual/self-not-found', async () => {
+    const d = detector({ containers: {} });
+    expect((await d.detect()).reason).toBe('self-not-found');
+  });
+
+  it('unpinned latest tag → available with repo/tag/id', async () => {
+    const d = detector({
+      containers: { abc123: inspectOf('ghcr.io/susomejias/rembric:latest') },
+    });
+    expect(await d.detect()).toEqual({
+      state: 'available',
+      reason: 'ok',
+      containerId: 'abc123',
+      imageRepo: 'ghcr.io/susomejias/rembric',
+      imageTag: 'latest',
+    });
+  });
+
+  it('pinned tag → pinned', async () => {
+    const d = detector({
+      containers: { abc123: inspectOf('ghcr.io/susomejias/rembric:0.21.1') },
+    });
+    const cap = await d.detect();
+    expect(cap.state).toBe('pinned');
+    expect(cap.imageTag).toBe('0.21.1');
+  });
+
+  it('latest tag but REMBRIC_VERSION env pin → pinned (env cross-check)', async () => {
+    const d = detector(
+      { containers: { abc123: inspectOf('ghcr.io/susomejias/rembric:latest') } },
+      { env: { REMBRIC_VERSION: '0.21.1' } },
+    );
+    const cap = await d.detect();
+    expect(cap.state).toBe('pinned');
+    expect(cap.imageTag).toBe('0.21.1');
+  });
+
+  it('falls back to the container name when hostname inspect misses', async () => {
+    const d = detector(
+      { containers: { rembric: inspectOf('ghcr.io/susomejias/rembric:latest') } },
+      { hostnameFn: () => 'not-a-container-id' },
+    );
+    expect((await d.detect()).state).toBe('available');
+  });
+
+  it('detectCached respects the TTL', async () => {
+    let t = 0;
+    let detects = 0;
+    const d = detector(
+      { containers: { abc123: inspectOf('ghcr.io/susomejias/rembric:latest') } },
+      { cacheTtlMs: 1000, now: () => t },
+    );
+    const original = d.detect.bind(d);
+    d.detect = () => {
+      detects++;
+      return original();
+    };
+    await d.detectCached();
+    t = 500;
+    await d.detectCached();
+    expect(detects).toBe(1);
+    t = 1500;
+    await d.detectCached();
+    expect(detects).toBe(2);
+  });
+});

--- a/apps/server/src/services/self-update/capability.ts
+++ b/apps/server/src/services/self-update/capability.ts
@@ -1,0 +1,151 @@
+/**
+ * Self-update capability detection — the four-quadrant contract.
+ *
+ * Detection is strictly runtime and side-effect free: no socket on disk
+ * means the Docker code path is never entered (zero-action compatibility).
+ * A socket that exists but cannot be used degrades to `manual` with a
+ * single informational log line, never an error.
+ */
+
+import { existsSync } from 'node:fs';
+import { hostname } from 'node:os';
+
+import { DEFAULT_DOCKER_SOCKET, DockerEngineApi } from './engine-api.js';
+
+export type SelfUpdateState = 'available' | 'pinned' | 'manual';
+
+export type SelfUpdateReason =
+  | 'ok'
+  | 'no-socket'
+  | 'socket-unusable'
+  | 'self-not-found'
+  | 'pinned-tag';
+
+export interface SelfUpdateCapability {
+  state: SelfUpdateState;
+  reason: SelfUpdateReason;
+  /** Resolved own container id (when inspection succeeded). */
+  containerId?: string;
+  /** Image repo without tag, e.g. `ghcr.io/susomejias/rembric`. */
+  imageRepo?: string;
+  imageTag?: string;
+}
+
+export interface CapabilityDetectorOptions {
+  socketPath?: string;
+  engineFactory?: (socketPath: string) => Pick<DockerEngineApi, 'ping' | 'inspectContainer'>;
+  env?: NodeJS.ProcessEnv;
+  hostnameFn?: () => string;
+  /** Container name fallback when the hostname is not the container id. */
+  containerName?: string;
+  log?: (line: string) => void;
+  /** Cache TTL for `detectCached()`; capability is consulted per page render. */
+  cacheTtlMs?: number;
+  now?: () => number;
+}
+
+export function splitImageRef(ref: string): { repo: string; tag: string } {
+  // The tag separator is the last ':' AFTER the last '/' (registries carry ports).
+  const slash = ref.lastIndexOf('/');
+  const colon = ref.lastIndexOf(':');
+  if (colon > slash) return { repo: ref.slice(0, colon), tag: ref.slice(colon + 1) };
+  return { repo: ref, tag: 'latest' };
+}
+
+export function isPinnedTag(tag: string): boolean {
+  return /^v?\d+\.\d+\.\d+$/.test(tag);
+}
+
+export class CapabilityDetector {
+  private readonly socketPath: string;
+  private readonly engineFactory: NonNullable<CapabilityDetectorOptions['engineFactory']>;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly hostnameFn: () => string;
+  private readonly containerName: string;
+  private readonly log: (line: string) => void;
+  private readonly cacheTtlMs: number;
+  private readonly now: () => number;
+
+  private warned = false;
+  private cached: SelfUpdateCapability | null = null;
+  private cachedAt = 0;
+  private inflight: Promise<SelfUpdateCapability> | null = null;
+
+  constructor(opts: CapabilityDetectorOptions = {}) {
+    this.socketPath = opts.socketPath ?? DEFAULT_DOCKER_SOCKET;
+    this.engineFactory = opts.engineFactory ?? ((p) => new DockerEngineApi(p));
+    this.env = opts.env ?? process.env;
+    this.hostnameFn = opts.hostnameFn ?? hostname;
+    this.containerName = opts.containerName ?? 'rembric';
+    this.log = opts.log ?? ((line) => console.error(line));
+    this.cacheTtlMs = opts.cacheTtlMs ?? 30_000;
+    this.now = opts.now ?? Date.now;
+  }
+
+  async detect(): Promise<SelfUpdateCapability> {
+    if (!existsSync(this.socketPath)) {
+      return { state: 'manual', reason: 'no-socket' };
+    }
+
+    const engine = this.engineFactory(this.socketPath);
+    if (!(await engine.ping())) {
+      if (!this.warned) {
+        this.warned = true;
+        this.log(
+          `  ℹ docker socket at ${this.socketPath} is mounted but not usable (check group_add); one-click updates disabled`,
+        );
+      }
+      return { state: 'manual', reason: 'socket-unusable' };
+    }
+
+    let inspect: Awaited<ReturnType<typeof engine.inspectContainer>> | null = null;
+    for (const candidate of [this.hostnameFn(), this.containerName]) {
+      try {
+        inspect = await engine.inspectContainer(candidate);
+        break;
+      } catch {
+        /* try the next candidate */
+      }
+    }
+    if (!inspect) {
+      return { state: 'manual', reason: 'self-not-found' };
+    }
+
+    const { repo, tag } = splitImageRef(inspect.Config.Image);
+    // Ground truth is the tag the container was created from; the
+    // REMBRIC_VERSION env var (compose pin via env_file) is a cross-check.
+    if (isPinnedTag(tag) || (tag === 'latest' && isPinnedTag(this.env['REMBRIC_VERSION'] ?? ''))) {
+      return {
+        state: 'pinned',
+        reason: 'pinned-tag',
+        containerId: inspect.Id,
+        imageRepo: repo,
+        imageTag: isPinnedTag(tag) ? tag : (this.env['REMBRIC_VERSION'] ?? tag),
+      };
+    }
+
+    return {
+      state: 'available',
+      reason: 'ok',
+      containerId: inspect.Id,
+      imageRepo: repo,
+      imageTag: tag,
+    };
+  }
+
+  /** TTL-cached detection — consulted on every dashboard page render. */
+  async detectCached(): Promise<SelfUpdateCapability> {
+    if (this.cached && this.now() - this.cachedAt < this.cacheTtlMs) return this.cached;
+    if (this.inflight) return this.inflight;
+    this.inflight = this.detect()
+      .then((cap) => {
+        this.cached = cap;
+        this.cachedAt = this.now();
+        return cap;
+      })
+      .finally(() => {
+        this.inflight = null;
+      });
+    return this.inflight;
+  }
+}

--- a/apps/server/src/services/self-update/engine-api.test.ts
+++ b/apps/server/src/services/self-update/engine-api.test.ts
@@ -1,0 +1,137 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { DockerEngineApi, EngineApiError, ENGINE_API_VERSION } from './engine-api.js';
+
+interface Seen {
+  method: string;
+  url: string;
+  body: string;
+}
+
+describe('DockerEngineApi', () => {
+  let dir: string;
+  let socketPath: string;
+  let server: Server;
+  const seen: Seen[] = [];
+
+  beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'rembric-engine-'));
+    socketPath = join(dir, 'docker.sock');
+    server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        seen.push({
+          method: req.method ?? '',
+          url: req.url ?? '',
+          body: Buffer.concat(chunks).toString('utf8'),
+        });
+        const url = req.url ?? '';
+        if (url.endsWith('/_ping')) {
+          res.writeHead(200).end('OK');
+        } else if (url.includes('/containers/self123/json')) {
+          res.writeHead(200, { 'content-type': 'application/json' }).end(
+            JSON.stringify({
+              Id: 'self123',
+              Name: '/rembric',
+              Config: { Image: 'ghcr.io/susomejias/rembric:latest' },
+              HostConfig: {},
+            }),
+          );
+        } else if (url.includes('/containers/missing/json')) {
+          res
+            .writeHead(404, { 'content-type': 'application/json' })
+            .end(JSON.stringify({ message: 'No such container' }));
+        } else if (url.includes('/images/create')) {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.write(JSON.stringify({ status: 'Pulling fs layer', id: 'aaa' }) + '\n');
+          res.write(
+            JSON.stringify({
+              status: 'Downloading',
+              id: 'aaa',
+              progressDetail: { current: 5, total: 10 },
+            }) + '\n',
+          );
+          res.end(JSON.stringify({ status: 'Status: Downloaded newer image' }) + '\n');
+        } else if (url.includes('/containers/create')) {
+          res
+            .writeHead(201, { 'content-type': 'application/json' })
+            .end(JSON.stringify({ Id: 'new456' }));
+        } else if (/\/(start|stop)/.test(url)) {
+          res.writeHead(204).end();
+        } else if (url.includes('/rename')) {
+          res.writeHead(204).end();
+        } else if (req.method === 'DELETE') {
+          res.writeHead(204).end();
+        } else {
+          res.writeHead(500).end('unexpected');
+        }
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('pings', async () => {
+    const api = new DockerEngineApi(socketPath);
+    expect(await api.ping()).toBe(true);
+  });
+
+  it('ping returns false when the socket does not exist', async () => {
+    const api = new DockerEngineApi(join(dir, 'nope.sock'));
+    expect(await api.ping()).toBe(false);
+  });
+
+  it('prefixes every path with the pinned API version', async () => {
+    const api = new DockerEngineApi(socketPath);
+    await api.ping();
+    expect(seen.at(-1)?.url).toBe(`/${ENGINE_API_VERSION}/_ping`);
+  });
+
+  it('inspects a container', async () => {
+    const api = new DockerEngineApi(socketPath);
+    const c = await api.inspectContainer('self123');
+    expect(c.Name).toBe('/rembric');
+    expect(c.Config.Image).toBe('ghcr.io/susomejias/rembric:latest');
+  });
+
+  it('throws EngineApiError with the daemon message on 404', async () => {
+    const api = new DockerEngineApi(socketPath);
+    await expect(api.inspectContainer('missing')).rejects.toThrowError(EngineApiError);
+    await expect(api.inspectContainer('missing')).rejects.toThrow(/No such container/);
+  });
+
+  it('streams pull progress events', async () => {
+    const api = new DockerEngineApi(socketPath);
+    const events: string[] = [];
+    await api.pullImage('ghcr.io/susomejias/rembric', '0.22.0', (ev) => {
+      if (ev.status) events.push(ev.status);
+    });
+    expect(events).toContain('Downloading');
+    expect(seen.at(-1)?.url).toContain('fromImage=ghcr.io%2Fsusomejias%2Frembric');
+    expect(seen.at(-1)?.url).toContain('tag=0.22.0');
+  });
+
+  it('creates, starts, stops, renames, removes', async () => {
+    const api = new DockerEngineApi(socketPath);
+    const created = await api.createContainer('rembric-upgrader-1', { Image: 'x' });
+    expect(created.Id).toBe('new456');
+    expect(seen.at(-1)?.body).toContain('"Image":"x"');
+    await api.startContainer('new456');
+    await api.stopContainer('self123', 10);
+    expect(seen.at(-1)?.url).toContain('t=10');
+    await api.renameContainer('self123', 'rembric-old');
+    expect(seen.at(-1)?.url).toContain('name=rembric-old');
+    await api.removeContainer('self123', true);
+    expect(seen.at(-1)?.url).toContain('force=true');
+  });
+});

--- a/apps/server/src/services/self-update/engine-api.ts
+++ b/apps/server/src/services/self-update/engine-api.ts
@@ -1,0 +1,240 @@
+/**
+ * Minimal Docker Engine API client over the unix socket.
+ *
+ * Implemented with `node:http` (`socketPath`) on purpose: the self-update
+ * feature is contractually zero-dependency (openspec/specs/self-update).
+ * Only the handful of endpoints the updater needs are covered.
+ */
+
+import { request as httpRequest } from 'node:http';
+
+export const DEFAULT_DOCKER_SOCKET = '/var/run/docker.sock';
+/** Oldest Engine API version exposing everything we call (Docker 20.10+). */
+export const ENGINE_API_VERSION = 'v1.41';
+
+export class EngineApiError extends Error {
+  constructor(
+    message: string,
+    readonly statusCode: number | null,
+  ) {
+    super(message);
+    this.name = 'EngineApiError';
+  }
+}
+
+export interface PullProgressEvent {
+  status?: string;
+  id?: string;
+  progressDetail?: { current?: number; total?: number };
+  error?: string;
+}
+
+/** Subset of `GET /containers/{id}/json` the updater relies on. */
+export interface ContainerInspect {
+  Id: string;
+  /** Leading-slash container name, e.g. `/rembric`. */
+  Name: string;
+  State?: {
+    Running?: boolean;
+    Health?: { Status?: string };
+  };
+  Config: {
+    Image: string;
+    Env?: string[];
+    Labels?: Record<string, string>;
+    ExposedPorts?: Record<string, unknown>;
+    Entrypoint?: string[] | string | null;
+    Cmd?: string[] | string | null;
+    User?: string;
+    Hostname?: string;
+    WorkingDir?: string;
+    Healthcheck?: unknown;
+  };
+  HostConfig: Record<string, unknown>;
+  NetworkSettings?: {
+    Networks?: Record<string, { Aliases?: string[] | null; IPAddress?: string }>;
+  };
+}
+
+interface EngineResponse {
+  statusCode: number;
+  body: string;
+}
+
+export class DockerEngineApi {
+  constructor(private readonly socketPath: string = DEFAULT_DOCKER_SOCKET) {}
+
+  async ping(): Promise<boolean> {
+    try {
+      const res = await this.request('GET', '/_ping');
+      return res.statusCode === 200;
+    } catch {
+      return false;
+    }
+  }
+
+  async inspectContainer(idOrName: string): Promise<ContainerInspect> {
+    const res = await this.request('GET', `/containers/${encodeURIComponent(idOrName)}/json`);
+    this.assertOk(res, `inspect ${idOrName}`);
+    return JSON.parse(res.body) as ContainerInspect;
+  }
+
+  /**
+   * Pull `repo:tag`, streaming the daemon's NDJSON progress events into
+   * `onProgress`. Resolves when the stream ends; rejects on a stream-level
+   * `error` event from the daemon.
+   */
+  async pullImage(
+    repo: string,
+    tag: string,
+    onProgress?: (ev: PullProgressEvent) => void,
+  ): Promise<void> {
+    const path = `/images/create?fromImage=${encodeURIComponent(repo)}&tag=${encodeURIComponent(tag)}`;
+    const res = await this.requestStreaming('POST', path, (line) => {
+      let ev: PullProgressEvent;
+      try {
+        ev = JSON.parse(line) as PullProgressEvent;
+      } catch {
+        return;
+      }
+      if (ev.error) throw new EngineApiError(`pull failed: ${ev.error}`, null);
+      onProgress?.(ev);
+    });
+    if (res.statusCode !== 200) {
+      throw new EngineApiError(`pull failed with HTTP ${res.statusCode}`, res.statusCode);
+    }
+  }
+
+  async createContainer(name: string, payload: unknown): Promise<{ Id: string }> {
+    const res = await this.request(
+      'POST',
+      `/containers/create?name=${encodeURIComponent(name)}`,
+      payload,
+    );
+    this.assertOk(res, `create ${name}`);
+    return JSON.parse(res.body) as { Id: string };
+  }
+
+  async startContainer(id: string): Promise<void> {
+    const res = await this.request('POST', `/containers/${encodeURIComponent(id)}/start`);
+    // 304 = already started.
+    if (res.statusCode !== 204 && res.statusCode !== 304) this.assertOk(res, `start ${id}`);
+  }
+
+  async stopContainer(id: string, timeoutSec = 30): Promise<void> {
+    const res = await this.request(
+      'POST',
+      `/containers/${encodeURIComponent(id)}/stop?t=${timeoutSec}`,
+    );
+    // 304 = already stopped.
+    if (res.statusCode !== 204 && res.statusCode !== 304) this.assertOk(res, `stop ${id}`);
+  }
+
+  async renameContainer(id: string, name: string): Promise<void> {
+    const res = await this.request(
+      'POST',
+      `/containers/${encodeURIComponent(id)}/rename?name=${encodeURIComponent(name)}`,
+    );
+    this.assertOk(res, `rename ${id} → ${name}`);
+  }
+
+  async removeContainer(id: string, force = false): Promise<void> {
+    const res = await this.request(
+      'DELETE',
+      `/containers/${encodeURIComponent(id)}?force=${force ? 'true' : 'false'}&v=false`,
+    );
+    if (res.statusCode !== 204) this.assertOk(res, `remove ${id}`);
+  }
+
+  private assertOk(res: EngineResponse, what: string): void {
+    if (res.statusCode >= 200 && res.statusCode < 300) return;
+    let message = `engine API ${what} failed with HTTP ${res.statusCode}`;
+    try {
+      const parsed = JSON.parse(res.body) as { message?: string };
+      if (parsed.message) message += `: ${parsed.message}`;
+    } catch {
+      /* non-JSON error body */
+    }
+    throw new EngineApiError(message, res.statusCode);
+  }
+
+  private request(method: string, path: string, body?: unknown): Promise<EngineResponse> {
+    return new Promise((resolve, reject) => {
+      const payload = body === undefined ? null : JSON.stringify(body);
+      const req = httpRequest(
+        {
+          socketPath: this.socketPath,
+          method,
+          path: `/${ENGINE_API_VERSION}${path}`,
+          headers: payload
+            ? { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) }
+            : {},
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (c: Buffer) => chunks.push(c));
+          res.on('end', () =>
+            resolve({
+              statusCode: res.statusCode ?? 0,
+              body: Buffer.concat(chunks).toString('utf8'),
+            }),
+          );
+          res.on('error', reject);
+        },
+      );
+      req.on('error', reject);
+      if (payload) req.write(payload);
+      req.end();
+    });
+  }
+
+  private requestStreaming(
+    method: string,
+    path: string,
+    onLine: (line: string) => void,
+  ): Promise<{ statusCode: number }> {
+    return new Promise((resolve, reject) => {
+      const req = httpRequest(
+        { socketPath: this.socketPath, method, path: `/${ENGINE_API_VERSION}${path}` },
+        (res) => {
+          let buffer = '';
+          let failed: Error | null = null;
+          res.on('data', (c: Buffer) => {
+            if (failed) return;
+            buffer += c.toString('utf8');
+            let nl: number;
+            while ((nl = buffer.indexOf('\n')) >= 0) {
+              const line = buffer.slice(0, nl).trim();
+              buffer = buffer.slice(nl + 1);
+              if (!line) continue;
+              try {
+                onLine(line);
+              } catch (err) {
+                failed = err instanceof Error ? err : new Error(String(err));
+                res.destroy();
+              }
+            }
+          });
+          res.on('end', () => {
+            if (failed) return reject(failed);
+            const tail = buffer.trim();
+            if (tail) {
+              try {
+                onLine(tail);
+              } catch (err) {
+                return reject(err instanceof Error ? err : new Error(String(err)));
+              }
+            }
+            resolve({ statusCode: res.statusCode ?? 0 });
+          });
+          res.on('close', () => {
+            if (failed) reject(failed);
+          });
+          res.on('error', (err) => reject(failed ?? err));
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+  }
+}

--- a/apps/server/src/services/self-update/orchestrator.test.ts
+++ b/apps/server/src/services/self-update/orchestrator.test.ts
@@ -1,0 +1,196 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { CapabilityDetector, SelfUpdateCapability } from './capability.js';
+import type { PullProgressEvent } from './engine-api.js';
+import { createPreUpdateBackup, SelfUpdateOrchestrator } from './orchestrator.js';
+
+const AVAILABLE: SelfUpdateCapability = {
+  state: 'available',
+  reason: 'ok',
+  containerId: 'abc123',
+  imageRepo: 'ghcr.io/susomejias/rembric',
+  imageTag: 'latest',
+};
+
+function fakeCapability(cap: SelfUpdateCapability): CapabilityDetector {
+  return {
+    detect: () => Promise.resolve(cap),
+    detectCached: () => Promise.resolve(cap),
+  } as unknown as CapabilityDetector;
+}
+
+interface EngineCalls {
+  pulls: Array<{ repo: string; tag: string }>;
+  created: Array<{ name: string; payload: Record<string, unknown> }>;
+  started: string[];
+}
+
+function fakeEngine(calls: EngineCalls, opts: { failPull?: boolean } = {}) {
+  return {
+    pullImage: (repo: string, tag: string, onProgress?: (ev: PullProgressEvent) => void) => {
+      calls.pulls.push({ repo, tag });
+      if (opts.failPull) return Promise.reject(new Error('no space left on device'));
+      onProgress?.({ status: 'Downloading', id: 'aaa' });
+      onProgress?.({ status: 'Pull complete', id: 'aaa' });
+      return Promise.resolve();
+    },
+    createContainer: (name: string, payload: unknown) => {
+      calls.created.push({ name, payload: payload as Record<string, unknown> });
+      return Promise.resolve({ Id: 'helper789' });
+    },
+    startContainer: (id: string) => {
+      calls.started.push(id);
+      return Promise.resolve();
+    },
+  };
+}
+
+async function settle(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe('createPreUpdateBackup', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'rembric-backup-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('creates the backups dir and vacuums into a timestamped file', () => {
+    const written: string[] = [];
+    const backupsDir = join(dir, 'backups');
+    const backup = createPreUpdateBackup({
+      vacuumInto: (p) => {
+        written.push(p);
+        writeFileSync(p, 'snapshot');
+      },
+      backupsDir,
+      now: () => 1000,
+    });
+    backup('0.22.0');
+    expect(existsSync(backupsDir)).toBe(true);
+    expect(written[0]).toBe(join(backupsDir, 'pre-update-v0.22.0-1000.sqlite'));
+  });
+
+  it('propagates vacuum failures', () => {
+    const backup = createPreUpdateBackup({
+      vacuumInto: () => {
+        throw new Error('disk full');
+      },
+      backupsDir: join(dir, 'backups'),
+    });
+    expect(() => backup('0.22.0')).toThrow('disk full');
+  });
+
+  it('keeps only the 3 most recent pre-update backups', () => {
+    let t = 1000;
+    const backupsDir = join(dir, 'backups');
+    const backup = createPreUpdateBackup({
+      vacuumInto: (p) => writeFileSync(p, 'x'),
+      backupsDir,
+      now: () => t++,
+    });
+    for (const v of ['0.22.0', '0.22.1', '0.22.2', '0.22.3']) backup(v);
+    const left = readdirSync(backupsDir).sort();
+    expect(left.length).toBe(3);
+    expect(left.some((f) => f.includes('v0.22.0'))).toBe(false);
+  });
+});
+
+describe('SelfUpdateOrchestrator', () => {
+  function build(opts: { cap?: SelfUpdateCapability; failPull?: boolean; failBackup?: boolean }): {
+    orch: SelfUpdateOrchestrator;
+    calls: EngineCalls;
+    backups: string[];
+  } {
+    const calls: EngineCalls = { pulls: [], created: [], started: [] };
+    const backups: string[] = [];
+    const orch = new SelfUpdateOrchestrator({
+      capability: fakeCapability(opts.cap ?? AVAILABLE),
+      engineFactory: () => fakeEngine(calls, { failPull: opts.failPull }),
+      backup: (v) => {
+        if (opts.failBackup) throw new Error('disk full');
+        backups.push(v);
+        return `/data/backups/pre-update-v${v}-42.sqlite`;
+      },
+      socketPath: '/tmp/test.sock',
+      now: () => 42,
+      log: () => {},
+    });
+    return { orch, calls, backups };
+  }
+
+  it('starts idle', () => {
+    const { orch } = build({});
+    expect(orch.status().phase).toBe('idle');
+  });
+
+  it('refuses with no side effects when capability is manual', async () => {
+    const { orch, calls, backups } = build({ cap: { state: 'manual', reason: 'no-socket' } });
+    const r = await orch.start('0.22.0');
+    expect(r).toEqual({ ok: false, code: 'not_available' });
+    expect(backups.length).toBe(0);
+    expect(calls.pulls.length).toBe(0);
+    expect(orch.status().phase).toBe('idle');
+  });
+
+  it('refuses when pinned', async () => {
+    const { orch } = build({
+      cap: { state: 'pinned', reason: 'pinned-tag', containerId: 'abc', imageRepo: 'r' },
+    });
+    expect((await orch.start('0.22.0')).ok).toBe(false);
+  });
+
+  it('backup failure aborts before any engine call', async () => {
+    const { orch, calls } = build({ failBackup: true });
+    const r = await orch.start('0.22.0');
+    expect(r).toEqual({ ok: false, code: 'backup_failed' });
+    expect(calls.pulls.length).toBe(0);
+    expect(orch.status().phase).toBe('failed');
+    expect(orch.status().error).toContain('disk full');
+  });
+
+  it('happy path: backup → pull → launch helper → restarting', async () => {
+    const { orch, calls, backups } = build({});
+    const r = await orch.start('0.22.0');
+    expect(r).toEqual({ ok: true });
+    await settle();
+    expect(backups).toEqual(['0.22.0']);
+    expect(calls.pulls).toEqual([{ repo: 'ghcr.io/susomejias/rembric', tag: 'latest' }]);
+    expect(calls.created.length).toBe(1);
+    const helper = calls.created[0];
+    expect(helper?.name).toBe('rembric-upgrader-42');
+    const env = helper?.payload['Env'] as string[];
+    expect(env).toContain('REMBRIC_UPGRADE_TARGET_CONTAINER=abc123');
+    expect(env).toContain('REMBRIC_UPGRADE_IMAGE=ghcr.io/susomejias/rembric:latest');
+    const hostConfig = helper?.payload['HostConfig'] as { Binds: string[] };
+    expect(hostConfig.Binds[0]).toBe('/tmp/test.sock:/var/run/docker.sock');
+    expect(calls.started).toEqual(['helper789']);
+    expect(orch.status().phase).toBe('restarting');
+    expect(orch.status().pull).toEqual({ done: 1, total: 1 });
+  });
+
+  it('pull failure surfaces in status and unlocks re-runs', async () => {
+    const { orch } = build({ failPull: true });
+    expect((await orch.start('0.22.0')).ok).toBe(true);
+    await settle();
+    expect(orch.status().phase).toBe('failed');
+    expect(orch.status().error).toContain('no space left');
+    // failed runs unlock the orchestrator for another attempt
+    expect((await orch.start('0.22.0')).ok).toBe(true);
+  });
+
+  it('rejects concurrent runs', async () => {
+    const { orch } = build({});
+    expect((await orch.start('0.22.0')).ok).toBe(true);
+    expect(await orch.start('0.22.0')).toEqual({ ok: false, code: 'already_running' });
+  });
+});

--- a/apps/server/src/services/self-update/orchestrator.ts
+++ b/apps/server/src/services/self-update/orchestrator.ts
@@ -1,0 +1,207 @@
+/**
+ * Self-update orchestrator — the server-side half of the one-click flow.
+ *
+ * Runs everything that can run while this process is still alive:
+ * backup → pull → launch the ephemeral upgrader container. The container
+ * swap itself happens in the upgrader (see `scripts/upgrade-helper.ts`),
+ * which outlives this process by design.
+ */
+
+import { mkdirSync, readdirSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { type CapabilityDetector, type SelfUpdateCapability } from './capability.js';
+import {
+  DEFAULT_DOCKER_SOCKET,
+  type DockerEngineApi,
+  type PullProgressEvent,
+} from './engine-api.js';
+
+export type UpdatePhase = 'idle' | 'backup' | 'pull' | 'launch' | 'restarting' | 'failed';
+
+export interface UpdateStatus {
+  phase: UpdatePhase;
+  targetVersion: string | null;
+  error: string | null;
+  /** Pull progress: layers completed / layers seen. */
+  pull: { done: number; total: number } | null;
+  startedAt: number | null;
+}
+
+export type StartResult =
+  | { ok: true }
+  | { ok: false; code: 'not_available' | 'already_running' | 'backup_failed' };
+
+const BACKUP_PREFIX = 'pre-update-';
+const BACKUP_KEEP = 3;
+
+export interface BackupDeps {
+  /** Runs `VACUUM INTO` to the given absolute path (throws on failure). */
+  vacuumInto: (destPath: string) => void;
+  backupsDir: string;
+  now?: () => number;
+}
+
+/**
+ * Consistent pre-update snapshot, mandatory and gating: any throw here
+ * aborts the update before a single container is touched. Keeps the
+ * `BACKUP_KEEP` most recent pre-update files. Returns the snapshot path
+ * so the upgrader can name it in recovery instructions.
+ */
+export function createPreUpdateBackup(deps: BackupDeps): (targetVersion: string) => string {
+  const now = deps.now ?? Date.now;
+  return (targetVersion: string) => {
+    mkdirSync(deps.backupsDir, { recursive: true, mode: 0o700 });
+    const file = join(deps.backupsDir, `${BACKUP_PREFIX}v${targetVersion}-${now()}.sqlite`);
+    deps.vacuumInto(file);
+    const old = readdirSync(deps.backupsDir)
+      .filter((f) => f.startsWith(BACKUP_PREFIX) && f.endsWith('.sqlite'))
+      .sort()
+      .reverse()
+      .slice(BACKUP_KEEP);
+    for (const f of old) {
+      try {
+        unlinkSync(join(deps.backupsDir, f));
+      } catch {
+        /* retention is best-effort; never fail the update over it */
+      }
+    }
+    return file;
+  };
+}
+
+export interface OrchestratorDeps {
+  capability: CapabilityDetector;
+  engineFactory: (
+    socketPath: string,
+  ) => Pick<DockerEngineApi, 'pullImage' | 'createContainer' | 'startContainer'>;
+  /** Takes the pre-update snapshot; returns its path (named in recovery hints). */
+  backup: (targetVersion: string) => string;
+  socketPath?: string;
+  /** Entrypoint of the upgrader inside the new image. */
+  helperEntrypoint?: string[];
+  now?: () => number;
+  log?: (line: string) => void;
+}
+
+export class SelfUpdateOrchestrator {
+  private readonly deps: OrchestratorDeps;
+  private readonly socketPath: string;
+  private readonly now: () => number;
+  private readonly log: (line: string) => void;
+
+  private current: UpdateStatus = {
+    phase: 'idle',
+    targetVersion: null,
+    error: null,
+    pull: null,
+    startedAt: null,
+  };
+  private running = false;
+
+  constructor(deps: OrchestratorDeps) {
+    this.deps = deps;
+    this.socketPath = deps.socketPath ?? DEFAULT_DOCKER_SOCKET;
+    this.now = deps.now ?? Date.now;
+    this.log = deps.log ?? ((line) => console.error(line));
+  }
+
+  status(): UpdateStatus {
+    return { ...this.current, pull: this.current.pull ? { ...this.current.pull } : null };
+  }
+
+  capability(): Promise<SelfUpdateCapability> {
+    return this.deps.capability.detectCached();
+  }
+
+  /**
+   * Kick off a one-click update. Refuses with no side effects unless the
+   * capability state is `available`. Returns as soon as the upgrader
+   * container is launched — from there the swap is out of our hands.
+   */
+  async start(targetVersion: string): Promise<StartResult> {
+    if (this.running) return { ok: false, code: 'already_running' };
+    const cap = await this.deps.capability.detect();
+    if (cap.state !== 'available' || !cap.containerId || !cap.imageRepo) {
+      return { ok: false, code: 'not_available' };
+    }
+    this.running = true;
+    this.current = {
+      phase: 'backup',
+      targetVersion,
+      error: null,
+      pull: null,
+      startedAt: this.now(),
+    };
+
+    let backupPath: string;
+    try {
+      backupPath = this.deps.backup(targetVersion);
+    } catch (err) {
+      this.fail(`backup failed: ${err instanceof Error ? err.message : String(err)}`);
+      return { ok: false, code: 'backup_failed' };
+    }
+
+    // Pull + launch run detached: the dashboard polls `status()`.
+    void this.pullAndLaunch(cap, targetVersion, backupPath).catch((err: unknown) => {
+      this.fail(err instanceof Error ? err.message : String(err));
+    });
+    return { ok: true };
+  }
+
+  private async pullAndLaunch(
+    cap: SelfUpdateCapability,
+    targetVersion: string,
+    backupPath: string,
+  ): Promise<void> {
+    const repo = cap.imageRepo as string;
+    const tag = cap.imageTag ?? 'latest';
+    const engine = this.deps.engineFactory(this.socketPath);
+
+    this.current.phase = 'pull';
+    const layers = new Map<string, boolean>();
+    await engine.pullImage(repo, tag, (ev: PullProgressEvent) => {
+      if (!ev.id) return;
+      const done = ev.status === 'Pull complete' || ev.status === 'Already exists';
+      layers.set(ev.id, done || (layers.get(ev.id) ?? false));
+      this.current.pull = {
+        done: [...layers.values()].filter(Boolean).length,
+        total: layers.size,
+      };
+    });
+
+    this.current.phase = 'launch';
+    const imageRef = `${repo}:${tag}`;
+    const name = `rembric-upgrader-${this.now()}`;
+    const created = await engine.createContainer(name, {
+      Image: imageRef,
+      Entrypoint: this.deps.helperEntrypoint ?? ['node', '/app/dist/scripts/upgrade-helper.js'],
+      // Root inside the one-shot upgrader sidesteps host docker-GID
+      // mismatches; it only ever talks to the socket it is handed.
+      User: 'root',
+      Env: [
+        `REMBRIC_UPGRADE_TARGET_CONTAINER=${cap.containerId}`,
+        `REMBRIC_UPGRADE_IMAGE=${imageRef}`,
+        `REMBRIC_UPGRADE_VERSION=${targetVersion}`,
+        // Path as seen from the host-side data volume; only used in
+        // operator-facing recovery messages, never opened by the helper.
+        `REMBRIC_UPGRADE_BACKUP=${backupPath}`,
+      ],
+      Labels: { 'rembric.upgrader': '1' },
+      HostConfig: {
+        Binds: [`${this.socketPath}:/var/run/docker.sock`],
+        AutoRemove: false,
+      },
+    });
+    await engine.startContainer(created.Id);
+    this.log(`  ↑ self-update to v${targetVersion} handed off to upgrader ${name}`);
+    this.current.phase = 'restarting';
+    // `running` stays true: this process is now waiting to be replaced.
+  }
+
+  private fail(message: string): void {
+    this.current.phase = 'failed';
+    this.current.error = message;
+    this.running = false;
+  }
+}

--- a/apps/server/src/services/update-check.test.ts
+++ b/apps/server/src/services/update-check.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseSemver, semverGt, UpdateCheckService } from './update-check.js';
+
+function release(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    tag_name: 'server-v0.22.0',
+    body: '## New features\n- one-click updates',
+    html_url: 'https://github.com/susomejias/rembric/releases/tag/server-v0.22.0',
+    published_at: '2026-06-01T00:00:00Z',
+    prerelease: false,
+    draft: false,
+    ...over,
+  };
+}
+
+function fakeFetch(responses: Array<{ status: number; body?: unknown; etag?: string }>): {
+  fetchImpl: typeof fetch;
+  calls: Array<{ url: string; headers: Record<string, string> }>;
+} {
+  const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+  let i = 0;
+  const fetchImpl = ((url: string | URL | Request, init?: RequestInit) => {
+    calls.push({
+      url: typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url,
+      headers: (init?.headers as Record<string, string>) ?? {},
+    });
+    const r = responses[Math.min(i, responses.length - 1)];
+    i++;
+    if (!r) throw new Error('no response configured');
+    return Promise.resolve(
+      new Response(r.body === undefined ? null : JSON.stringify(r.body), {
+        status: r.status,
+        headers: r.etag ? { etag: r.etag } : {},
+      }),
+    );
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function svc(
+  opts: Partial<ConstructorParameters<typeof UpdateCheckService>[0]> & {
+    fetchImpl: typeof fetch;
+  },
+): UpdateCheckService {
+  return new UpdateCheckService({ currentVersion: '0.21.1', enabled: true, ...opts });
+}
+
+describe('semver helpers', () => {
+  it('parses plain and v-prefixed versions', () => {
+    expect(parseSemver('0.21.1')).toEqual([0, 21, 1]);
+    expect(parseSemver('v1.2.3')).toEqual([1, 2, 3]);
+    expect(parseSemver('1.2.3-rc.1')).toBeNull();
+    expect(parseSemver('latest')).toBeNull();
+  });
+
+  it('compares correctly', () => {
+    expect(semverGt('0.22.0', '0.21.1')).toBe(true);
+    expect(semverGt('0.21.1', '0.21.1')).toBe(false);
+    expect(semverGt('0.21.0', '0.21.1')).toBe(false);
+    expect(semverGt('1.0.0', '0.99.99')).toBe(true);
+  });
+});
+
+describe('UpdateCheckService', () => {
+  it('reports a newer server release', async () => {
+    const { fetchImpl } = fakeFetch([{ status: 200, body: [release()] }]);
+    const s = svc({ fetchImpl });
+    const info = await s.refresh();
+    expect(info).not.toBeNull();
+    expect(info?.latestVersion).toBe('0.22.0');
+    expect(info?.currentVersion).toBe('0.21.1');
+    expect(info?.changelog).toContain('one-click');
+    expect(s.peek()?.latestVersion).toBe('0.22.0');
+  });
+
+  it('returns null when latest equals or precedes the running version', async () => {
+    const { fetchImpl } = fakeFetch([
+      { status: 200, body: [release({ tag_name: 'server-v0.21.1' })] },
+    ]);
+    expect(await svc({ fetchImpl }).refresh()).toBeNull();
+
+    const older = fakeFetch([{ status: 200, body: [release({ tag_name: 'server-v0.20.0' })] }]);
+    expect(await svc({ fetchImpl: older.fetchImpl }).refresh()).toBeNull();
+  });
+
+  it('skips prereleases, drafts, and non-server components', async () => {
+    const { fetchImpl } = fakeFetch([
+      {
+        status: 200,
+        body: [
+          release({ tag_name: 'server-v0.23.0', prerelease: true }),
+          release({ tag_name: 'server-v0.24.0', draft: true }),
+          release({ tag_name: 'claude-code-plugin-v9.9.9' }),
+          release({ tag_name: 'server-v0.22.0' }),
+        ],
+      },
+    ]);
+    const info = await svc({ fetchImpl }).refresh();
+    expect(info?.latestVersion).toBe('0.22.0');
+  });
+
+  it('is disabled by REMBRIC_UPDATE_CHECK=off semantics', async () => {
+    const { fetchImpl, calls } = fakeFetch([{ status: 200, body: [release()] }]);
+    const s = svc({ fetchImpl, enabled: false });
+    expect(await s.refresh()).toBeNull();
+    expect(s.peek()).toBeNull();
+    expect(calls.length).toBe(0);
+  });
+
+  it('fails silently on network errors', async () => {
+    const fetchImpl = (() => Promise.reject(new Error('offline'))) as typeof fetch;
+    const s = svc({ fetchImpl });
+    expect(await s.refresh()).toBeNull();
+    expect(s.peek()).toBeNull();
+  });
+
+  it('sends If-None-Match and keeps the cache on 304', async () => {
+    const { fetchImpl, calls } = fakeFetch([
+      { status: 200, body: [release()], etag: 'W/"abc"' },
+      { status: 304 },
+    ]);
+    const s = svc({ fetchImpl, intervalMs: 0 });
+    await s.refresh();
+    const info = await s.refresh();
+    expect(info?.latestVersion).toBe('0.22.0');
+    expect(calls[1]?.headers['if-none-match']).toBe('W/"abc"');
+  });
+
+  it('peek respects the 24h interval', async () => {
+    let t = 0;
+    const { fetchImpl, calls } = fakeFetch([{ status: 200, body: [release()] }]);
+    const s = svc({ fetchImpl, now: () => t, intervalMs: 1000 });
+    s.peek();
+    await s.refresh(); // settle the background kick
+    const before = calls.length;
+    t = 500;
+    s.peek(); // within interval — no new fetch
+    expect(calls.length).toBe(before);
+    t = 1500;
+    s.peek(); // stale — background refresh fires
+    await new Promise((r) => setTimeout(r, 0));
+    expect(calls.length).toBeGreaterThan(before);
+  });
+});

--- a/apps/server/src/services/update-check.ts
+++ b/apps/server/src/services/update-check.ts
@@ -1,0 +1,143 @@
+/**
+ * Release update check against the GitHub Releases API.
+ *
+ * Lazy: nothing runs at boot. `peek()` returns the cached result
+ * synchronously and kicks a background refresh when the cache is stale.
+ * Failures are silent by contract (air-gapped hosts must see zero noise);
+ * see openspec/specs/self-update/spec.md.
+ */
+
+import { REMBRIC_VERSION } from '../version.js';
+
+const DEFAULT_RELEASES_URL = 'https://api.github.com/repos/susomejias/rembric/releases?per_page=30';
+const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000;
+/** Server releases are tagged `server-v<semver>` (release-please multi-component). */
+const SERVER_TAG_PREFIX = 'server-v';
+
+export interface UpdateInfo {
+  currentVersion: string;
+  latestVersion: string;
+  publishedAt: Date | null;
+  /** Markdown body of the GitHub release (release-please changelog). */
+  changelog: string;
+  releaseUrl: string;
+}
+
+interface GithubRelease {
+  tag_name?: string;
+  body?: string;
+  html_url?: string;
+  published_at?: string;
+  prerelease?: boolean;
+  draft?: boolean;
+}
+
+export interface UpdateCheckOptions {
+  currentVersion?: string;
+  /** `false` disables the check entirely (REMBRIC_UPDATE_CHECK=off). */
+  enabled?: boolean;
+  fetchImpl?: typeof fetch;
+  releasesUrl?: string;
+  intervalMs?: number;
+  now?: () => number;
+}
+
+export function parseSemver(v: string): [number, number, number] | null {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(v.trim());
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+export function semverGt(a: string, b: string): boolean {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) return false;
+  for (let i = 0; i < 3; i++) {
+    const da = pa[i] ?? 0;
+    const db = pb[i] ?? 0;
+    if (da !== db) return da > db;
+  }
+  return false;
+}
+
+export class UpdateCheckService {
+  private readonly currentVersion: string;
+  private readonly enabled: boolean;
+  private readonly fetchImpl: typeof fetch;
+  private readonly releasesUrl: string;
+  private readonly intervalMs: number;
+  private readonly now: () => number;
+
+  private cache: UpdateInfo | null = null;
+  private lastCheckedAt = 0;
+  private etag: string | null = null;
+  private inflight: Promise<UpdateInfo | null> | null = null;
+
+  constructor(opts: UpdateCheckOptions = {}) {
+    this.currentVersion = opts.currentVersion ?? REMBRIC_VERSION;
+    this.enabled = opts.enabled ?? process.env['REMBRIC_UPDATE_CHECK'] !== 'off';
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.releasesUrl = opts.releasesUrl ?? DEFAULT_RELEASES_URL;
+    this.intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.now = opts.now ?? Date.now;
+  }
+
+  /**
+   * Cached update info, refreshing in the background when stale. Returns
+   * `null` until a refresh has found a strictly newer version.
+   */
+  peek(): UpdateInfo | null {
+    if (!this.enabled) return null;
+    if (this.now() - this.lastCheckedAt >= this.intervalMs && !this.inflight) {
+      // Background kick; silent-failure contract means errors are dropped.
+      void this.refresh().catch(() => {});
+    }
+    return this.cache;
+  }
+
+  /** Refresh now (awaitable; used by tests and the update view). */
+  async refresh(): Promise<UpdateInfo | null> {
+    if (!this.enabled) return null;
+    if (this.inflight) return this.inflight;
+    this.inflight = this.doRefresh().finally(() => {
+      this.inflight = null;
+    });
+    return this.inflight;
+  }
+
+  private async doRefresh(): Promise<UpdateInfo | null> {
+    this.lastCheckedAt = this.now();
+    try {
+      const headers: Record<string, string> = { accept: 'application/vnd.github+json' };
+      if (this.etag) headers['if-none-match'] = this.etag;
+      const res = await this.fetchImpl(this.releasesUrl, { headers });
+      if (res.status === 304) return this.cache;
+      if (!res.ok) return this.cache;
+      this.etag = res.headers.get('etag');
+      const releases = (await res.json()) as GithubRelease[];
+      if (!Array.isArray(releases)) return this.cache;
+      const latest = releases.find(
+        (r) =>
+          !r.draft &&
+          !r.prerelease &&
+          typeof r.tag_name === 'string' &&
+          r.tag_name.startsWith(SERVER_TAG_PREFIX) &&
+          parseSemver(r.tag_name.slice(SERVER_TAG_PREFIX.length)) !== null,
+      );
+      if (!latest?.tag_name) return this.cache;
+      const version = latest.tag_name.slice(SERVER_TAG_PREFIX.length);
+      this.cache = semverGt(version, this.currentVersion)
+        ? {
+            currentVersion: this.currentVersion,
+            latestVersion: version,
+            publishedAt: latest.published_at ? new Date(latest.published_at) : null,
+            changelog: latest.body ?? '',
+            releaseUrl: latest.html_url ?? '',
+          }
+        : null;
+      return this.cache;
+    } catch {
+      return this.cache;
+    }
+  }
+}

--- a/apps/server/src/test/dashboard-e2e.test.ts
+++ b/apps/server/src/test/dashboard-e2e.test.ts
@@ -120,6 +120,8 @@ describe('dashboard E2E', () => {
         REMBRIC_PORT: String(port),
         REMBRIC_DATA_DIR: tmp.dataDir,
         REMBRIC_ADMIN_TOKEN: ADMIN_TOKEN,
+        // Keep the suite hermetic — never call the real GitHub API.
+        REMBRIC_UPDATE_CHECK: 'off',
       },
       { embedder: new FakeEmbedder() },
     );
@@ -567,5 +569,246 @@ describe('dashboard E2E', () => {
     const missing = await get(baseUrl, '/dashboard/judgments/non-existent-id-xyz', jar);
     expect(missing.status).toBe(404);
     expect(await missing.text()).toContain('Judgment not found');
+  });
+});
+
+describe('dashboard E2E — self-update surface', () => {
+  let server: BootstrappedServer;
+  let baseUrl: string;
+  const ADMIN_TOKEN = 'integration-admin-token-with-enough-entropy-upd';
+
+  // Mutable capability the fake detector reads — tests flip quadrants.
+  const capability = {
+    current: { state: 'manual', reason: 'no-socket' } as Record<string, unknown>,
+  };
+
+  beforeAll(async () => {
+    const [{ createTestDb }, { FakeEmbedder }] = [
+      await import('./db.js'),
+      await import('./embedder.js'),
+    ];
+    const { UpdateCheckService } = await import('../services/update-check.js');
+    const { SelfUpdateOrchestrator } = await import('../services/self-update/orchestrator.js');
+
+    const tmp = createTestDb();
+    tmp.cleanup();
+    const port = await findFreePort();
+
+    const fakeFetch = (() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify([
+            {
+              tag_name: 'server-v9.9.9',
+              body: '## New features\n- e2e changelog entry',
+              html_url: 'https://github.com/susomejias/rembric/releases/tag/server-v9.9.9',
+              published_at: '2026-06-01T00:00:00Z',
+              prerelease: false,
+              draft: false,
+            },
+          ]),
+          { status: 200 },
+        ),
+      )) as typeof fetch;
+    const updates = new UpdateCheckService({ enabled: true, fetchImpl: fakeFetch });
+    await updates.refresh();
+
+    // Duck-typed stand-in for CapabilityDetector; tests mutate `capability.current`.
+    const fakeDetector = {
+      detect: () => Promise.resolve(capability.current),
+      detectCached: () => Promise.resolve(capability.current),
+    } as unknown as ConstructorParameters<typeof SelfUpdateOrchestrator>[0]['capability'];
+    const selfUpdate = new SelfUpdateOrchestrator({
+      capability: fakeDetector,
+      engineFactory: () => {
+        throw new Error('engine must not be reached in these tests');
+      },
+      backup: () => {
+        throw new Error('backup must not be reached in these tests');
+      },
+      log: () => {},
+    });
+
+    server = await createServer(
+      {
+        REMBRIC_HOST: '127.0.0.1',
+        REMBRIC_PORT: String(port),
+        REMBRIC_DATA_DIR: tmp.dataDir,
+        REMBRIC_ADMIN_TOKEN: ADMIN_TOKEN,
+      },
+      { embedder: new FakeEmbedder(), updates, selfUpdate },
+    );
+    baseUrl = `http://127.0.0.1:${port}`;
+  }, 30_000);
+
+  afterAll(async () => {
+    await server.shutdown();
+  });
+
+  async function login(): Promise<CookieJar> {
+    const jar: CookieJar = { cookie: null };
+    await postForm(baseUrl, '/dashboard/login', jar, { token: ADMIN_TOKEN });
+    return jar;
+  }
+
+  it('renders the update badge and the per-version modal on every page', async () => {
+    capability.current = { state: 'manual', reason: 'no-socket' };
+    const jar = await login();
+    const home = await get(baseUrl, '/dashboard', jar);
+    const body = await home.text();
+    expect(body).toContain('sb-update');
+    expect(body).toContain('UPDATE v9.9.9');
+    expect(body).toContain('id="rbr-update"');
+    expect(body).toContain('data-version="9.9.9"');
+    expect(body).toContain('e2e changelog entry');
+
+    const memories = await get(baseUrl, '/dashboard/memories', jar);
+    expect(await memories.text()).toContain('sb-update');
+  });
+
+  it('manual quadrant: copy-paste command + docs link, no update button', async () => {
+    capability.current = { state: 'manual', reason: 'no-socket' };
+    const jar = await login();
+    const page = await get(baseUrl, '/dashboard/update', jar);
+    const body = await page.text();
+    expect(body).toContain('docker compose pull');
+    expect(body).toContain('docs/updates.md');
+    expect(body).not.toContain('action="/dashboard/update/start"');
+  });
+
+  it('pinned quadrant: explanation instead of button', async () => {
+    capability.current = {
+      state: 'pinned',
+      reason: 'pinned-tag',
+      containerId: 'abc',
+      imageRepo: 'ghcr.io/susomejias/rembric',
+      imageTag: '0.21.1',
+    };
+    const jar = await login();
+    const page = await get(baseUrl, '/dashboard/update', jar);
+    const body = await page.text();
+    expect(body).toContain('IMAGE TAG PINNED');
+    expect(body).toContain(':0.21.1');
+    expect(body).not.toContain('action="/dashboard/update/start"');
+  });
+
+  it('available quadrant: danger-tone confirm form with CSRF', async () => {
+    capability.current = {
+      state: 'available',
+      reason: 'ok',
+      containerId: 'abc',
+      imageRepo: 'ghcr.io/susomejias/rembric',
+      imageTag: 'latest',
+    };
+    const jar = await login();
+    const page = await get(baseUrl, '/dashboard/update', jar);
+    const body = await page.text();
+    expect(body).toContain('action="/dashboard/update/start"');
+    expect(body).toContain('data-confirm-tone="danger"');
+    expect(body).toContain('back up the database');
+    expect(extractCsrf(body, '/dashboard/update/start')).toBeTruthy();
+  });
+
+  it('start without CSRF returns 403', async () => {
+    const jar = await login();
+    const res = await postForm(baseUrl, '/dashboard/update/start', jar, {});
+    expect(res.status).toBe(403);
+  });
+
+  it('start is refused with no side effects when capability is not available', async () => {
+    capability.current = { state: 'manual', reason: 'no-socket' };
+    const jar = await login();
+    const page = await get(baseUrl, '/dashboard/update', jar);
+    // The form is not rendered, but a handcrafted POST must also bounce.
+    // Mint a CSRF via the modal on a page where the form exists? It does
+    // not — so reuse the sidebar-toggle pattern: pull CSRF from the
+    // available quadrant first, then flip to manual.
+    capability.current = {
+      state: 'available',
+      reason: 'ok',
+      containerId: 'abc',
+      imageRepo: 'ghcr.io/susomejias/rembric',
+      imageTag: 'latest',
+    };
+    const armed = await get(baseUrl, '/dashboard/update', jar);
+    const csrf = extractCsrf(await armed.text(), '/dashboard/update/start');
+    expect(csrf).toBeTruthy();
+    capability.current = { state: 'manual', reason: 'no-socket' };
+    const res = await postForm(baseUrl, '/dashboard/update/start', jar, { csrf: csrf! });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('err=not_available');
+    void page;
+  });
+
+  it('version probe answers the running version behind the session', async () => {
+    const jar = await login();
+    const res = await get(baseUrl, '/dashboard/update/version', jar);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ version: REMBRIC_VERSION });
+
+    const anon: CookieJar = { cookie: null };
+    const unauth = await get(baseUrl, '/dashboard/update/version', anon);
+    expect([302, 401]).toContain(unauth.status);
+  });
+
+  it('status endpoint reports idle before any run', async () => {
+    const jar = await login();
+    const res = await get(baseUrl, '/dashboard/update/status', jar);
+    expect(res.status).toBe(200);
+    const status = (await res.json()) as { phase: string };
+    expect(status.phase).toBe('idle');
+  });
+});
+
+describe('dashboard E2E — zero-action compatibility', () => {
+  // openspec/specs/self-update: a deployment without the Docker socket and
+  // without any new configuration boots and operates identically, with the
+  // feature in its degraded form and no badge when the check is off.
+  let server: BootstrappedServer;
+  let baseUrl: string;
+  const ADMIN_TOKEN = 'integration-admin-token-with-enough-entropy-zac';
+
+  beforeAll(async () => {
+    const { createTestDb } = await import('./db.js');
+    const { FakeEmbedder } = await import('./embedder.js');
+    const tmp = createTestDb();
+    tmp.cleanup();
+    const port = await findFreePort();
+    server = await createServer(
+      {
+        REMBRIC_HOST: '127.0.0.1',
+        REMBRIC_PORT: String(port),
+        REMBRIC_DATA_DIR: tmp.dataDir,
+        REMBRIC_ADMIN_TOKEN: ADMIN_TOKEN,
+        REMBRIC_UPDATE_CHECK: 'off',
+      },
+      { embedder: new FakeEmbedder() },
+    );
+    baseUrl = `http://127.0.0.1:${port}`;
+  }, 30_000);
+
+  afterAll(async () => {
+    await server.shutdown();
+  });
+
+  it('boots and serves healthz, dashboard and MCP surfaces with no update chrome', async () => {
+    const health = await fetch(`${baseUrl}/healthz`, {
+      headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+    });
+    expect(health.status).toBe(200);
+
+    const jar: CookieJar = { cookie: null };
+    await postForm(baseUrl, '/dashboard/login', jar, { token: ADMIN_TOKEN });
+    const home = await get(baseUrl, '/dashboard', jar);
+    expect(home.status).toBe(200);
+    const body = await home.text();
+    expect(body).toContain(`v${REMBRIC_VERSION}`);
+    expect(body).not.toContain('sb-update');
+    expect(body).not.toContain('id="rbr-update"');
+
+    // The update page itself degrades to the up-to-date notice.
+    const page = await get(baseUrl, '/dashboard/update', jar);
+    expect(page.status).toBe(200);
+    expect(await page.text()).toContain('UP TO DATE');
   });
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
 
     volumes:
       - ./data:/data
+      # One-click updates from the dashboard. Root-equivalent on the host — read docs/updates.md first.
+      # - /var/run/docker.sock:/var/run/docker.sock
 
     env_file:
       - .env

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -1,0 +1,89 @@
+# Updates
+
+Rembric tells you when a new version is out and — if you opt in — updates itself from the dashboard, Arcane-style: backup → pull → container swap → automatic page reload.
+
+## What you get with zero configuration
+
+Nothing to enable. Every deployment that runs `docker compose pull && docker compose up -d` gets:
+
+- An **update badge** next to the version in the dashboard sidebar when a newer release exists.
+- A **per-version modal** with the release changelog and a copy-paste update command. "Later" dismisses it until the next release.
+- **Automatic reload**: after you run the update command on the host, the open dashboard page detects the new version and reloads itself.
+
+The check calls the GitHub Releases API at most once per 24 hours, fails silently when offline (air-gapped hosts see no errors and no badge), and can be disabled entirely:
+
+```ini
+# .env
+REMBRIC_UPDATE_CHECK=off
+```
+
+## One-click updates (opt-in)
+
+With access to the Docker socket, the **Update** button performs the whole cycle from the dashboard: pre-update database backup, image pull with progress, container swap with health-check and automatic rollback, page reload on the new version.
+
+### Enable it
+
+Uncomment the socket mount in `docker-compose.yml` (or add it via `docker-compose.override.yml`):
+
+```yaml
+services:
+  rembric:
+    volumes:
+      - ./data:/data
+      - /var/run/docker.sock:/var/run/docker.sock
+    # Only needed if the socket is not world-accessible on your host:
+    # group_add:
+    #   - '<docker-gid>'   # stat -c '%g' /var/run/docker.sock
+```
+
+Then `docker compose up -d` once. The dashboard detects the socket at runtime — no flag, no restart loop.
+
+> [!WARNING]
+> **Mounting the Docker socket is root-equivalent on the host.** Anyone who obtains your admin token can then control Docker on the machine, not just your memory data. Only enable this on hosts where you accept that trade, keep the port off the public internet (Tailscale/WireGuard/reverse proxy), and consider the loopback-only override from the README when agent and server share a host.
+
+The container itself keeps running as the unprivileged `rembric` user. If the socket is mounted but not readable by that user (the usual cause is the docker group id), the dashboard degrades to the copy-paste flow and logs a single hint about `group_add`.
+
+### Pinned versions disable one-click
+
+If your `.env` pins `REMBRIC_VERSION=x.y.z`, the compose file declares that exact tag — a self-update would be silently reverted by your next `docker compose up`. Rembric therefore refuses one-click on pinned deployments and the modal explains why. To switch to dashboard-driven updates, remove the pin and run `docker compose up -d` once. To stay pinned, update by bumping the version in `.env`.
+
+### What an update does, in order
+
+1. **Backup** — `VACUUM INTO /data/backups/pre-update-v<target>-<ts>.sqlite`. If this fails (e.g. disk full) the update aborts before any container is touched. The 3 most recent pre-update backups are kept.
+2. **Pull** — the new image is downloaded; the running container is untouched until the pull succeeds.
+3. **Swap** — a one-shot upgrader container (created from the new image, labeled `rembric.upgrader=1`) stops the old container, renames it aside, recreates it under the original name with identical configuration (ports, volumes, env, labels, restart policy) and the new image, and waits for the health check.
+4. **Verify or roll back** — healthy: the old container is removed and your dashboard page reloads on the new version. Unhealthy: the replacement is removed, the old container is renamed back and restarted — you stay on the previous version and the upgrader's logs (`docker logs <upgrader>`) explain what happened.
+
+## Recovery
+
+**Interrupted swap** (host reboot at exactly the wrong moment): if `docker ps -a` shows a stopped `rembric-old-<ts>` and no `rembric`, restore by hand:
+
+```bash
+docker rename rembric-old-<ts> rembric
+docker start rembric
+```
+
+**Rolled back, but the old version won't boot** (the failed release migrated the database forward before dying): the upgrader detects this — after a rollback it waits for the restored container to become healthy and, if it never does, its logs name the exact pre-update snapshot to restore. The rollback deliberately does **not** restore the database automatically: writes may have landed during the failed update's brief life, and silently discarding memories is the one thing Rembric never does — that trade is yours to make. To restore:
+
+```bash
+docker stop rembric
+cd <your-compose-dir>
+rm -f data/data.db-wal data/data.db-shm
+cp data/backups/pre-update-v<target>-<ts>.sqlite data/data.db
+docker start rembric
+```
+
+Anything written between the backup and the restore is lost — that window is the failed update's lifetime, typically under three minutes.
+
+**Bad release** (healthy but misbehaving): pin the previous version in `.env` and `docker compose up -d`. Your data directory is untouched by updates; if you also need the pre-update state of the database, stop the container and copy `data/backups/pre-update-v<target>-<ts>.sqlite` over `data/data.db` (remove `data.db-wal` / `data.db-shm` first).
+
+## Testing the flow locally
+
+For development, point the release feed at a stub and serve the image from a local registry:
+
+```ini
+# .env
+REMBRIC_UPDATE_CHECK_URL=http://<stub-host>/releases.json
+```
+
+The stub must answer with the GitHub releases JSON shape (`tag_name: server-v<semver>`, `body`, `html_url`, `published_at`). Combined with a `localhost:5000` registry and a `latest` tag, the full one-click cycle can be exercised without touching GHCR or GitHub.

--- a/openspec/changes/archive/2026-06-06-dashboard-self-update/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-06-dashboard-self-update/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/archive/2026-06-06-dashboard-self-update/design.md
+++ b/openspec/changes/archive/2026-06-06-dashboard-self-update/design.md
@@ -1,0 +1,121 @@
+# Design: dashboard-self-update
+
+## Context
+
+Rembric ships exclusively as a Docker image (`ghcr.io/susomejias/rembric`), normally run via the repo's `docker-compose.yml` (`image: …:${REMBRIC_VERSION:-latest}`, `container_name: rembric`, `restart: unless-stopped`, non-root uid 10001, no Docker socket). The dashboard already displays the running version (`REMBRIC_VERSION` constant from `version.ts`, sourced from `package.json`) in the brand block. Operators currently discover releases by watching GitHub and update by running compose commands on the host.
+
+Arcane's update flow is the UX reference: persistent sidebar badge → modal with version diff + changelog → one-click update → step progress (pull / restart / verify / reload). Arcane solves the "a process cannot outlive its own container" problem by launching an ephemeral upgrader container that performs the swap from outside.
+
+Hard constraints from exploration:
+
+- **Zero-action compatibility**: a deployment that only runs `docker compose pull && docker compose up -d` must keep working identically, with the feature simply `unavailable`. No config change may ever be required.
+- The container runs as non-root with no Docker access by default; that posture must not change by default.
+- Supply-chain posture: no new npm dependencies without strong justification (`.agents/skills/npm-security-best-practices/`).
+- Name collision to keep straight: the `REMBRIC_VERSION` _constant_ is the running version (package.json); the `REMBRIC_VERSION` _env var_ (via `env_file: .env`) is the compose image-tag pin. They are different values with the same name.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Every deployment (no action taken) learns about new releases in the dashboard: badge + changelog modal + ready-to-paste update command + automatic post-update page reload.
+- Deployments that opt in by mounting `/var/run/docker.sock` get Arcane-style one-click update: pull → SQLite backup → container swap with health-check and rollback → page reloads on the new version.
+- Refuse one-click when the image tag is pinned, with an explanation, so a later `compose up` can never silently downgrade.
+- No new dependencies, no DB schema changes, no change to MCP/memory semantics.
+
+**Non-Goals:**
+
+- Updating anything other than Rembric's own container (this is not a container manager).
+- Automatic/unattended updates (cron-style). One-click is always operator-initiated behind a danger confirmation.
+- Editing host files (`.env`, compose files) from inside the container.
+- Multi-replica / orchestrator (Swarm, k8s) support — compose single-container only; anything else degrades to the copy-paste quadrant.
+- Changing the default compose security posture (socket stays opt-in, commented out).
+
+## Decisions
+
+### D1 — Full execution path, gated by runtime capability detection (not notify-only, not external updater)
+
+The feature ships both halves: notification (works everywhere) and execution (works when the operator has mounted the socket and the tag is unpinned). Detection happens at runtime per-request, never at boot: if `/var/run/docker.sock` is absent, the Docker code path is simply never entered.
+
+- _Alternative: notify-only + recommend Watchtower/Arcane._ Rejected by product decision — the goal is Arcane-parity from Rembric's own UI with no external tooling.
+- _Alternative: require a `REMBRIC_SELF_UPDATE=on` flag in addition to the socket._ Rejected: mounting the socket is already an explicit, deliberate opt-in; a second flag adds a support-burden failure mode ("I mounted the socket, why no button?") without adding real security.
+
+Capability state machine (computed server-side, drives the modal):
+
+|                              | no socket                     | socket OK                                |
+| ---------------------------- | ----------------------------- | ---------------------------------------- |
+| **tag unpinned** (`:latest`) | `manual` — copy-paste command | `available` — one-click                  |
+| **tag pinned** (`:0.21.1`)   | `manual` + unpin hint         | `pinned` — button disabled, explains why |
+
+Plus `unavailable-perms` (socket mounted but EACCES — treated as `manual` with a log line and an in-modal hint about `group_add`) and `no-update` / `check-disabled`.
+
+### D2 — Ephemeral upgrader container reusing the freshly pulled Rembric image
+
+The swap is performed by a one-shot container started from the _new_ Rembric image with an alternate entrypoint (`node /app/dist/upgrade-helper.js`), socket mounted, parameterized with the old container id and target image. Sequence: inspect old → derive an identical create payload (Config/HostConfig/NetworkingConfig, labels included, image swapped) → stop old → rename old to `rembric-old-<ts>` → create + start new under the original name → poll the new container's `/healthz` → on success remove the old container; on failure stop/remove the new one, rename the old back, start it (rollback).
+
+- _Alternative: orchestrate the swap from inside the running server._ Physically impossible — the orchestrating process dies at `stop`.
+- _Alternative: use a third-party helper image (`docker:cli`, watchtower one-shot)._ Rejected: pulls a foreign image into the trust boundary; the new Rembric image is already present, already trusted, and already contains Node + our compiled code.
+- Copying the `com.docker.compose.*` labels keeps compose recognizing the container as its own; with the tag at `latest` and the freshly pulled image being local-latest, a later `compose up -d` is a no-op (this is exactly why D3 refuses pinned tags).
+- On success the upgrader removes the old container and itself; on failure the upgrader container is left in place (exited) so its logs are available for forensics.
+
+### D3 — Refuse one-click on pinned tags; detect the pin from ground truth
+
+If the running container was created from a version-pinned tag, one-click is disabled with an explanation ("your `.env` pins `REMBRIC_VERSION=0.21.1`; a later `compose up` would downgrade the update — unpin to enable one-click"). This _dissolves_ the compose-drift problem instead of mitigating it: a pinned deployment is never self-updated, so compose state and container state can never diverge.
+
+Detection: when the socket is available, self-inspect and read `Config.Image`'s tag — ground truth. Fallback/cross-check: `process.env.REMBRIC_VERSION` (the compose pin reaches the container through `env_file`). Self-identification: container hostname (= short container id by default), falling back to the `rembric` container name.
+
+- _Alternative: self-update anyway and tell the user to update `.env`._ Rejected: the failure mode (silent downgrade weeks later) is invisible exactly when the instruction has been forgotten.
+- _Alternative: pin by digest after update._ Rejected: still diverges from the compose file's declared tag; more state to explain.
+
+### D4 — Zero-dependency Docker Engine API client
+
+A minimal client (`services/self-update/engine-api.ts`) over `node:http` with `socketPath` — the Engine API is plain JSON/HTTP. Needed calls: `GET /_ping`, `GET /containers/{id}/json`, `POST /images/create` (streamed pull progress), `POST /containers/create|start|stop|rename`, `DELETE /containers/{id}`. Versioned path prefix (e.g. `/v1.44`) pinned to a floor the feature requires.
+
+- _Alternative: `dockerode`._ Rejected: large transitive surface for ~6 endpoints, against the repo's supply-chain posture (`minimumReleaseAge`, lockfile gates) for no capability we need.
+
+### D5 — Update check: server-side, 24h in-memory cache, default-on with `REMBRIC_UPDATE_CHECK=off`
+
+One `GET https://api.github.com/repos/susomejias/rembric/releases/latest` at most per 24h (lazy — triggered by dashboard visits, not a timer), ETag-aware, in-memory cache. Any failure (offline, rate-limited, air-gapped) silently yields "no update info"; no warnings, no retry storm. Semver compare against the running version; prereleases ignored. The release body (release-please generated, markdown with PR links) feeds the modal changelog.
+
+- _Alternative: browser-side check against the GitHub API._ Rejected: leaks deployment metadata from every operator's browser, hits CORS/rate limits per viewer, and can't feed server-side capability state.
+- _Alternative: opt-in check._ Rejected: defeats the purpose — the failure mode this feature fixes is operators who never opt into anything staying outdated silently. Opt-out + documented is the honest middle.
+- _Alternative: persist cache in SQLite._ Rejected: a 24h-refetch after restart costs nothing; no reason to touch the schema.
+
+### D6 — Pre-update backup is mandatory: `VACUUM INTO` under the data volume
+
+Before launching the upgrader, the server runs `VACUUM INTO '/data/backups/pre-update-v<target>-<ts>.sqlite'` and aborts the update if it fails (including on insufficient disk). Retention: keep the 3 most recent `pre-update-*` files, deleting older ones after a successful backup. Rationale: migrations run on the new version's boot and are not reversible; the memory store is append-only and precious. This is Rembric's deliberate divergence from Arcane's flow (an extra "Backing up database" step in the progress UI).
+
+- Coordination note: the in-flight `add-data-protection-defaults` change introduces general auto-snapshots; this backup is narrower (pre-update insurance) and intentionally independent. If both land, the implementations may share a snapshot helper but the pre-update gate stays non-skippable.
+
+### D7 — Progress UX: polling, not SSE; reload by version probe
+
+The dashboard is SSR + HTMX with no streaming infra; the update progress view polls a status endpoint (`GET /dashboard/update/status`) rendering the step list (check → backup → pull (with Engine-API progress) → restarting → verifying). Once the swap begins the server goes down mid-poll; the page treats connection errors as the "restarting" step and switches to probing a lightweight version endpoint until it answers with a version different from the one the page was rendered with, then reloads. Dashboard session cookies survive the restart because `dashboard_sessions` lives in SQLite on the persistent volume.
+
+The version probe must be reachable during the auth dance after restart: reuse `/healthz`-style bearer-less exposure is NOT acceptable; instead the probe is a dashboard-session-authenticated endpoint returning `{ version }` — the session cookie survives, so no special unauthenticated surface is added.
+
+Modal dismissal ("Later") is per-version in `localStorage`; the badge in the brand block persists regardless until updated.
+
+### D8 — Dashboard integration follows existing conventions
+
+Badge in the brand block next to the existing `v<version>` line (`components.ts`); modal and progress view in a new `dashboard/update.ts` using the locked design tokens (CSS in `dashboard/styles/`, no inline styles); the one-click trigger is a `<form>` with `data-confirm` and `data-confirm-tone="danger"`; timestamps ("published 2 days ago") via `formatTs`.
+
+## Risks / Trade-offs
+
+- **[Risk] Socket mount is root-equivalent on the host; a leaked admin token escalates from data access to host compromise.** → Strictly opt-in (commented compose line + docs), danger-tone confirmation, `docs/updates.md` states the trade-off plainly and recommends loopback/VPN binding when enabling, dashboard copy near the button names the risk.
+- **[Risk] Upgrader dies mid-swap (host reboot, OOM) leaving the old container stopped/renamed and no new one running.** → Step order minimizes the window (create new before removing old); rollback path in the helper; `docs/updates.md` documents manual recovery (`docker rename` + `docker start`); the old container is only removed after the new one passes health-check.
+- **[Risk] New version boots and passes `/healthz` but is functionally broken.** → Pre-update SQLite backup + previous image remains on disk; manual rollback documented (run old image, restore backup). MIT/no-warranty posture documented; one-click never auto-reruns.
+- **[Risk] Failed new version migrates the DB forward before dying; the rolled-back old code can't boot against the newer schema.** → The upgrader health-checks the restored container after rollback and, on failure, logs the exact pre-update snapshot path (threaded via `REMBRIC_UPGRADE_BACKUP`) with restore instructions. DB restore is deliberately NOT automatic: the failed version's brief life may contain real writes (agent memories), and silently discarding them is data loss of the opposite kind — the operator decides. Documented in `docs/updates.md::Recovery`.
+- **[Risk] GitHub anonymous rate limit (60 req/h/IP).** → ≤1 request/24h, ETag conditional requests, silent failure.
+- **[Risk] Socket mounted but uid 10001 lacks permission (docker GID mismatch).** → Detected ping failure degrades to `manual` quadrant with a `group_add` hint; never an error.
+- **[Risk] Disk exhaustion during pull or backup.** → Backup runs first and aborts the update on failure; pull errors surface in the progress view and leave the running container untouched (pull is side-effect-free until the swap).
+- **[Trade-off] In-memory update-check cache refetches after every restart.** → Accepted: one cheap conditional GET; avoids schema changes.
+- **[Trade-off] Polling instead of SSE for progress.** → Accepted: matches the HTMX/SSR architecture; 1–2s polls for under a minute is negligible.
+- **[Trade-off] One-click unavailable on pinned tags even with the socket mounted.** → Accepted deliberately (D3); the alternative is silent-downgrade risk.
+
+## Migration Plan
+
+Nothing migrates. The feature is dormant-by-absence: existing deployments pull the new image and see only the badge/modal (notification quadrant). Enabling one-click is a one-time operator action (uncomment the socket line or add a `docker-compose.override.yml`, plus `group_add` where needed) — documented, never required. Rollback of the feature itself = run the previous image tag.
+
+## Open Questions
+
+- Backup retention count (default 3) — confirm against `add-data-protection-defaults` once that change lands to avoid two competing retention policies under `/data/backups/`.
+- Engine API version floor: pick the oldest version that supports everything we call (likely `v1.41`+) and verify against Docker 20.10 as the practical minimum host.

--- a/openspec/changes/archive/2026-06-06-dashboard-self-update/proposal.md
+++ b/openspec/changes/archive/2026-06-06-dashboard-self-update/proposal.md
@@ -1,0 +1,47 @@
+# Proposal: dashboard-self-update
+
+## Why
+
+Operators have no way to learn a new Rembric version exists short of watching the GitHub repo, and updating requires manual `docker compose pull` on the host. Tools like Arcane have set the expectation for self-hosted apps: the dashboard tells you a release is out, shows the changelog, and — when the operator has granted Docker access — performs the stop/pull/recreate cycle itself with one click. Rembric already surfaces its running version in the dashboard brand; this change closes the loop from "version shown" to "version managed".
+
+## What Changes
+
+- New server-side **update check**: fetch the latest GitHub Release for `susomejias/rembric` at most once per 24h, compare against the running `REMBRIC_VERSION`, cache in memory. Disabled with `REMBRIC_UPDATE_CHECK=off`. Failure is silent (air-gapped hosts keep working with no badge and no warnings).
+- New **dashboard update surface**: badge next to the version in the brand block, a dismissable per-version modal with the release changelog, and an update progress view (pull → backup → restart → verify → reload via browser polling).
+- New **one-click self-update execution**, available only when BOTH hold: `/var/run/docker.sock` is mounted into the container AND the running container's image tag is not pinned to a specific version. Implementation: a zero-dependency Docker Engine API client over the unix socket (`node:http` `socketPath`), plus an ephemeral upgrader container started from the freshly pulled image with an alternate entrypoint (`upgrade-helper`) that stops/renames the old container, recreates it with identical config and the new image, health-checks it, and rolls back on failure.
+- New **pre-update SQLite backup**: `VACUUM INTO` a timestamped file under the data volume before any container swap. Non-skippable.
+- **Graceful capability degradation** (the four-quadrant contract):
+  - no socket → modal shows the copy-paste `docker compose pull && docker compose up -d` command and the docs link for enabling one-click;
+  - socket present but image tag pinned (e.g. `.env` sets `REMBRIC_VERSION=0.21.1`) → modal explains one-click is disabled because a later `compose up` would silently downgrade, and shows how to unpin;
+  - socket present, unpinned tag → one-click button behind a danger-tone confirmation;
+  - update check off/unreachable → no badge, everything else identical.
+- **Zero-action compatibility** (hard acceptance criterion): an existing deployment that only runs `docker compose pull && docker compose up -d` MUST boot and operate with no config change, no new errors or warnings, self-update in `unavailable` state, and every other feature intact.
+- `docker-compose.yml` gains a **commented** socket-mount line (affects new installs only; existing compose files are untouched by image updates by nature).
+- Documentation: new `docs/updates.md` (enabling one-click, the socket security trade-off, pinned-tag behavior) and a README feature entry ("auto-updater from the UI") linking to it.
+
+No DB schema changes, no new npm dependencies, no changes to MCP tools or memory semantics. Append-only memory, scope-at-service, and topic_key invariants are untouched.
+
+## Capabilities
+
+### New Capabilities
+
+- `self-update`: version-update detection (GitHub Releases poll, opt-out, silent failure), capability detection (socket presence, tag-pin detection via self-inspect with env fallback), one-click update execution (Engine API client, ephemeral upgrader container, pre-update SQLite backup, health-check + rollback), zero-action compatibility for socket-less deployments, and the operator documentation/compose opt-in contract.
+
+### Modified Capabilities
+
+- `dashboard`: new requirements for the update badge in the brand block, the per-version dismissable update modal with changelog, the update progress view with post-restart polling/reload, and the danger-tone confirmation on the one-click action.
+
+## Impact
+
+- **New code** (all under `apps/server/src/`):
+  - `services/update-check.ts` — release poll, semver compare, 24h in-memory cache, `REMBRIC_UPDATE_CHECK` gate.
+  - `services/self-update/engine-api.ts` — minimal Docker Engine API client over the unix socket (ping, inspect, image pull with progress, container create/start/stop/rename/remove).
+  - `services/self-update/capability.ts` — socket detection, self-container resolution (hostname → inspect, `container_name` fallback), tag-pin detection, four-quadrant state.
+  - `services/self-update/orchestrator.ts` — update state machine driven by the dashboard (pull → backup → launch helper), status exposed for polling.
+  - `scripts/upgrade-helper.ts` — compiled to `dist/`; entrypoint of the ephemeral upgrader container (swap + health-check + rollback).
+- **Modified code**:
+  - `apps/server/src/server/dashboard-router.ts` — update endpoints (trigger, status poll, unauthenticated-safe version probe for post-restart reload) and badge data.
+  - `apps/server/src/dashboard/components.ts` — brand badge; new `apps/server/src/dashboard/update.ts` view; styles under `apps/server/src/dashboard/styles/`.
+- **Deployment/docs**: `docker-compose.yml` (commented opt-in line), `docs/updates.md` (new), `README.md` (feature section + link).
+- **Tests**: unit tests for update-check/capability/orchestrator/helper against a mocked Engine API; dashboard e2e for the four quadrants; explicit zero-action regression (boot without socket → healthz OK, dashboard OK, no new warnings). Invariant tests unaffected.
+- **Security posture**: unchanged by default. Mounting the Docker socket is root-equivalent on the host and is strictly opt-in; the docs and the in-dashboard copy must state this plainly.

--- a/openspec/changes/archive/2026-06-06-dashboard-self-update/specs/dashboard/spec.md
+++ b/openspec/changes/archive/2026-06-06-dashboard-self-update/specs/dashboard/spec.md
@@ -1,0 +1,63 @@
+# dashboard Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: The dashboard MUST surface update availability as a badge in the brand block
+
+When the update check reports a newer version, the dashboard SHALL render an update badge adjacent to the running-version line in the brand block (sidebar, mobile bar) showing the latest available version. The badge SHALL persist across visits until the deployment runs the newer version and SHALL NOT be affected by modal dismissal. When no update is available, or the update check is disabled or failed, no badge SHALL render.
+
+#### Scenario: Update available
+
+- **WHEN** an authenticated operator loads any dashboard page while a newer version is known
+- **THEN** the brand block SHALL show an update badge with the latest version next to the running version
+
+#### Scenario: No update information
+
+- **WHEN** the update check is disabled or has no result
+- **THEN** the brand block SHALL render exactly as it does today (running version only)
+
+### Requirement: The dashboard MUST present a per-version dismissable update modal with the release changelog
+
+When a newer version is known and the operator has not dismissed that specific version, the dashboard SHALL present an update modal showing: current version → new version, the release publication time (via `formatTs`), the release changelog body rendered from the GitHub Release, and a link to the release on GitHub. A "Later" action SHALL dismiss the modal for that version only (client-side persistence); the next newer release SHALL re-trigger it. The modal's primary action SHALL depend on the self-update capability state:
+
+- `available` — an update button that triggers the one-click flow
+- `pinned` — no button; an explanation that the image tag is pinned and how to unpin
+- `manual` — a copy-to-clipboard `docker compose pull && docker compose up -d` command and a link to `docs/updates.md` for enabling one-click
+
+#### Scenario: First visit after a release
+
+- **WHEN** an operator opens the dashboard and a newer, undismissed version exists
+- **THEN** the update modal SHALL appear with the version diff, changelog, and the capability-appropriate action
+
+#### Scenario: Dismissed version stays dismissed
+
+- **WHEN** the operator chose "Later" for `0.22.0` and reloads the dashboard
+- **THEN** the modal SHALL NOT reappear for `0.22.0`, while the brand badge remains
+
+#### Scenario: Manual quadrant
+
+- **WHEN** the modal renders with capability `manual`
+- **THEN** it SHALL show the copy-paste update command and the docs link instead of an update button
+
+### Requirement: The one-click update action MUST require a danger-tone confirmation
+
+The one-click update trigger SHALL be a form protected by the dashboard's `data-confirm` modal with `data-confirm-tone="danger"`, and its confirmation copy SHALL state that the server will stop, replace its container, and restart, and that a database backup is taken first.
+
+#### Scenario: Confirmation before update
+
+- **WHEN** the operator clicks the update button
+- **THEN** the danger-tone confirmation modal SHALL appear and no update SHALL start until confirmed
+
+### Requirement: The dashboard MUST show update progress and reload itself on the new version
+
+After a one-click update is confirmed, the dashboard SHALL show a progress view with discrete steps (backup, image pull with progress, service restart, version verification) updated by polling a status endpoint. While the server is restarting, connection failures SHALL be rendered as the restart step, not as errors. The page SHALL then poll a session-authenticated version endpoint and, once it answers with a version different from the one the page rendered with, SHALL reload automatically. If the update fails before the swap, the progress view SHALL show the failure reason; if it fails after the swap (rollback), the reloaded page SHALL surface that the previous version is still running.
+
+#### Scenario: Successful update reloads on new version
+
+- **WHEN** the upgrader completes and the replacement container becomes healthy
+- **THEN** the operator's page SHALL detect the new version via polling and reload, showing the dashboard on the new version with the session still valid
+
+#### Scenario: Failure before swap
+
+- **WHEN** the backup or pull step fails
+- **THEN** the progress view SHALL display the failure reason and the dashboard SHALL remain fully functional on the current version

--- a/openspec/changes/archive/2026-06-06-dashboard-self-update/specs/self-update/spec.md
+++ b/openspec/changes/archive/2026-06-06-dashboard-self-update/specs/self-update/spec.md
@@ -1,0 +1,130 @@
+# self-update Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: The server MUST check for new releases at most once per 24 hours, default-on with an opt-out
+
+The server SHALL determine the latest published release of Rembric by querying the GitHub Releases API for the distribution repository, at most once per 24-hour window, lazily (triggered by dashboard activity, not a timer), using conditional requests (ETag) where possible. The result SHALL be cached in memory together with the release changelog body. Setting `REMBRIC_UPDATE_CHECK=off` SHALL disable the check entirely. Any failure of the check (network unreachable, rate-limited, malformed response) SHALL be silent: no error logs above debug level, no dashboard warnings, and all other functionality unaffected. Prerelease versions SHALL be ignored.
+
+#### Scenario: New version detected
+
+- **WHEN** the running version is `0.21.1` and the GitHub Releases API reports latest release `server-v0.22.0`
+- **THEN** the server SHALL expose update availability (current version, latest version, publication date, changelog body) to the dashboard layer
+
+#### Scenario: Check disabled by operator
+
+- **WHEN** `REMBRIC_UPDATE_CHECK=off` is set
+- **THEN** the server SHALL NOT contact the GitHub API and the dashboard SHALL render with no update badge or modal
+
+#### Scenario: Air-gapped host
+
+- **WHEN** the GitHub API is unreachable
+- **THEN** the server SHALL behave as if no update is available, without surfacing errors or warnings to the operator
+
+### Requirement: Self-update capability MUST be detected at runtime and never assumed
+
+The server SHALL compute a self-update capability state on demand, without any boot-time dependency on Docker. The state SHALL be one of:
+
+- `available` — `/var/run/docker.sock` exists, the Engine API responds to a ping, and the running container's image tag is not pinned to a specific version
+- `pinned` — socket usable, but the running container was created from a version-pinned image tag
+- `manual` — no socket, or the socket exists but is not usable (e.g. permission denied)
+
+Tag-pin detection SHALL use the running container's actual image reference obtained by self-inspection over the Engine API (container hostname as id, `rembric` container name as fallback) as ground truth, with the `REMBRIC_VERSION` environment variable as a secondary signal when inspection is unavailable. A socket that exists but fails the ping SHALL degrade to `manual` with at most a single informational log line.
+
+#### Scenario: Socket mounted, tag unpinned
+
+- **WHEN** the Docker socket is mounted and usable and the container runs image tag `latest`
+- **THEN** the capability state SHALL be `available`
+
+#### Scenario: Socket mounted, tag pinned
+
+- **WHEN** the Docker socket is mounted and usable and the container runs image tag `0.21.1`
+- **THEN** the capability state SHALL be `pinned`
+
+#### Scenario: Socket mounted without permissions
+
+- **WHEN** the Docker socket is mounted but the server's uid cannot connect to it
+- **THEN** the capability state SHALL be `manual` and the server SHALL NOT raise errors or repeat warnings
+
+### Requirement: Deployments without the Docker socket MUST keep working with zero action (zero-action compatibility)
+
+A deployment that updates the image with `docker compose pull && docker compose up -d` and changes nothing else SHALL boot and operate identically to the previous version: no new configuration required, no new errors or warnings at boot or during operation, `/healthz` unaffected, MCP and dashboard surfaces unaffected, and the self-update feature present only in its degraded `manual` form (notification + copy-paste command).
+
+#### Scenario: Existing compose file, new image, no socket
+
+- **WHEN** a container built from this version starts with a compose file that predates this feature (no socket mount)
+- **THEN** the server SHALL start cleanly, log no new warnings, serve all existing functionality, and report capability `manual`
+
+### Requirement: One-click self-update MUST be executed by an ephemeral upgrader container with health-check and rollback
+
+When the capability state is `available` and the operator confirms the update, the server SHALL execute, in order: (1) pre-update database backup (see backup requirement) — abort on failure; (2) pull the target image via the Engine API, surfacing pull progress; (3) create and start a one-shot upgrader container from the freshly pulled image with an alternate entrypoint, with the Docker socket mounted, parameterized with the current container's id and the target image.
+
+The upgrader SHALL: inspect the old container and derive a creation payload preserving its configuration (ports, volumes, environment, labels — including compose labels — restart policy, network settings) with only the image changed; stop the old container; rename it out of the way; create and start the replacement under the original name; poll the replacement's health endpoint until healthy or a bounded timeout. On success the upgrader SHALL remove the old container and itself. On failure the upgrader SHALL stop and remove the replacement, restore the old container's name, restart it, and leave itself (exited) for log inspection.
+
+The update SHALL only proceed for the Rembric container itself; the feature SHALL NOT manage any other container.
+
+#### Scenario: Successful update
+
+- **WHEN** the operator confirms a one-click update from `0.21.1` to `0.22.0`
+- **THEN** the system SHALL back up the database, pull the new image, swap the container preserving its configuration, verify health, remove the old container, and the dashboard SHALL come back on `0.22.0` with data intact
+
+#### Scenario: Replacement fails health check
+
+- **WHEN** the replacement container does not become healthy within the timeout
+- **THEN** the upgrader SHALL remove the replacement, restore and restart the old container under its original name, and the deployment SHALL be back on the previous version
+
+#### Scenario: Pull fails
+
+- **WHEN** the image pull fails (network, disk)
+- **THEN** the running container SHALL be untouched and the failure SHALL be reported in the update progress view
+
+#### Scenario: Old version fails to recover after rollback
+
+- **WHEN** the rollback restarts the previous container but it does not become healthy (e.g. the failed release migrated the database schema forward)
+- **THEN** the upgrader SHALL log that the database may have been migrated forward and SHALL name the pre-update snapshot path with restore instructions; the database SHALL NOT be restored automatically (writes accepted during the failed update's lifetime must never be silently discarded)
+
+### Requirement: A database backup MUST be taken before any container swap and MUST gate the update
+
+Before launching the upgrader, the server SHALL produce a consistent SQLite snapshot via `VACUUM INTO` to a timestamped file under the data volume (e.g. `/data/backups/pre-update-v<target>-<ts>.sqlite`). If the backup fails for any reason, the update SHALL be aborted before any container is stopped. After a successful backup, the server SHALL retain at most the 3 most recent pre-update backup files, removing older ones.
+
+#### Scenario: Backup failure aborts update
+
+- **WHEN** the pre-update `VACUUM INTO` fails (e.g. insufficient disk)
+- **THEN** the update SHALL abort with the running container untouched and the failure reason shown to the operator
+
+#### Scenario: Retention
+
+- **WHEN** a fourth pre-update backup completes successfully
+- **THEN** the oldest pre-update backup file SHALL be removed
+
+### Requirement: One-click update MUST be refused when the image tag is pinned
+
+When the capability state is `pinned`, the server SHALL refuse to execute a one-click update and the dashboard SHALL explain that the deployment pins the image tag (e.g. via `REMBRIC_VERSION` in `.env`), that self-updating would be silently reverted by a later `docker compose up`, and how to unpin to enable one-click.
+
+#### Scenario: Pinned deployment requests update
+
+- **WHEN** the capability state is `pinned` and an update-trigger request reaches the server
+- **THEN** the server SHALL reject it without side effects and the UI SHALL show the pinned-tag explanation instead of an update button
+
+### Requirement: The self-update implementation MUST NOT add runtime npm dependencies
+
+All Docker Engine API interaction SHALL be implemented with Node built-ins (`node:http` over the unix socket). The feature SHALL NOT introduce new entries in `apps/server/package.json` `dependencies`.
+
+#### Scenario: Dependency audit
+
+- **WHEN** the feature is fully implemented
+- **THEN** `apps/server/package.json` SHALL contain no new runtime dependencies attributable to it
+
+### Requirement: The socket opt-in and update behavior MUST be documented in compose, docs, and README
+
+`docker-compose.yml` SHALL include the Docker socket mount as a commented-out line with a pointer to the documentation. A `docs/updates.md` page SHALL document: the zero-action notification behavior, how to enable one-click (uncomment or `docker-compose.override.yml`, plus `group_add` guidance), the explicit statement that mounting the socket is root-equivalent on the host, the pinned-tag behavior, the pre-update backup location, and manual recovery steps if an update is interrupted. `README.md` SHALL list the auto-updater from the UI as a feature and link to `docs/updates.md`.
+
+#### Scenario: New install reads compose
+
+- **WHEN** a new operator opens the shipped `docker-compose.yml`
+- **THEN** the socket mount SHALL be present but commented out, with a comment referencing the security trade-off and the docs page
+
+#### Scenario: README feature entry
+
+- **WHEN** a visitor reads the README features
+- **THEN** the UI auto-updater SHALL be listed and SHALL link to `docs/updates.md`

--- a/openspec/changes/archive/2026-06-06-dashboard-self-update/tasks.md
+++ b/openspec/changes/archive/2026-06-06-dashboard-self-update/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: dashboard-self-update
+
+## 1. Update check
+
+- [x] 1.1 Implement `apps/server/src/services/update-check.ts`: lazy GitHub Releases `latest` fetch with ETag, semver compare against `REMBRIC_VERSION`, 24h in-memory cache, prerelease filtering, `REMBRIC_UPDATE_CHECK=off` gate, silent failure. Co-located unit tests (mocked fetch) cover: newer/equal/older versions, off-gate, network failure, ETag 304, prerelease skip.
+- [x] 1.2 Expose update info (current, latest, publishedAt, changelog body, release URL) to the dashboard layer via a single accessor used by `dashboard-router.ts`.
+
+## 2. Capability detection
+
+- [x] 2.1 Implement `apps/server/src/services/self-update/engine-api.ts`: zero-dependency Engine API client over `node:http` `socketPath` (ping, container inspect, image pull with progress stream, container create/start/stop/rename/remove), versioned path prefix per design D4/open question. Unit tests against a mocked unix-socket HTTP server.
+- [x] 2.2 Implement `apps/server/src/services/self-update/capability.ts`: socket existence + ping, self-container resolution (hostname → inspect, `rembric` name fallback), tag-pin detection from `Config.Image` with `process.env.REMBRIC_VERSION` fallback, resulting state `available | pinned | manual`. EACCES degrades to `manual` with one informational log line. Unit tests for all quadrants + perms degradation.
+- [x] 2.3 Verify zero-action compatibility: test that constructing the server with no socket present produces no Docker calls, no warnings, and capability `manual` (regression test named after the requirement).
+
+## 3. Update execution
+
+- [x] 3.1 Implement pre-update backup in the orchestrator: `VACUUM INTO /data/backups/pre-update-v<target>-<ts>.sqlite`, abort-on-failure, retention of 3 most recent pre-update files. Unit tests: success, failure aborts before any container call, retention prune.
+- [x] 3.2 Implement `apps/server/src/services/self-update/orchestrator.ts`: state machine (idle → backup → pull → launching-helper → restarting | failed) driven by dashboard endpoints, pull progress captured from the Engine API stream, refusal with no side effects when state is `pinned` or `manual`. Unit tests with mocked engine-api.
+- [x] 3.3 Implement `apps/server/src/scripts/upgrade-helper.ts` (compiled into `dist/`): inspect old → derive identical create payload (ports, volumes, env, labels incl. compose labels, restart policy, networking) with new image → stop → rename → create+start under original name → poll `/healthz` with bounded timeout → success: remove old + self; failure: remove replacement, restore name, restart old, exit non-zero leaving its container for logs. Unit-test the payload derivation and the rollback branch against mocked engine-api.
+- [x] 3.4 Wire the helper launch: create the upgrader container from the freshly pulled image with alternate entrypoint, socket bind-mount, and old-container-id/target-image parameters.
+
+## 4. Dashboard surface
+
+- [x] 4.1 Brand badge: extend `apps/server/src/dashboard/components.ts` brand block (sidebar, mobile bar) with the update badge fed by update-check; no badge when no info. Update `components.test.ts`.
+- [x] 4.2 Update modal in new `apps/server/src/dashboard/update.ts`: version diff, `formatTs` publication time, changelog rendered from release body, GitHub link, "Later" per-version dismissal (localStorage), capability-dependent primary action (button / pinned explanation / copy-paste command + docs link). CSS in `apps/server/src/dashboard/styles/` (no inline styles, locked tokens).
+- [x] 4.3 One-click trigger as a `<form>` with `data-confirm` + `data-confirm-tone="danger"`, copy stating stop/replace/restart + backup-first.
+- [x] 4.4 Progress view: step list (backup, pull with progress, restart, verify) polling `GET /dashboard/update/status`; connection errors render as the restart step; then poll the session-authenticated version endpoint and auto-reload when the version changes. Failure-before-swap shows reason and leaves dashboard functional.
+- [x] 4.5 Router endpoints in `apps/server/src/server/dashboard-router.ts`: trigger (POST, CSRF-protected, rejects unless `available`), status (GET), version probe (GET, dashboard-session-authenticated). Extend `dashboard-e2e.test.ts`: badge render, modal quadrants (`available`/`pinned`/`manual`), trigger rejection when not `available`, zero-action boot (no socket → healthz OK, dashboard OK, no new warnings).
+
+## 5. Deployment + docs
+
+- [x] 5.1 Add the commented socket-mount line to `docker-compose.yml` with a one-line pointer to `docs/updates.md` (terse, per infra-comment convention).
+- [x] 5.2 Write `docs/updates.md`: zero-action notification behavior, enabling one-click (uncomment or `docker-compose.override.yml` + `group_add` GID guidance), explicit root-equivalent warning, pinned-tag behavior, backup location/retention, manual recovery for an interrupted swap (`docker rename` + `docker start`), manual rollback (old image + backup restore).
+- [x] 5.3 README: add "auto-updater from the UI" to the features section linking to `docs/updates.md` (respect open-source-distribution README requirements: no deprecated install mechanisms, keep existing nav links intact).
+
+## 6. Validation
+
+- [x] 6.1 `pnpm run typecheck`, `pnpm run lint`, `pnpm test` green; confirm no new runtime deps in `apps/server/package.json` (self-update dependency requirement).
+- [x] 6.2 OPERATOR-ASSISTED: end-to-end smoke on a host with Docker — run the image with socket mounted + `latest` tag, point update-check at a stubbed release (or temporarily lower the running version), execute one-click, verify: backup file created, container swapped with config preserved, page auto-reloads on new version, old container removed. Then repeat with a pinned tag (button disabled + explanation) and without socket (copy-paste quadrant, no warnings in logs).
+- [x] 6.3 OPERATOR-ASSISTED: rollback drill — make the replacement fail its healthcheck (e.g. bogus target image/entrypoint) and verify the upgrader restores the old container under its original name and the deployment keeps serving.

--- a/openspec/specs/dashboard/spec.md
+++ b/openspec/specs/dashboard/spec.md
@@ -819,3 +819,63 @@ The dashboard SHALL render the running server version (the `version` field of th
 
 - **WHEN** the sidebar is in collapsed mode
 - **THEN** the version SHALL be hidden along with the entire `.label-stack` (existing collapse behavior, unchanged)
+
+### Requirement: The dashboard MUST surface update availability as a badge in the brand block
+
+When the update check reports a newer version, the dashboard SHALL render an update badge adjacent to the running-version line in the brand block (sidebar, mobile bar) showing the latest available version. The badge SHALL persist across visits until the deployment runs the newer version and SHALL NOT be affected by modal dismissal. When no update is available, or the update check is disabled or failed, no badge SHALL render.
+
+#### Scenario: Update available
+
+- **WHEN** an authenticated operator loads any dashboard page while a newer version is known
+- **THEN** the brand block SHALL show an update badge with the latest version next to the running version
+
+#### Scenario: No update information
+
+- **WHEN** the update check is disabled or has no result
+- **THEN** the brand block SHALL render exactly as it does today (running version only)
+
+### Requirement: The dashboard MUST present a per-version dismissable update modal with the release changelog
+
+When a newer version is known and the operator has not dismissed that specific version, the dashboard SHALL present an update modal showing: current version → new version, the release publication time (via `formatTs`), the release changelog body rendered from the GitHub Release, and a link to the release on GitHub. A "Later" action SHALL dismiss the modal for that version only (client-side persistence); the next newer release SHALL re-trigger it. The modal's primary action SHALL depend on the self-update capability state:
+
+- `available` — an update button that triggers the one-click flow
+- `pinned` — no button; an explanation that the image tag is pinned and how to unpin
+- `manual` — a copy-to-clipboard `docker compose pull && docker compose up -d` command and a link to `docs/updates.md` for enabling one-click
+
+#### Scenario: First visit after a release
+
+- **WHEN** an operator opens the dashboard and a newer, undismissed version exists
+- **THEN** the update modal SHALL appear with the version diff, changelog, and the capability-appropriate action
+
+#### Scenario: Dismissed version stays dismissed
+
+- **WHEN** the operator chose "Later" for `0.22.0` and reloads the dashboard
+- **THEN** the modal SHALL NOT reappear for `0.22.0`, while the brand badge remains
+
+#### Scenario: Manual quadrant
+
+- **WHEN** the modal renders with capability `manual`
+- **THEN** it SHALL show the copy-paste update command and the docs link instead of an update button
+
+### Requirement: The one-click update action MUST require a danger-tone confirmation
+
+The one-click update trigger SHALL be a form protected by the dashboard's `data-confirm` modal with `data-confirm-tone="danger"`, and its confirmation copy SHALL state that the server will stop, replace its container, and restart, and that a database backup is taken first.
+
+#### Scenario: Confirmation before update
+
+- **WHEN** the operator clicks the update button
+- **THEN** the danger-tone confirmation modal SHALL appear and no update SHALL start until confirmed
+
+### Requirement: The dashboard MUST show update progress and reload itself on the new version
+
+After a one-click update is confirmed, the dashboard SHALL show a progress view with discrete steps (backup, image pull with progress, service restart, version verification) updated by polling a status endpoint. While the server is restarting, connection failures SHALL be rendered as the restart step, not as errors. The page SHALL then poll a session-authenticated version endpoint and, once it answers with a version different from the one the page rendered with, SHALL reload automatically. If the update fails before the swap, the progress view SHALL show the failure reason; if it fails after the swap (rollback), the reloaded page SHALL surface that the previous version is still running.
+
+#### Scenario: Successful update reloads on new version
+
+- **WHEN** the upgrader completes and the replacement container becomes healthy
+- **THEN** the operator's page SHALL detect the new version via polling and reload, showing the dashboard on the new version with the session still valid
+
+#### Scenario: Failure before swap
+
+- **WHEN** the backup or pull step fails
+- **THEN** the progress view SHALL display the failure reason and the dashboard SHALL remain fully functional on the current version

--- a/openspec/specs/self-update/spec.md
+++ b/openspec/specs/self-update/spec.md
@@ -1,0 +1,134 @@
+# self-update Specification
+
+## Purpose
+
+Defines how Rembric detects new releases and updates its own container from the dashboard: the daily GitHub Releases check (default-on, opt-out, silent failure), runtime capability detection over the Docker socket (`available` / `pinned` / `manual`), the one-click execution path (mandatory pre-update SQLite backup, ephemeral upgrader container, health-check, rollback with post-rollback verification), the zero-action compatibility guarantee for deployments that change nothing, and the operator documentation contract (compose opt-in, docs, README).
+
+## Requirements
+
+### Requirement: The server MUST check for new releases at most once per 24 hours, default-on with an opt-out
+
+The server SHALL determine the latest published release of Rembric by querying the GitHub Releases API for the distribution repository, at most once per 24-hour window, lazily (triggered by dashboard activity, not a timer), using conditional requests (ETag) where possible. The result SHALL be cached in memory together with the release changelog body. Setting `REMBRIC_UPDATE_CHECK=off` SHALL disable the check entirely. Any failure of the check (network unreachable, rate-limited, malformed response) SHALL be silent: no error logs above debug level, no dashboard warnings, and all other functionality unaffected. Prerelease versions SHALL be ignored.
+
+#### Scenario: New version detected
+
+- **WHEN** the running version is `0.21.1` and the GitHub Releases API reports latest release `server-v0.22.0`
+- **THEN** the server SHALL expose update availability (current version, latest version, publication date, changelog body) to the dashboard layer
+
+#### Scenario: Check disabled by operator
+
+- **WHEN** `REMBRIC_UPDATE_CHECK=off` is set
+- **THEN** the server SHALL NOT contact the GitHub API and the dashboard SHALL render with no update badge or modal
+
+#### Scenario: Air-gapped host
+
+- **WHEN** the GitHub API is unreachable
+- **THEN** the server SHALL behave as if no update is available, without surfacing errors or warnings to the operator
+
+### Requirement: Self-update capability MUST be detected at runtime and never assumed
+
+The server SHALL compute a self-update capability state on demand, without any boot-time dependency on Docker. The state SHALL be one of:
+
+- `available` — `/var/run/docker.sock` exists, the Engine API responds to a ping, and the running container's image tag is not pinned to a specific version
+- `pinned` — socket usable, but the running container was created from a version-pinned image tag
+- `manual` — no socket, or the socket exists but is not usable (e.g. permission denied)
+
+Tag-pin detection SHALL use the running container's actual image reference obtained by self-inspection over the Engine API (container hostname as id, `rembric` container name as fallback) as ground truth, with the `REMBRIC_VERSION` environment variable as a secondary signal when inspection is unavailable. A socket that exists but fails the ping SHALL degrade to `manual` with at most a single informational log line.
+
+#### Scenario: Socket mounted, tag unpinned
+
+- **WHEN** the Docker socket is mounted and usable and the container runs image tag `latest`
+- **THEN** the capability state SHALL be `available`
+
+#### Scenario: Socket mounted, tag pinned
+
+- **WHEN** the Docker socket is mounted and usable and the container runs image tag `0.21.1`
+- **THEN** the capability state SHALL be `pinned`
+
+#### Scenario: Socket mounted without permissions
+
+- **WHEN** the Docker socket is mounted but the server's uid cannot connect to it
+- **THEN** the capability state SHALL be `manual` and the server SHALL NOT raise errors or repeat warnings
+
+### Requirement: Deployments without the Docker socket MUST keep working with zero action (zero-action compatibility)
+
+A deployment that updates the image with `docker compose pull && docker compose up -d` and changes nothing else SHALL boot and operate identically to the previous version: no new configuration required, no new errors or warnings at boot or during operation, `/healthz` unaffected, MCP and dashboard surfaces unaffected, and the self-update feature present only in its degraded `manual` form (notification + copy-paste command).
+
+#### Scenario: Existing compose file, new image, no socket
+
+- **WHEN** a container built from this version starts with a compose file that predates this feature (no socket mount)
+- **THEN** the server SHALL start cleanly, log no new warnings, serve all existing functionality, and report capability `manual`
+
+### Requirement: One-click self-update MUST be executed by an ephemeral upgrader container with health-check and rollback
+
+When the capability state is `available` and the operator confirms the update, the server SHALL execute, in order: (1) pre-update database backup (see backup requirement) — abort on failure; (2) pull the target image via the Engine API, surfacing pull progress; (3) create and start a one-shot upgrader container from the freshly pulled image with an alternate entrypoint, with the Docker socket mounted, parameterized with the current container's id and the target image.
+
+The upgrader SHALL: inspect the old container and derive a creation payload preserving its configuration (ports, volumes, environment, labels — including compose labels — restart policy, network settings) with only the image changed; stop the old container; rename it out of the way; create and start the replacement under the original name; poll the replacement's health endpoint until healthy or a bounded timeout. On success the upgrader SHALL remove the old container and itself. On failure the upgrader SHALL stop and remove the replacement, restore the old container's name, restart it, and leave itself (exited) for log inspection.
+
+The update SHALL only proceed for the Rembric container itself; the feature SHALL NOT manage any other container.
+
+#### Scenario: Successful update
+
+- **WHEN** the operator confirms a one-click update from `0.21.1` to `0.22.0`
+- **THEN** the system SHALL back up the database, pull the new image, swap the container preserving its configuration, verify health, remove the old container, and the dashboard SHALL come back on `0.22.0` with data intact
+
+#### Scenario: Replacement fails health check
+
+- **WHEN** the replacement container does not become healthy within the timeout
+- **THEN** the upgrader SHALL remove the replacement, restore and restart the old container under its original name, and the deployment SHALL be back on the previous version
+
+#### Scenario: Pull fails
+
+- **WHEN** the image pull fails (network, disk)
+- **THEN** the running container SHALL be untouched and the failure SHALL be reported in the update progress view
+
+#### Scenario: Old version fails to recover after rollback
+
+- **WHEN** the rollback restarts the previous container but it does not become healthy (e.g. the failed release migrated the database schema forward)
+- **THEN** the upgrader SHALL log that the database may have been migrated forward and SHALL name the pre-update snapshot path with restore instructions; the database SHALL NOT be restored automatically (writes accepted during the failed update's lifetime must never be silently discarded)
+
+### Requirement: A database backup MUST be taken before any container swap and MUST gate the update
+
+Before launching the upgrader, the server SHALL produce a consistent SQLite snapshot via `VACUUM INTO` to a timestamped file under the data volume (e.g. `/data/backups/pre-update-v<target>-<ts>.sqlite`). If the backup fails for any reason, the update SHALL be aborted before any container is stopped. After a successful backup, the server SHALL retain at most the 3 most recent pre-update backup files, removing older ones.
+
+#### Scenario: Backup failure aborts update
+
+- **WHEN** the pre-update `VACUUM INTO` fails (e.g. insufficient disk)
+- **THEN** the update SHALL abort with the running container untouched and the failure reason shown to the operator
+
+#### Scenario: Retention
+
+- **WHEN** a fourth pre-update backup completes successfully
+- **THEN** the oldest pre-update backup file SHALL be removed
+
+### Requirement: One-click update MUST be refused when the image tag is pinned
+
+When the capability state is `pinned`, the server SHALL refuse to execute a one-click update and the dashboard SHALL explain that the deployment pins the image tag (e.g. via `REMBRIC_VERSION` in `.env`), that self-updating would be silently reverted by a later `docker compose up`, and how to unpin to enable one-click.
+
+#### Scenario: Pinned deployment requests update
+
+- **WHEN** the capability state is `pinned` and an update-trigger request reaches the server
+- **THEN** the server SHALL reject it without side effects and the UI SHALL show the pinned-tag explanation instead of an update button
+
+### Requirement: The self-update implementation MUST NOT add runtime npm dependencies
+
+All Docker Engine API interaction SHALL be implemented with Node built-ins (`node:http` over the unix socket). The feature SHALL NOT introduce new entries in `apps/server/package.json` `dependencies`.
+
+#### Scenario: Dependency audit
+
+- **WHEN** the feature is fully implemented
+- **THEN** `apps/server/package.json` SHALL contain no new runtime dependencies attributable to it
+
+### Requirement: The socket opt-in and update behavior MUST be documented in compose, docs, and README
+
+`docker-compose.yml` SHALL include the Docker socket mount as a commented-out line with a pointer to the documentation. A `docs/updates.md` page SHALL document: the zero-action notification behavior, how to enable one-click (uncomment or `docker-compose.override.yml`, plus `group_add` guidance), the explicit statement that mounting the socket is root-equivalent on the host, the pinned-tag behavior, the pre-update backup location, and manual recovery steps if an update is interrupted. `README.md` SHALL list the auto-updater from the UI as a feature and link to `docs/updates.md`.
+
+#### Scenario: New install reads compose
+
+- **WHEN** a new operator opens the shipped `docker-compose.yml`
+- **THEN** the socket mount SHALL be present but commented out, with a comment referencing the security trade-off and the docs page
+
+#### Scenario: README feature entry
+
+- **WHEN** a visitor reads the README features
+- **THEN** the UI auto-updater SHALL be listed and SHALL link to `docs/updates.md`


### PR DESCRIPTION
## What

Arcane-style self-update, designed in OpenSpec change `dashboard-self-update` (archived in this PR; specs synced — new `self-update` capability + 4 requirements added to `dashboard`).

- **Update check** — daily GitHub Releases poll (`server-v*` tags), ETag-aware, in-memory cache, silent failure for air-gapped hosts, `REMBRIC_UPDATE_CHECK=off` opt-out, `REMBRIC_UPDATE_CHECK_URL` stub seam for local testing.
- **Dashboard surface** — brand badge, per-version dismissable modal with the release changelog, danger-tone confirmation, progress view (backup → pull → restart → verify) with post-restart polling and automatic reload.
- **One-click execution** (requires `/var/run/docker.sock` mounted + unpinned tag) — mandatory `VACUUM INTO` backup (abort-on-failure, retention 3), Engine API pull with progress, swap by an ephemeral upgrader container created from the freshly pulled image (identical config, compose labels preserved), health-check, rollback on failure, post-rollback recovery verification that names the exact snapshot to restore if the failed release migrated the DB forward.
- **Capability quadrants** — `available` / `pinned` (refused with explanation: prevents silent compose downgrades) / `manual` (copy-paste command + docs link).
- Zero new runtime dependencies (Engine API over `node:http` `socketPath`).

## Zero-action compatibility (hard requirement)

Existing deployments that only `docker compose pull && docker compose up -d` boot and operate identically: no config change, no new warnings, feature degrades to notification + manual flow. Covered by a named e2e test.

## Tests

- 47 new unit/e2e tests (`update-check`, `engine-api` against a real unix-socket server, `capability`, `orchestrator`, `upgrade-helper` incl. rollback/double-fault/post-rollback-unhealthy, dashboard e2e for all quadrants + CSRF + zero-action). Suite: 604 passing.
- **Real smoke on Docker Desktop** (local registry + stubbed release feed): one-click 0.21.1→9.9.9 verified end-to-end (backup file, swap, session survives, auto-reload, upgrader self-removal) and rollback drill verified (broken image → upgrader exits 1 with clear logs → service restored on previous version).

## Verified on screen

All three flows visually verified on a real Docker Desktop deployment (local registry + stubbed release feed): happy-path one-click (swap + auto-reload + session survival), rollback drill (broken image -> upgrader exits 1 -> service restored), and the rollback banner on the progress page (server down -> back on same version -> clear error, no infinite spinner). `AbortSignal.timeout` guards every poll against hung port-forward connections.

## Docs

`docs/updates.md` (enable one-click, root-equivalent warning, pinned-tag behavior, backup location, manual recovery incl. the DB-migrated-forward case), README feature entry + config table row, commented socket-mount line in `docker-compose.yml` (new installs only).
