### PR TITLE
feat(server): drop dashboard table id columns and sort active sessions first

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -613,15 +613,16 @@ trivially reversible).
 ```ts
 html`
   <tr data-href="/dashboard/memories/${m.id}">
-    <td class="mono"><a href="/dashboard/memories/${m.id}">${shortId(m.id)}</a></td>
+    <td><a href="/dashboard/memories/${m.id}">${truncate(m.content, 100)}</a></td>
     …
   </tr>
 `;
 ```
 
-The link inside the ID column is still there for keyboard users and
-right-clickers; the `data-href` lets the whole row be clickable for
-mouse users.
+Tables don't spend a column on row ids. The row's semantic cell (title,
+content, or timestamp) hosts the one real `<a>` — kept for keyboard
+users and right-clickers — while `data-href` lets the whole row be
+clickable for mouse users.
 
 ## JS enhancements (in `templates.ts`)
 

--- a/apps/server/src/dashboard/consolidation.ts
+++ b/apps/server/src/dashboard/consolidation.ts
@@ -77,8 +77,9 @@ export function createConsolidationRouter(deps: ConsolidationDeps): Hono {
 
       return html`
         <tr data-href="/dashboard/consolidation/${r.id}">
-          <td class="mono"><a href="/dashboard/consolidation/${r.id}">${shortId(r.id)}</a></td>
-          <td class="muted">${formatTs(r.startedAt)}</td>
+          <td class="muted">
+            <a href="/dashboard/consolidation/${r.id}">${formatTs(r.startedAt)}</a>
+          </td>
           <td class="muted">${formatTs(r.finishedAt)}</td>
           <td>${r.scope ?? '—'}</td>
           <td>${r.llmModel ?? '—'}</td>
@@ -105,7 +106,6 @@ export function createConsolidationRouter(deps: ConsolidationDeps): Hono {
               <table>
                 <thead>
                   <tr>
-                    <th>id</th>
                     <th>started</th>
                     <th>finished</th>
                     <th>scope</th>
@@ -180,7 +180,6 @@ export function createConsolidationRouter(deps: ConsolidationDeps): Hono {
             `;
       return html`
         <tr>
-          <td class="mono">${shortId(op.id)}</td>
           <td><span class="pill ${pillTone}">${op.opType}</span></td>
           <td class="mono small">
             ${op.affectedIds.map((m) =>
@@ -258,7 +257,6 @@ export function createConsolidationRouter(deps: ConsolidationDeps): Hono {
               <table>
                 <thead>
                   <tr>
-                    <th>id</th>
                     <th>type</th>
                     <th>affected</th>
                     <th>created</th>

--- a/apps/server/src/dashboard/judgments.ts
+++ b/apps/server/src/dashboard/judgments.ts
@@ -128,7 +128,7 @@ export function createJudgmentsRouter(deps: JudgmentsDeps): Hono {
     const tableBody =
       visible.length === 0
         ? html`<tr>
-            <td colspan="7" class="muted">No judgments match this filter.</td>
+            <td colspan="6" class="muted">No judgments match this filter.</td>
           </tr>`
         : visible.map((r) => {
             const orphanForm =
@@ -148,10 +148,7 @@ export function createJudgmentsRouter(deps: JudgmentsDeps): Hono {
                   `
                 : raw('<span class="muted small">—</span>');
             return html`
-              <tr>
-                <td class="mono small">
-                  <a href="/dashboard/judgments/${r.id}">${shortId(r.id)}</a>
-                </td>
+              <tr data-href="/dashboard/judgments/${r.id}">
                 <td>${statusPill(r.status)}</td>
                 <td>${verdictPill(r.relation)}</td>
                 <td class="small">
@@ -160,7 +157,9 @@ export function createJudgmentsRouter(deps: JudgmentsDeps): Hono {
                   <a href="/dashboard/memories/${r.target_id}">${truncate(r.target_content, 60)}</a>
                 </td>
                 <td class="small">${r.marked_by_actor ?? raw('<span class="muted">—</span>')}</td>
-                <td class="muted">${formatTs(new Date(r.created_at))}</td>
+                <td class="muted">
+                  <a href="/dashboard/judgments/${r.id}">${formatTs(new Date(r.created_at))}</a>
+                </td>
                 <td>${orphanForm}</td>
               </tr>
             `;
@@ -178,7 +177,6 @@ export function createJudgmentsRouter(deps: JudgmentsDeps): Hono {
         <table>
           <thead>
             <tr>
-              <th>id</th>
               <th>status</th>
               <th>verdict</th>
               <th>source → target</th>

--- a/apps/server/src/dashboard/memories.ts
+++ b/apps/server/src/dashboard/memories.ts
@@ -105,11 +105,10 @@ export function createMemoriesRouter(deps: MemoriesDeps): Hono {
         : '—';
       return html`
         <tr data-href="/dashboard/memories/${m.id}">
-          <td class="mono"><a href="/dashboard/memories/${m.id}">${shortId(m.id)}</a></td>
           <td>${scopePill(m.scope)}</td>
           <td>${projectLabel}</td>
           <td>${m.type}</td>
-          <td>${truncate(m.content, 100)}</td>
+          <td><a href="/dashboard/memories/${m.id}">${truncate(m.content, 100)}</a></td>
           <td>${statusPill(m.status)}</td>
           <td class="muted">${formatTs(m.createdAt)}</td>
         </tr>
@@ -190,7 +189,6 @@ export function createMemoriesRouter(deps: MemoriesDeps): Hono {
         <table>
           <thead>
             <tr>
-              <th>id</th>
               <th>scope</th>
               <th>project</th>
               <th>type</th>
@@ -202,7 +200,7 @@ export function createMemoriesRouter(deps: MemoriesDeps): Hono {
           <tbody>
             ${visible.length === 0
               ? html`<tr>
-                  <td colspan="7" class="muted">No memories match this filter.</td>
+                  <td colspan="6" class="muted">No memories match this filter.</td>
                 </tr>`
               : rowsHtml}
           </tbody>
@@ -279,7 +277,6 @@ export function createMemoriesRouter(deps: MemoriesDeps): Hono {
               <table>
                 <thead>
                   <tr>
-                    <th>id</th>
                     <th>status</th>
                     <th>content</th>
                     <th>created</th>
@@ -289,11 +286,10 @@ export function createMemoriesRouter(deps: MemoriesDeps): Hono {
                   ${predecessors.map(
                     (p) => html`
                       <tr data-href="/dashboard/memories/${p.id}">
-                        <td class="mono">
-                          <a href="/dashboard/memories/${p.id}">${shortId(p.id)}</a>
-                        </td>
                         <td>${statusPill(p.status)}</td>
-                        <td>${truncate(p.content, 120)}</td>
+                        <td>
+                          <a href="/dashboard/memories/${p.id}">${truncate(p.content, 120)}</a>
+                        </td>
                         <td class="muted">${formatTs(p.createdAt)}</td>
                       </tr>
                     `,

--- a/apps/server/src/dashboard/projects.ts
+++ b/apps/server/src/dashboard/projects.ts
@@ -7,7 +7,7 @@ import type { SessionsService } from '../services/sessions.js';
 import { viewHead } from './components.js';
 import { readFormAndVerifyCsrf, csrfInput } from './csrf.js';
 import { renderPage } from './page-shell.js';
-import { formatTs, html, raw, shortId } from './templates.js';
+import { formatTs, html, raw } from './templates.js';
 import type { ResolvedSession } from './types.js';
 
 export interface ProjectsDeps {
@@ -47,7 +47,6 @@ export function createProjectsRouter(deps: ProjectsDeps): Hono {
           <td class="mono">
             ${p.slug} ${isLegacy ? raw(' <span class="pill superseded">legacy</span>') : raw('')}
           </td>
-          <td class="muted small">${shortId(p.id)}</td>
           <td class="muted">${formatTs(p.createdAt)}</td>
           <td class="project-actions">
             <form action="/dashboard/projects/${p.id}/rename" method="post" class="rename-form">
@@ -129,7 +128,6 @@ export function createProjectsRouter(deps: ProjectsDeps): Hono {
                   <tr>
                     <th>name</th>
                     <th>slug</th>
-                    <th>id</th>
                     <th>created</th>
                     <th>actions</th>
                   </tr>
@@ -150,7 +148,6 @@ export function createProjectsRouter(deps: ProjectsDeps): Hono {
                   <tr>
                     <th>name</th>
                     <th>slug</th>
-                    <th>id</th>
                     <th>created</th>
                     <th>actions</th>
                   </tr>

--- a/apps/server/src/dashboard/prompts.ts
+++ b/apps/server/src/dashboard/prompts.ts
@@ -186,7 +186,6 @@ export function createPromptsRouter(deps: PromptsDeps): Hono {
           `;
       return html`
         <tr>
-          <td class="mono">${shortId(p.id)}</td>
           <td>${titleCell}</td>
           <td>${projectLabel}</td>
           <td>${sessionCell}</td>
@@ -255,7 +254,6 @@ export function createPromptsRouter(deps: PromptsDeps): Hono {
               <table>
                 <thead>
                   <tr>
-                    <th>id</th>
                     <th>title</th>
                     <th>project</th>
                     <th>session</th>

--- a/apps/server/src/dashboard/sessions.ts
+++ b/apps/server/src/dashboard/sessions.ts
@@ -42,7 +42,7 @@ export function createSessionsRouter(deps: SessionsDeps): Hono {
     const page = Math.max(0, parseInt(url.searchParams.get('page') ?? '0', 10) || 0);
     const offset = page * PAGE_SIZE;
 
-    const baseQuery = () =>
+    const baseQuery = (opts: { activeFirst: boolean }) =>
       deps.db
         .select({
           id: agentSessions.id,
@@ -61,15 +61,22 @@ export function createSessionsRouter(deps: SessionsDeps): Hono {
         .from(agentSessions)
         .leftJoin(tokens, eq(tokens.id, agentSessions.tokenId))
         .leftJoin(projects, eq(projects.id, agentSessions.projectId))
-        .orderBy(desc(agentSessions.startedAt))
+        .orderBy(
+          ...(opts.activeFirst
+            ? [sql`CASE WHEN ${agentSessions.status} = 'active' THEN 0 ELSE 1 END`]
+            : []),
+          desc(agentSessions.startedAt),
+        )
         .limit(PAGE_SIZE + 1)
         .offset(offset);
 
-    const visibleRowsRaw = baseQuery().where(isNull(agentSessions.deletedAt)).all();
+    const visibleRowsRaw = baseQuery({ activeFirst: true })
+      .where(isNull(agentSessions.deletedAt))
+      .all();
     const visibleHasMore = visibleRowsRaw.length > PAGE_SIZE;
     const visibleRows = visibleRowsRaw.slice(0, PAGE_SIZE);
     const deletedRowsRaw = includeDeleted
-      ? baseQuery().where(isNotNull(agentSessions.deletedAt)).all()
+      ? baseQuery({ activeFirst: false }).where(isNotNull(agentSessions.deletedAt)).all()
       : [];
     const deletedHasMore = deletedRowsRaw.length > PAGE_SIZE;
     const deletedRows = deletedRowsRaw.slice(0, PAGE_SIZE);
@@ -107,9 +114,6 @@ export function createSessionsRouter(deps: SessionsDeps): Hono {
         <tr data-href="/dashboard/sessions/${r.id}">
           <td class="rbr-session-title" title="${displayTitle}">
             <a href="/dashboard/sessions/${r.id}">${displayTitle}</a>
-          </td>
-          <td class="mono">
-            <a href="/dashboard/sessions/${r.id}">${shortId(r.id)}</a>
           </td>
           <td>${r.agent}</td>
           <td>${r.projectSlug ? raw(`<code>${r.projectSlug}</code>`) : scopePill('global')}</td>
@@ -209,7 +213,6 @@ export function createSessionsRouter(deps: SessionsDeps): Hono {
                 <thead>
                   <tr>
                     <th>title</th>
-                    <th>id</th>
                     <th>agent</th>
                     <th>project</th>
                     <th>token</th>
@@ -235,7 +238,6 @@ export function createSessionsRouter(deps: SessionsDeps): Hono {
                 <thead>
                   <tr>
                     <th>title</th>
-                    <th>id</th>
                     <th>agent</th>
                     <th>project</th>
                     <th>token</th>
@@ -421,7 +423,6 @@ export function createSessionsRouter(deps: SessionsDeps): Hono {
               <table>
                 <thead>
                   <tr>
-                    <th>id</th>
                     <th>type</th>
                     <th>content</th>
                     <th>status</th>
@@ -432,11 +433,10 @@ export function createSessionsRouter(deps: SessionsDeps): Hono {
                   ${memories.map(
                     (m) => html`
                       <tr data-href="/dashboard/memories/${m.id}">
-                        <td class="mono">
-                          <a href="/dashboard/memories/${m.id}">${shortId(m.id)}</a>
-                        </td>
                         <td>${m.type}</td>
-                        <td>${truncate(m.content, 120)}</td>
+                        <td>
+                          <a href="/dashboard/memories/${m.id}">${truncate(m.content, 120)}</a>
+                        </td>
                         <td>${statusPill(m.status)}</td>
                         <td class="muted">${formatTs(m.createdAt)}</td>
                       </tr>
@@ -455,7 +455,6 @@ export function createSessionsRouter(deps: SessionsDeps): Hono {
               <table>
                 <thead>
                   <tr>
-                    <th>id</th>
                     <th>title</th>
                     <th>content</th>
                     <th>tags</th>
@@ -466,7 +465,6 @@ export function createSessionsRouter(deps: SessionsDeps): Hono {
                   ${sessionPrompts.map(
                     (p) => html`
                       <tr>
-                        <td class="mono">${shortId(p.id)}</td>
                         <td>${p.title ?? '—'}</td>
                         <td>${truncate(p.content, 120)}</td>
                         <td>

--- a/apps/server/src/dashboard/styles/core/content.css
+++ b/apps/server/src/dashboard/styles/core/content.css
@@ -221,7 +221,7 @@
 .main tbody tr[data-href] {
   cursor: pointer;
 }
-/* links inside tables render in lime so the ID column feels clickable */
+/* links inside tables render in lime so the row's navigable cell reads as such */
 .main table a {
   color: var(--lime);
 }

--- a/apps/server/src/test/dashboard-e2e.test.ts
+++ b/apps/server/src/test/dashboard-e2e.test.ts
@@ -246,6 +246,39 @@ describe('dashboard E2E', () => {
     expect(body).toContain('Sessions');
   });
 
+  it('sessions list sorts active rows above ended ones regardless of age', async () => {
+    const jar: CookieJar = { cookie: null };
+    await postForm(baseUrl, '/dashboard/login', jar, { token: ADMIN_TOKEN });
+
+    const { createDb } = await import('../db/index.js');
+    const { ProjectsService } = await import('../services/projects.js');
+    const { AgentSessionsService } = await import('../services/agent-sessions.js');
+    const { tokens: tokensSchema } = await import('../db/schema/tokens.js');
+    const { eq } = await import('drizzle-orm');
+    const dataDir = server.config.dataDir;
+    const handle = createDb({ dataDir });
+    const admin = handle.db.select().from(tokensSchema).where(eq(tokensSchema.name, 'admin')).get();
+    const proj = new ProjectsService(handle.db).create({ slug: 'e2e-order-proj' });
+    const agentSessions = new AgentSessionsService(handle.db);
+    // Older active session first, then a newer session that ends — plain
+    // started_at DESC would render the ended one on top.
+    const activeOld = agentSessions.start({ tokenId: admin!.id, projectId: proj.id, agent: 'e2e' });
+    await new Promise((r) => setTimeout(r, 10));
+    const endedNew = agentSessions.start({ tokenId: admin!.id, projectId: proj.id, agent: 'e2e' });
+    agentSessions.end(endedNew.id, { tokenId: admin!.id });
+    handle.close();
+
+    const list = await get(baseUrl, '/dashboard/sessions', jar);
+    expect(list.status).toBe(200);
+    const body = await list.text();
+    expect(body).not.toContain('<th>id</th>');
+    const activeIdx = body.indexOf(`data-href="/dashboard/sessions/${activeOld.id}"`);
+    const endedIdx = body.indexOf(`data-href="/dashboard/sessions/${endedNew.id}"`);
+    expect(activeIdx).toBeGreaterThan(-1);
+    expect(endedIdx).toBeGreaterThan(-1);
+    expect(activeIdx).toBeLessThan(endedIdx);
+  });
+
   it('sessions detail 404 for unknown id', async () => {
     const jar: CookieJar = { cookie: null };
     await postForm(baseUrl, '/dashboard/login', jar, { token: ADMIN_TOKEN });
@@ -540,7 +573,8 @@ describe('dashboard E2E', () => {
     // Same seed appears on /dashboard/judgments: source → target column
     // shows truncated content as memory-detail links, not bare short ids;
     // the verdict cell uses the shared verdictPill helper (k-supersedes);
-    // the leftmost id column is a link to the detail page.
+    // rows are whole-row clickable (data-href) with the real detail anchor
+    // on the created cell — no id column.
     const list = await get(baseUrl, '/dashboard/judgments', jar);
     expect(list.status).toBe(200);
     const listBody = await list.text();
@@ -549,7 +583,9 @@ describe('dashboard E2E', () => {
     expect(listBody).toContain(`href="/dashboard/memories/${a.id}"`);
     expect(listBody).toContain(`href="/dashboard/memories/${b.id}"`);
     expect(listBody).toContain('pill k-supersedes');
-    expect(listBody).toContain(`href="/dashboard/judgments/${rel.id}"`);
+    expect(listBody).toContain(`data-href="/dashboard/judgments/${rel.id}"`);
+    expect(listBody).toContain(`<a href="/dashboard/judgments/${rel.id}">`);
+    expect(listBody).not.toContain('<th>id</th>');
 
     // Judgment detail view: renders full content for both sides, the verdict
     // pill, reason text, back-link, and resolves 404 for unknown ids.

--- a/openspec/changes/archive/2026-06-07-declutter-table-id-columns/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-07-declutter-table-id-columns/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/archive/2026-06-07-declutter-table-id-columns/design.md
+++ b/openspec/changes/archive/2026-06-07-declutter-table-id-columns/design.md
@@ -1,0 +1,105 @@
+# Design — declutter-table-id-columns
+
+## Context
+
+Dashboard tables render a `shortId(...)` column that exists for one historical reason: it was the cell carrying the real `<a>` to the row's detail page (see the comment at `styles/core/content.css` — "links inside tables render in lime so the ID column feels clickable"). Whole-row navigation was later added via the `ROW_LINK` inline script (`templates.ts`): any `<tr data-href>` navigates on click, bailing out when the click lands on an interactive element (a, button, input, select, textarea, label, form).
+
+The result today is two navigation mechanisms stacked on top of each other, with the id column serving as the anchor host even where another cell (session title) already carries an identical link. Tables that never had a detail page (projects, prompts, ops) render the id as plain text — pure noise.
+
+Current inventory:
+
+| Table                             | `data-href` | id cell role                          |
+| --------------------------------- | ----------- | ------------------------------------- |
+| Sessions list (visible + deleted) | yes         | redundant link (title cell links too) |
+| Memories list                     | yes         | only real `<a>` in row                |
+| Consolidation runs                | yes         | only real `<a>` in row                |
+| Session detail → Memories         | yes         | only real `<a>` in row                |
+| Memory detail → Predecessors      | yes         | only real `<a>` in row                |
+| Judgments list                    | **no**      | only path to detail page              |
+| Projects (active + archived)      | no          | plain text, no detail page            |
+| Prompts list                      | no          | plain text, no detail page            |
+| Session detail → Prompts          | no          | plain text, no detail page            |
+| Run detail → Ops                  | no          | plain text, no detail page            |
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Remove the id column from all ten tables.
+- Preserve exactly one real `<a href>` per whole-row-clickable row (cmd-click, middle-click, keyboard, a11y).
+- Make judgments rows whole-row clickable, consistent with the other navigable lists.
+- Update the four dashboard spec requirements that mandate id columns.
+
+**Non-Goals:**
+
+- No change to the `ROW_LINK` script, the `data-confirm` modal, or any design token.
+- No change to memory shortId links inside consolidation op cells (`affected` / `created`) — those are functional cross-navigation, not row identity.
+- No detail pages for prompts, projects, or ops.
+- No change to `shortId()` itself — it remains used in page titles (`Memory {shortId}`), viewHead headings, and op cells.
+
+## Decisions
+
+### D1 — Every clickable row keeps one real `<a>`, hosted on the row's semantic cell
+
+`data-href` is JS-only (`window.location.href`); without a real anchor the row loses open-in-new-tab, middle-click, keyboard focus, and link semantics. The anchor relocates to the cell an operator naturally reads as the row's identity:
+
+| Table                        | Anchor host after change                                                          |
+| ---------------------------- | --------------------------------------------------------------------------------- |
+| Sessions list                | `title` cell (already the anchor — id column simply dropped)                      |
+| Memories list                | `content` cell (truncated content wraps in `<a href="/dashboard/memories/{id}">`) |
+| Session detail → Memories    | `content` cell                                                                    |
+| Memory detail → Predecessors | `content` cell                                                                    |
+| Consolidation runs           | `started` cell (the `<a>` wraps the `formatTs(...)` `<time>` output)              |
+| Judgments list               | `created` cell (see D2)                                                           |
+
+Alternatives considered:
+
+- _Rely on `data-href` alone, no anchor_ — rejected: breaks cmd-click/middle-click/keyboard and screen-reader link semantics.
+- _Wrap the `<tr>` in an `<a>`_ — rejected: invalid HTML (anchors cannot wrap table rows).
+- _Keep a narrow id column as link-host_ — rejected: that is the noise this change removes.
+
+Content-cell anchors render lime via the existing `.main table a` rule — same treatment the judgments `source → target` cells and session titles already use. No new CSS.
+
+### D2 — Judgments rows get `data-href`; the detail anchor lives on the `created` cell (option B)
+
+Judgments is the only navigable list whose rows are not clickable; the id cell is the sole path to `/dashboard/judgments/:id`. The row gains `data-href="/dashboard/judgments/{id}"` and the id column is removed.
+
+The anchor cannot live on `source → target` (already occupied by two memory anchors) and should not wrap the status/verdict pills (pills read as state badges, and lime link styling fights the pill styling). The `created` timestamp cell is the only non-interactive cell left, so the real `<a>` wraps the `formatTs(...)` output there — mirroring the consolidation-runs treatment in D1.
+
+The `ROW_LINK` bail-out keeps the memory anchors and the `Mark orphaned` form fully functional inside a clickable row (identical to how sessions rows host Delete/Abandon forms today).
+
+Alternative considered: _keep judgments as-is (option A, id column stays)_ — rejected by the operator: inconsistent with every other navigable list, and `source → target` is the cell that most benefits from the recovered width.
+
+### D3 — Tables without detail pages just drop the column
+
+Projects, prompts list, session-detail prompts, and the ops table render ids as plain text. Removal with no compensation: actions already carry the full id in their form `action` URLs, and ops cross-link memories through `affected` / `created`. Empty-state `colspan` values decrement accordingly (judgments 7→6; others where present).
+
+### D4 — Sessions list sorts active-first via a SQL `CASE` expression
+
+The list query (`sessions.ts` — `orderBy(desc(agentSessions.startedAt))`) gains a leading sort key: `CASE WHEN status = 'active' THEN 0 ELSE 1 END`, keeping `started_at DESC` as the secondary key. Active sessions are the rows an operator acts on (Abandon, watch progress); burying them under ended ones once history grows defeats the list.
+
+Alternatives considered:
+
+- _Sort in JS after fetch_ — rejected: pagination is SQL-side (`LIMIT`/`OFFSET`); a JS sort would only reorder within the fetched page, so an active session on page 2 would still hide behind page 1's ended rows.
+- _Separate "Active" table above the main list_ (like projects' active/archived split) — rejected: heavier change, duplicates headers, and active sessions are usually few; a sort suffices.
+
+The deleted-rows table (under `?include_deleted=1`) keeps plain `started_at DESC` — soft-deleted rows are an audit view, not a work queue.
+
+### D5 — Spec deltas modify the existing `dashboard` capability; no new capability
+
+Four requirements change (sessions list columns + ordering, prompts list columns, session-detail prompts columns, judgments queue + its id-anchor scenario). Per project convention, each delta carries the full updated requirement text so the archive sync resolves cleanly. The memories, consolidation, and projects requirements do not enumerate columns, so no delta is needed for them.
+
+## Risks / Trade-offs
+
+- [Risk] Operators occasionally copy ids from list views (e.g. to query the DB or hit admin endpoints) → Mitigation: every detail page keeps the full/short id in its heading (`Memory {shortId}`, `Run {shortId}`, `Judgment {shortId}`), and list rows still expose the id in the anchor `href`. One extra click for a rare workflow.
+- [Risk] `dashboard-e2e.test.ts` asserts an exact multiline anchor snippet for the judgments id link (line ~533) and the spec scenario "Judgments list id column links to the detail page" → Mitigation: both are updated in the same change; the looser assertions (`href="/dashboard/judgments/{id}"` present in list body) survive unchanged because the anchor relocates rather than disappears.
+- [Trade-off] Timestamp cells in runs/judgments become lime links, slightly louder than the muted grey they render today → Accepted because it is the existing visual grammar for "this navigates" (`.main table a`), and it replaces a whole dead column.
+- [Trade-off] Rows without `title`/`content` worth reading (e.g. a memory with very short content) lose the always-uniform-width id anchor → Accepted because content is never empty for these rows and `data-href` covers the whole row anyway.
+
+## Migration Plan
+
+Presentation-only; no DB, API, or plugin changes. Ships in one PR: templates + CSS comment + spec deltas + test updates. Rollback = revert the commit.
+
+## Open Questions
+
+(none)

--- a/openspec/changes/archive/2026-06-07-declutter-table-id-columns/proposal.md
+++ b/openspec/changes/archive/2026-06-07-declutter-table-id-columns/proposal.md
@@ -1,0 +1,48 @@
+# Declutter table id columns
+
+## Why
+
+Dashboard tables spend a column on `shortId(...)` values that carry no operator-readable information: rows already navigate via `data-href` (or could), and the id duplicates a link that belongs on the semantic cell (title, content, timestamp). Removing the dead id columns recovers horizontal space for the cells operators actually read (memory content, judgment `source → target`, prompt title/content) and reduces visual noise across every list view.
+
+## What Changes
+
+- Remove the `id` column from ten dashboard tables:
+  - Sessions list (`sessions.ts` — title cell already carries the anchor)
+  - Memories list (`memories.ts` — anchor moves to the content cell)
+  - Consolidation runs list (`consolidation.ts` — anchor moves to the `started` cell)
+  - Session detail → Memories table (anchor moves to content cell)
+  - Memory detail → Predecessors table (anchor moves to content cell)
+  - Judgments list (`judgments.ts` — see below)
+  - Projects list, active + archived tables (id was never a link; pure noise)
+  - Prompts list (no detail page exists; id was plain text)
+  - Session detail → Prompts table (same)
+  - Consolidation run detail → Ops table (op id is plain text; ops have no detail page). The `affected` / `created` cells keep their memory shortId links — those are functional navigation, out of scope here.
+- Make judgments list rows whole-row clickable (`data-href="/dashboard/judgments/{id}"`), consistent with sessions/memories/consolidation. The real `<a>` to the judgment detail relocates from the removed `id` cell to the `created` timestamp cell. The existing `ROW_LINK` interactive-element bail-out keeps the memory anchors in `source → target` and the `Mark orphaned` form working.
+- Every whole-row-clickable table keeps exactly one real `<a href>` to the row's detail page (cmd-click / middle-click / keyboard navigation preserved).
+- Sessions list ordering changes: rows with `status = 'active'` sort first, then everything else; within each group the existing `started_at DESC` order is kept. The ordering stays SQL-side so pagination remains correct.
+- Update the stale CSS comment in `styles/core/content.css` ("…so the ID column feels clickable").
+- Adjust empty-state `colspan` values and any tests asserting the removed `<th>`/cells.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `dashboard`: column contracts change in four requirements — sessions list (drop "session id (short form)" column; title no longer "left of session id"; ordering becomes active-first then `started_at DESC`), prompts list (drop "short prompt id" column), session detail prompts section (drop "short prompt id" column), judgments queue (drop leftmost `id` column, rows become `data-href`-clickable, detail anchor moves to the `created` cell; the "Judgments list id column links to the detail page" scenario is replaced accordingly).
+
+## Impact
+
+- `apps/server/src/dashboard/sessions.ts` — list table (×2: visible + deleted), detail memories table, detail prompts table
+- `apps/server/src/dashboard/memories.ts` — list table, predecessors table
+- `apps/server/src/dashboard/judgments.ts` — list table (row `data-href`, anchor relocation, `colspan` 7→6)
+- `apps/server/src/dashboard/projects.ts` — active + archived tables
+- `apps/server/src/dashboard/prompts.ts` — list table
+- `apps/server/src/dashboard/consolidation.ts` — runs list, ops table
+- `apps/server/src/dashboard/styles/core/content.css` — stale comment
+- `openspec/specs/dashboard/spec.md` — four requirement deltas (above)
+- Tests touching these templates (e.g. any asserting `<th>id</th>`, `colspan`, or the judgments id-anchor scenario)
+
+No DB, MCP, HTTP-API, or plugin surface changes. No load-bearing invariants touched — presentation-only within the dashboard layer; the locked design tokens (brutalist theme, lime accent, fonts) are unchanged.

--- a/openspec/changes/archive/2026-06-07-declutter-table-id-columns/specs/dashboard/spec.md
+++ b/openspec/changes/archive/2026-06-07-declutter-table-id-columns/specs/dashboard/spec.md
@@ -1,0 +1,253 @@
+# Dashboard delta — declutter-table-id-columns
+
+## ADDED Requirements
+
+### Requirement: List tables MUST NOT spend a column on row ids
+
+Dashboard list tables SHALL NOT render a dedicated `id` column. Row identity is carried by the row's semantic cell (title, content, or timestamp), and navigation to a detail page — where one exists — is provided by whole-row `data-href` plus exactly one real `<a href>` anchor hosted on that semantic cell, so cmd-click / middle-click / keyboard navigation keep working.
+
+Concretely:
+
+- Sessions list: the `title` cell carries the anchor to `/dashboard/sessions/{id}` (rows keep `data-href`).
+- Memories list, session detail → Memories, memory detail → Predecessors: the `content` cell carries the anchor to `/dashboard/memories/{id}` (rows keep `data-href`).
+- Consolidation runs list: the `started` cell carries the anchor to `/dashboard/consolidation/{id}` (rows keep `data-href`).
+- Judgments list: the `created` cell carries the anchor to `/dashboard/judgments/{id}` (rows gain `data-href`).
+- Projects (active + archived), prompts list, session detail → Prompts, consolidation run detail → Ops: the id column is removed with no replacement anchor — these rows have no detail page. Memory shortId anchors inside the ops table's `affected` / `created` cells are retained: they are cross-navigation, not row identity.
+
+`shortId(...)` rendering remains in use outside list-table columns (detail-page headings such as `Rembric Memory {shortId}.`, ops `affected`/`created` cells, prompt session links).
+
+#### Scenario: A navigable list row keeps exactly one real anchor
+
+- **WHEN** an authenticated operator renders any list whose rows have a detail page (sessions, memories, consolidation runs, judgments, predecessors, session-detail memories)
+- **THEN** each row SHALL carry `data-href` pointing at its detail URL
+- **AND** each row SHALL contain exactly one `<a>` anchor pointing at that same detail URL, hosted on the row's semantic cell
+- **AND** no `<th>` labelled `id` SHALL be present in the table header
+
+#### Scenario: Tables without detail pages drop the id column with no replacement
+
+- **WHEN** an authenticated operator renders the projects, prompts, session-detail prompts, or run-detail ops tables
+- **THEN** no `<th>` labelled `id` SHALL be present and no cell SHALL render the row's own short id
+- **AND** row action forms SHALL keep functioning (they carry the full id in their `action` URLs)
+
+## MODIFIED Requirements
+
+### Requirement: The dashboard MUST surface a sessions list view at `/dashboard/sessions`
+
+A logged-in dashboard user SHALL see a list of recent sessions for the active project (or globally when no project is selected). The list SHALL include columns for title, agent, started_at, ended_at, status, a memory count (number of `memory` rows with that `session_id`), and a prompt count (number of `prompts` rows with that `session_id` AND `deleted_at IS NULL`). The list SHALL NOT include a session id column; the `title` cell carries the row's anchor to `/dashboard/sessions/:id`.
+
+The list SHALL be ordered with `status = 'active'` rows first, then all remaining rows; within each group rows SHALL be ordered by `started_at DESC`. The ordering SHALL be applied in the SQL query (before `LIMIT`/`OFFSET`) so pagination respects it. The soft-deleted table shown under `?include_deleted=1` keeps plain `started_at DESC`.
+
+The `title` column SHALL render using the cascade `row.title ?? row.description ?? shortId(row.id)`. The cascade SHALL NOT short-circuit on placeholder titles (e.g. `'rembric · 22:14 UTC'`) — those count as real titles for the purpose of display, because they are still more informative than `shortId` alone. The cascade ensures legacy rows (where `title` is NULL because they predate the column migration) still get a sensible value.
+
+The title column SHALL be the first visible content column and SHALL truncate with `text-overflow: ellipsis` past ~40 chars to keep the table compact. The full title SHALL be available as the cell's `title` attribute (HTML tooltip) so operators can hover to see the full string.
+
+The memory count and the prompt count SHALL be rendered as two separate right-aligned columns (`memories`, `prompts`). The detail view at `/dashboard/sessions/:id` SHALL render BOTH a `Memories (N)` and a `Prompts (N)` table — memories first, prompts below.
+
+#### Scenario: A dashboard user navigates to `/dashboard/sessions`
+
+- **WHEN** the user is authenticated with an admin token and visits `/dashboard/sessions`
+- **THEN** the server SHALL return a paginated list of 50 sessions ordered active-first then `started_at DESC`, with each row linking to `/dashboard/sessions/:id` via `data-href` and via the `title` cell's anchor
+- **AND** each row SHALL include a `title` column rendered via the documented cascade
+- **AND** each row SHALL include both a `memories` count column and a `prompts` count column
+- **AND** the table header SHALL NOT contain a `<th>` labelled `id`
+
+#### Scenario: Active sessions sort above ended ones regardless of age
+
+- **GIVEN** an active session `A` started three days ago and an ended session `E` started one hour ago
+- **WHEN** the operator navigates to `/dashboard/sessions`
+- **THEN** `A`'s row SHALL appear before `E`'s row
+- **AND** two active sessions SHALL order between themselves by `started_at DESC`
+
+#### Scenario: Session with a model-authored title
+
+- **GIVEN** a session whose `sessions.title = 'Fix Stop→SessionEnd bug'`
+- **WHEN** the list view renders that row
+- **THEN** the title cell SHALL display `'Fix Stop→SessionEnd bug'` (truncated with ellipsis past ~40 chars; full string in `title` attribute)
+
+#### Scenario: Legacy session with no title
+
+- **GIVEN** a session predating the `title` column migration, with `sessions.title = NULL` and `description = NULL`
+- **WHEN** the list view renders that row
+- **THEN** the title cell SHALL fall back to `shortId(row.id)`
+
+#### Scenario: Session with description but no title
+
+- **GIVEN** a session with `title = NULL` and `description = 'investigate auth bug'`
+- **WHEN** the list view renders that row
+- **THEN** the title cell SHALL display `'investigate auth bug'`
+
+#### Scenario: A dashboard user opens a session detail page
+
+- **WHEN** the user navigates to `/dashboard/sessions/:id` for an accessible session
+- **THEN** the page SHALL display: the title as the `<h1>` (via the same cascade as the list view), the session metadata (agent, project, token name, started_at, ended_at, status), the verbatim `summary` text, a table of memories whose `session_id` matches, AND a table of prompts whose `session_id` matches AND `deleted_at IS NULL` rendered below the memories table
+
+#### Scenario: A session was created by a now-revoked token
+
+- **WHEN** the underlying token has been revoked but the session row still exists
+- **THEN** the detail page SHALL still render and SHALL show the token name with a "(revoked)" suffix; the session SHALL not be hidden from the list
+
+#### Scenario: Prompts count column reflects non-deleted prompts only
+
+- **GIVEN** session `S` has 5 prompts: 3 with `deleted_at IS NULL` and 2 with `deleted_at IS NOT NULL`
+- **WHEN** the list view renders `S`'s row
+- **THEN** the `prompts` column SHALL display `3`
+
+### Requirement: The judgment-queue view MUST be served at `/dashboard/judgments`
+
+The dashboard SHALL serve the operator-facing queue of memory-relation judgments at the URL `/dashboard/judgments`. The page SHALL list every row of `memory_relations` (status `pending`, `judged`, or `orphaned`), SHALL support filtering by status and verdict kind, and SHALL paginate results. The legacy path `/dashboard/relations` SHALL NOT respond; any request to it SHALL return the standard dashboard `404` body.
+
+The page heading SHALL read `Rembric Judgments.` (with `Rembric` highlighted via `hl-lime`), the document `<title>` SHALL read `Judgments · Rembric`, the empty-state cell SHALL read `No judgments match this filter.`, the table column previously labelled `relation` SHALL be labelled `verdict`, and the orphan-not-found flash SHALL read `Judgment not found or already closed.`.
+
+The list SHALL NOT render an `id` column. Each row SHALL carry `data-href="/dashboard/judgments/{id}"` (whole-row click navigation, consistent with the sessions/memories/consolidation lists), and the `created` cell SHALL contain the row's real `<a href="/dashboard/judgments/{id}">` anchor wrapping the `formatTs(created_at)` output. The whole-row click handler's interactive-element bail-out keeps the memory anchors in `source → target` and the `Mark orphaned` form working inside the clickable row.
+
+The `source → target` column SHALL render each side as an `<a href="/dashboard/memories/{id}">` anchor whose visible text is the corresponding memory's `content` truncated to 60 characters (not the memory's short id). The two anchors SHALL be separated by the `→` arrow as before.
+
+The `verdict` column SHALL render via the shared `verdictPill(relation)` helper. When `relation` is non-null the cell SHALL contain a `<span class="pill k-{relation}">{relation}</span>` element (matching the home overview's `RECENT JUDGMENTS` tile). When `relation` is null (pending or orphaned rows) the cell SHALL contain the muted em-dash `<span class="muted">—</span>`. No inline `pill k-…` HTML SHALL exist in the judgments page template.
+
+#### Scenario: Operator opens the judgment queue
+
+- **WHEN** an authenticated operator navigates to `/dashboard/judgments`
+- **THEN** the server SHALL return a `200` HTML response whose heading reads `Rembric Judgments.` and whose table column header for the relation kind reads `verdict`
+- **AND** the table header SHALL NOT contain a `<th>` labelled `id`
+
+#### Scenario: Judgment rows are whole-row clickable
+
+- **WHEN** an authenticated operator navigates to `/dashboard/judgments` with at least one row present
+- **THEN** each row SHALL carry `data-href="/dashboard/judgments/{id}"` where `{id}` is that row's `memory_relations.id`
+- **AND** the row's `created` cell SHALL contain an `<a href="/dashboard/judgments/{id}">` anchor wrapping the rendered timestamp
+
+#### Scenario: Legacy `/dashboard/relations` returns 404
+
+- **WHEN** any authenticated request reaches `/dashboard/relations`
+- **THEN** the server SHALL respond with `404 Not Found` (no redirect)
+
+#### Scenario: Sidebar and home links to the judgments view
+
+- **WHEN** any authenticated dashboard page is rendered
+- **THEN** the sidebar nav item labelled `JUDGMENTS` SHALL have `href="/dashboard/judgments"`
+- **AND** the home overview `RECENT JUDGMENTS` section header `OPEN ALL ›` anchor SHALL link to `/dashboard/judgments` (the unfiltered default view)
+- **AND** the home overview stat strip SHALL NOT include a `PENDING JUDGMENTS` stat card; pending counts are surfaced only via the sidebar badge on the `JUDGMENTS` nav entry
+
+#### Scenario: CSRF action token uses the judgment vocabulary
+
+- **WHEN** the operator submits the "mark this judgment as orphaned" form on the judgments page
+- **THEN** the CSRF token issued by the form and the action verified by the server SHALL both be the string `judgment.orphan`
+
+### Requirement: The dashboard MUST surface a prompts list view at `/dashboard/prompts`
+
+A logged-in dashboard user SHALL see a list of curated user prompts for the active project (or globally when no project is selected). The list SHALL include columns for title (cascade `title → content[truncated to 80 chars] → shortId`), project slug, session short id (link to session detail when present), agent, tags (comma-separated), and created_at. The list SHALL NOT include a prompt id column.
+
+The view SHALL paginate at 50 rows per page (`PAGE_SIZE` shared constant). The view SHALL support a free-text query box that submits as the `q` query parameter; when non-empty, the server-side handler SHALL use the FTS5 `prompts_fts` index (matching against `content` + `tags`). The view SHALL support filters by `project_slug`, `session_id` (shortId match), and `agent`.
+
+Each row SHALL render a `Delete` form (soft-delete, `data-confirm-tone="warn"`, action `prompt.delete`). Rows shown under `?include_deleted=1` SHALL additionally render an `Undelete` form (action `prompt.undelete`). A row whose `replaces` is not NULL AND whose `deleted_at` is not NULL SHALL render a `REFINED` badge instead of the default `DELETED` indicator — the `replaces` link encodes that the deletion was the consequence of an agent-driven refine, not an operator action.
+
+The view SHALL NOT include a detail page at `/dashboard/prompts/:id` in this revision; long contents SHALL be expandable inline via an HTMX `<details>` toggle.
+
+#### Scenario: An operator opens the prompts list
+
+- **WHEN** an authenticated admin operator navigates to `/dashboard/prompts`
+- **THEN** the server SHALL return a paginated list of the 50 most recent prompts (active and not-deleted) ordered by `created_at DESC`
+- **AND** each row SHALL include the documented columns
+- **AND** the table header SHALL NOT contain a `<th>` labelled `id`
+- **AND** each row SHALL include a `Delete` form using `data-confirm` modal attributes on the `<form>` element
+
+#### Scenario: An operator searches prompts by content
+
+- **GIVEN** prompts exist with content "deploy via Docker Compose" and "refactor the auth middleware"
+- **WHEN** the operator submits `?q=deploy` on `/dashboard/prompts`
+- **THEN** the server SHALL return only the first prompt
+- **AND** the SQL query SHALL use a `JOIN` against `prompts_fts MATCH 'deploy'`
+
+#### Scenario: An operator filters by session
+
+- **GIVEN** session `S1` has 3 prompts and session `S2` has 1 prompt
+- **WHEN** the operator submits `?session=<S1-shortId>`
+- **THEN** the response SHALL contain exactly the 3 prompts whose `session_id = S1.id`
+
+#### Scenario: Soft-deleted prompts are hidden by default
+
+- **GIVEN** prompts `P1`, `P2` exist and `P2.deleted_at IS NOT NULL`
+- **WHEN** the operator navigates to `/dashboard/prompts`
+- **THEN** the response SHALL contain `P1` and SHALL NOT contain `P2`
+
+#### Scenario: `?include_deleted=1` reveals deleted prompts with Undelete actions
+
+- **GIVEN** prompts `P1`, `P2` exist and `P2.deleted_at IS NOT NULL`
+- **WHEN** the operator navigates to `/dashboard/prompts?include_deleted=1`
+- **THEN** the response SHALL contain both prompts
+- **AND** `P2`'s row SHALL render an `Undelete` form using CSRF action `prompt.undelete`
+
+#### Scenario: A refined prompt renders a REFINED badge
+
+- **GIVEN** prompt `P1` was refined: its `deleted_at IS NOT NULL` and there exists a successor `P2` with `P2.replaces = ['<P1.id>']`
+- **WHEN** the operator navigates to `/dashboard/prompts?include_deleted=1`
+- **THEN** `P1`'s row SHALL render a `REFINED` badge (NOT the default `DELETED` indicator)
+
+#### Scenario: Delete form opens the confirmation modal
+
+- **GIVEN** an authenticated admin operator viewing the prompts list
+- **WHEN** the operator clicks the `Delete` button of a row
+- **THEN** the global `#rbr-confirm` dialog SHALL open with `data-confirm-tone="warn"` styling
+- **AND** the form SHALL submit only after the operator confirms via the dialog
+
+### Requirement: The session detail view MUST list anchored prompts below memories
+
+The view at `/dashboard/sessions/:id` SHALL render a new `Prompts (N)` section AFTER the existing `Memories (N)` section. The section SHALL list every row of `prompts` whose `session_id` equals the URL id AND `deleted_at IS NULL`, ordered by `created_at ASC`, with columns: title (cascade), content (truncated to 120 chars), tags, created_at — no prompt id column. When the session has no prompts, the section SHALL render `<p class="muted">No prompts anchored to this session.</p>` and SHALL still be emitted (so the `<h2>` is visible).
+
+#### Scenario: Session with prompts and memories renders both sections
+
+- **GIVEN** session `S` with 3 anchored memories and 2 anchored non-deleted prompts
+- **WHEN** the operator opens `/dashboard/sessions/<S.id>`
+- **THEN** the response HTML SHALL contain a `<h2>Memories (3)</h2>` section BEFORE a `<h2>Prompts (2)</h2>` section
+
+#### Scenario: Session with only memories shows an empty-state prompts section
+
+- **GIVEN** session `S` with 1 anchored memory and 0 anchored prompts
+- **WHEN** the operator opens `/dashboard/sessions/<S.id>`
+- **THEN** the response HTML SHALL contain a `<h2>Prompts (0)</h2>` section
+- **AND** the prompts area SHALL render `No prompts anchored to this session.`
+
+#### Scenario: Soft-deleted prompts are excluded from the session detail count
+
+- **GIVEN** session `S` has 3 prompts with `session_id = S.id` and one of them has `deleted_at IS NOT NULL`
+- **WHEN** the operator opens `/dashboard/sessions/<S.id>`
+- **THEN** the rendered `<h2>` SHALL read `Prompts (2)`
+- **AND** the deleted prompt SHALL NOT appear in the table
+
+### Requirement: The dashboard MUST surface a judgment detail view at `/dashboard/judgments/:id`
+
+The dashboard SHALL serve a per-row detail page at `/dashboard/judgments/:id` (where `:id` is the `memory_relations.id` primary key). The page SHALL load the judgment row alongside the source and target memory contents (JOIN over `memory` twice) and SHALL render:
+
+- A `viewHead` whose title is `Rembric Judgment {shortId}.` with `Rembric` highlighted via `hl-lime`, and whose meta strip exposes `STATUS` and `VERDICT`.
+- A `BACK TO JUDGMENTS` back-link to `/dashboard/judgments`.
+- A stat grid with six cards: Status (rendered via `statusPill`), Verdict (rendered via `verdictPill`), Confidence, Marked by (`marked_by_kind` + `marked_by_actor`), Created (`formatTs(created_at)`), Judged (`formatTs(judged_at)` or em-dash when null).
+- A `Source` section with the source memory's short id rendered as an anchor to `/dashboard/memories/{sourceId}` followed by a `<pre>` block with the full untruncated source content.
+- A `Target` section structured identically for the target memory.
+- A `Reason` section showing the verbatim `reason` text or an em-dash when null.
+- An `Evidence` section showing the `evidence` JSON pretty-printed inside a `<pre>` block, or an em-dash when null.
+- A `Judgment id` section showing the opaque `judgment_id` token in mono.
+- An `Actions` section: when `status='pending'` the section SHALL render the existing `judgment.orphan` form (CSRF-protected, `data-confirm-tone="danger"`); otherwise it SHALL render a muted "No actions available — this judgment is closed." line.
+
+When the `:id` does not match any row, the page SHALL respond with `404 Not Found` and a `Judgment not found.` flash, using the standard dashboard shell.
+
+#### Scenario: Operator opens a judgment detail page
+
+- **WHEN** an authenticated operator navigates to `/dashboard/judgments/{id}` where `id` matches an existing `memory_relations.id`
+- **THEN** the server SHALL return a `200` HTML response whose heading reads `Rembric Judgment {shortId}.`, and whose body contains the source memory's full content inside a `<pre>` block, the target memory's full content inside a `<pre>` block, anchors to both `/dashboard/memories/{sourceId}` and `/dashboard/memories/{targetId}`, and the verdict pill rendered via `verdictPill`
+
+#### Scenario: Judgment detail returns 404 for unknown ids
+
+- **WHEN** an authenticated operator navigates to `/dashboard/judgments/non-existent-id`
+- **THEN** the server SHALL respond with `404 Not Found` and the response body SHALL contain the flash text `Judgment not found.`
+
+#### Scenario: Recent-judgments tile exposes a VIEW button to the detail page
+
+- **WHEN** the home overview is rendered with at least one judged row
+- **THEN** each row SHALL contain a `.btn.primary.sm` anchor labelled `VIEW →` inside the row's `.acts` slot, whose `href` is `/dashboard/judgments/{id}` (where `{id}` is the corresponding `memory_relations.id`)
+- **AND** the verdict pill itself SHALL NOT be wrapped in an anchor (no click conflict with the memory links in the row)
+
+#### Scenario: Judgments list created cell links to the detail page
+
+- **WHEN** the operator navigates to `/dashboard/judgments` with at least one row present
+- **THEN** each row's `created` cell SHALL contain an `<a href="/dashboard/judgments/{id}">` anchor wrapping the rendered timestamp, where `{id}` is that row's `memory_relations.id`
+- **AND** the list SHALL NOT render a standalone short-id cell for the judgment's own id

--- a/openspec/changes/archive/2026-06-07-declutter-table-id-columns/tasks.md
+++ b/openspec/changes/archive/2026-06-07-declutter-table-id-columns/tasks.md
@@ -1,0 +1,43 @@
+# Tasks — declutter-table-id-columns
+
+## 1. Sessions (`apps/server/src/dashboard/sessions.ts`)
+
+- [x] 1.1 Remove the `id` column (`<th>id</th>` + the `shortId` anchor cell) from `renderRow` and from BOTH list `<thead>`s (visible + Deleted); the `title` cell anchor already covers navigation
+- [x] 1.2 Session detail → Memories table: drop the `id` column and wrap the truncated content in `<a href="/dashboard/memories/{id}">` so the row keeps one real anchor
+- [x] 1.3 Session detail → Prompts table: drop the `id` column (plain text, no replacement)
+- [x] 1.4 List query: prepend `CASE WHEN status = 'active' THEN 0 ELSE 1 END` to the `orderBy` (before `desc(startedAt)`) so active sessions sort first SQL-side; leave the deleted-rows query on plain `started_at DESC`
+
+## 2. Memories (`apps/server/src/dashboard/memories.ts`)
+
+- [x] 2.1 List table: drop the `id` column; wrap the truncated content cell in `<a href="/dashboard/memories/{id}">`; decrement the empty-state `colspan` 7→6
+- [x] 2.2 Predecessors table on memory detail: drop the `id` column; wrap the truncated content in the anchor
+
+## 3. Judgments (`apps/server/src/dashboard/judgments.ts`)
+
+- [x] 3.1 Add `data-href="/dashboard/judgments/{id}"` to each list row
+- [x] 3.2 Drop the `id` column; wrap the `created` cell's `formatTs(...)` output in `<a href="/dashboard/judgments/{id}">`; decrement the empty-state `colspan` 7→6
+- [x] 3.3 Verify manually that memory anchors in `source → target` and the `Mark orphaned` form still work inside the clickable row (ROW_LINK bail-out)
+
+## 4. Consolidation (`apps/server/src/dashboard/consolidation.ts`)
+
+- [x] 4.1 Runs list: drop the `id` column; wrap the `started` cell's `formatTs(...)` output in `<a href="/dashboard/consolidation/{id}">`
+- [x] 4.2 Run detail → Ops table: drop the op `id` column (plain text, no replacement); keep the memory shortId anchors in `affected` / `created` cells untouched
+
+## 5. Projects & prompts
+
+- [x] 5.1 `projects.ts`: drop the `id` column from the active AND archived tables (header + `shortId(p.id)` cell in `renderRow`)
+- [x] 5.2 `prompts.ts`: drop the `id` column from the list table (header + `shortId(p.id)` cell); keep the session shortId link column as-is
+
+## 6. CSS & spec sync
+
+- [x] 6.1 Update the stale comment in `styles/core/content.css` ("links inside tables render in lime so the ID column feels clickable" → reflect that lime links mark the row's navigable cell)
+- [ ] 6.2 Apply the four MODIFIED requirements + one ADDED requirement from `specs/dashboard/spec.md` to `openspec/specs/dashboard/spec.md` at archive time (no manual action now — recorded for the archive step)
+
+## 7. Tests & verification
+
+- [x] 7.1 Update `apps/server/src/test/dashboard-e2e.test.ts`: the exact multiline anchor assertion for the judgments id link (~line 533) must match the relocated `created`-cell anchor; the loose `href="/dashboard/judgments/${rel.id}"` containment assertions should pass unchanged
+- [x] 7.2 Grep the test suites for assertions on removed markup (`<th>id`, `colspan="7"`, shortId cells) and update: `pnpm vitest run apps/server/src/test/dashboard-e2e.test.ts apps/server/src/test/smoke.test.ts` passes
+- [x] 7.2b Add/extend an e2e assertion for active-first ordering: seed an old active session + a newer ended one, assert the active row renders first in `/dashboard/sessions`
+- [x] 7.3 `pnpm run typecheck` and `pnpm run lint` pass
+- [x] 7.4 Full `pnpm test` passes
+- [x] 7.5 Visual smoke against `pnpm run dev:docker:up` (operator-assisted): every list page renders without the id column, every navigable row cmd-clicks open in a new tab via its semantic-cell anchor, judgments rows whole-row navigate, action forms (Delete/Abandon/Mark orphaned/Undo) still work

--- a/openspec/changes/archive/2026-06-07-declutter-table-id-columns/tasks.md
+++ b/openspec/changes/archive/2026-06-07-declutter-table-id-columns/tasks.md
@@ -31,7 +31,7 @@
 ## 6. CSS & spec sync
 
 - [x] 6.1 Update the stale comment in `styles/core/content.css` ("links inside tables render in lime so the ID column feels clickable" → reflect that lime links mark the row's navigable cell)
-- [ ] 6.2 Apply the four MODIFIED requirements + one ADDED requirement from `specs/dashboard/spec.md` to `openspec/specs/dashboard/spec.md` at archive time (no manual action now — recorded for the archive step)
+- [x] 6.2 Apply the four MODIFIED requirements + one ADDED requirement from `specs/dashboard/spec.md` to `openspec/specs/dashboard/spec.md` at archive time (no manual action now — recorded for the archive step)
 
 ## 7. Tests & verification
 

--- a/openspec/specs/dashboard/spec.md
+++ b/openspec/specs/dashboard/spec.md
@@ -155,20 +155,30 @@ The dashboard SHALL be implemented with HTMX and server-side template literals. 
 
 ### Requirement: The dashboard MUST surface a sessions list view at `/dashboard/sessions`
 
-A logged-in dashboard user SHALL see a list of recent sessions for the active project (or globally when no project is selected). The list SHALL include columns for title, session id (short form), agent, started_at, ended_at, status, a memory count (number of `memory` rows with that `session_id`), and a prompt count (number of `prompts` rows with that `session_id` AND `deleted_at IS NULL`).
+A logged-in dashboard user SHALL see a list of recent sessions for the active project (or globally when no project is selected). The list SHALL include columns for title, agent, started_at, ended_at, status, a memory count (number of `memory` rows with that `session_id`), and a prompt count (number of `prompts` rows with that `session_id` AND `deleted_at IS NULL`). The list SHALL NOT include a session id column; the `title` cell carries the row's anchor to `/dashboard/sessions/:id`.
+
+The list SHALL be ordered with `status = 'active'` rows first, then all remaining rows; within each group rows SHALL be ordered by `started_at DESC`. The ordering SHALL be applied in the SQL query (before `LIMIT`/`OFFSET`) so pagination respects it. The soft-deleted table shown under `?include_deleted=1` keeps plain `started_at DESC`.
 
 The `title` column SHALL render using the cascade `row.title ?? row.description ?? shortId(row.id)`. The cascade SHALL NOT short-circuit on placeholder titles (e.g. `'rembric · 22:14 UTC'`) — those count as real titles for the purpose of display, because they are still more informative than `shortId` alone. The cascade ensures legacy rows (where `title` is NULL because they predate the column migration) still get a sensible value.
 
-The title column SHALL be the first visible content column (left of session id) and SHALL truncate with `text-overflow: ellipsis` past ~40 chars to keep the table compact. The full title SHALL be available as the cell's `title` attribute (HTML tooltip) so operators can hover to see the full string.
+The title column SHALL be the first visible content column and SHALL truncate with `text-overflow: ellipsis` past ~40 chars to keep the table compact. The full title SHALL be available as the cell's `title` attribute (HTML tooltip) so operators can hover to see the full string.
 
 The memory count and the prompt count SHALL be rendered as two separate right-aligned columns (`memories`, `prompts`). The detail view at `/dashboard/sessions/:id` SHALL render BOTH a `Memories (N)` and a `Prompts (N)` table — memories first, prompts below.
 
 #### Scenario: A dashboard user navigates to `/dashboard/sessions`
 
 - **WHEN** the user is authenticated with an admin token and visits `/dashboard/sessions`
-- **THEN** the server SHALL return a paginated list of the 50 most recent sessions ordered by `started_at DESC`, with each row linking to `/dashboard/sessions/:id`
+- **THEN** the server SHALL return a paginated list of 50 sessions ordered active-first then `started_at DESC`, with each row linking to `/dashboard/sessions/:id` via `data-href` and via the `title` cell's anchor
 - **AND** each row SHALL include a `title` column rendered via the documented cascade
 - **AND** each row SHALL include both a `memories` count column and a `prompts` count column
+- **AND** the table header SHALL NOT contain a `<th>` labelled `id`
+
+#### Scenario: Active sessions sort above ended ones regardless of age
+
+- **GIVEN** an active session `A` started three days ago and an ended session `E` started one hour ago
+- **WHEN** the operator navigates to `/dashboard/sessions`
+- **THEN** `A`'s row SHALL appear before `E`'s row
+- **AND** two active sessions SHALL order between themselves by `started_at DESC`
 
 #### Scenario: Session with a model-authored title
 
@@ -527,7 +537,9 @@ The dashboard SHALL serve the operator-facing queue of memory-relation judgments
 
 The page heading SHALL read `Rembric Judgments.` (with `Rembric` highlighted via `hl-lime`), the document `<title>` SHALL read `Judgments · Rembric`, the empty-state cell SHALL read `No judgments match this filter.`, the table column previously labelled `relation` SHALL be labelled `verdict`, and the orphan-not-found flash SHALL read `Judgment not found or already closed.`.
 
-The `source → target` column SHALL render each side as an `<a href="/dashboard/memories/{id}">` anchor whose visible text is the corresponding memory's `content` truncated to 60 characters (not the memory's short id). The two anchors SHALL be separated by the `→` arrow as before. Short-id-only rendering is retained ONLY for the leftmost `id` column (the judgment's own id) and for any other surface that pre-dates this change.
+The list SHALL NOT render an `id` column. Each row SHALL carry `data-href="/dashboard/judgments/{id}"` (whole-row click navigation, consistent with the sessions/memories/consolidation lists), and the `created` cell SHALL contain the row's real `<a href="/dashboard/judgments/{id}">` anchor wrapping the `formatTs(created_at)` output. The whole-row click handler's interactive-element bail-out keeps the memory anchors in `source → target` and the `Mark orphaned` form working inside the clickable row.
+
+The `source → target` column SHALL render each side as an `<a href="/dashboard/memories/{id}">` anchor whose visible text is the corresponding memory's `content` truncated to 60 characters (not the memory's short id). The two anchors SHALL be separated by the `→` arrow as before.
 
 The `verdict` column SHALL render via the shared `verdictPill(relation)` helper. When `relation` is non-null the cell SHALL contain a `<span class="pill k-{relation}">{relation}</span>` element (matching the home overview's `RECENT JUDGMENTS` tile). When `relation` is null (pending or orphaned rows) the cell SHALL contain the muted em-dash `<span class="muted">—</span>`. No inline `pill k-…` HTML SHALL exist in the judgments page template.
 
@@ -535,6 +547,13 @@ The `verdict` column SHALL render via the shared `verdictPill(relation)` helper.
 
 - **WHEN** an authenticated operator navigates to `/dashboard/judgments`
 - **THEN** the server SHALL return a `200` HTML response whose heading reads `Rembric Judgments.` and whose table column header for the relation kind reads `verdict`
+- **AND** the table header SHALL NOT contain a `<th>` labelled `id`
+
+#### Scenario: Judgment rows are whole-row clickable
+
+- **WHEN** an authenticated operator navigates to `/dashboard/judgments` with at least one row present
+- **THEN** each row SHALL carry `data-href="/dashboard/judgments/{id}"` where `{id}` is that row's `memory_relations.id`
+- **AND** the row's `created` cell SHALL contain an `<a href="/dashboard/judgments/{id}">` anchor wrapping the rendered timestamp
 
 #### Scenario: Legacy `/dashboard/relations` returns 404
 
@@ -638,7 +657,7 @@ The detail view at `/dashboard/sessions/:id` SHALL render the Abandon form in th
 
 ### Requirement: The dashboard MUST surface a prompts list view at `/dashboard/prompts`
 
-A logged-in dashboard user SHALL see a list of curated user prompts for the active project (or globally when no project is selected). The list SHALL include columns for title (cascade `title → content[truncated to 80 chars] → shortId`), short prompt id, project slug, session short id (link to session detail when present), agent, tags (comma-separated), and created_at.
+A logged-in dashboard user SHALL see a list of curated user prompts for the active project (or globally when no project is selected). The list SHALL include columns for title (cascade `title → content[truncated to 80 chars] → shortId`), project slug, session short id (link to session detail when present), agent, tags (comma-separated), and created_at. The list SHALL NOT include a prompt id column.
 
 The view SHALL paginate at 50 rows per page (`PAGE_SIZE` shared constant). The view SHALL support a free-text query box that submits as the `q` query parameter; when non-empty, the server-side handler SHALL use the FTS5 `prompts_fts` index (matching against `content` + `tags`). The view SHALL support filters by `project_slug`, `session_id` (shortId match), and `agent`.
 
@@ -651,6 +670,7 @@ The view SHALL NOT include a detail page at `/dashboard/prompts/:id` in this rev
 - **WHEN** an authenticated admin operator navigates to `/dashboard/prompts`
 - **THEN** the server SHALL return a paginated list of the 50 most recent prompts (active and not-deleted) ordered by `created_at DESC`
 - **AND** each row SHALL include the documented columns
+- **AND** the table header SHALL NOT contain a `<th>` labelled `id`
 - **AND** each row SHALL include a `Delete` form using `data-confirm` modal attributes on the `<form>` element
 
 #### Scenario: An operator searches prompts by content
@@ -704,7 +724,7 @@ The primary dashboard navigation (`apps/server/src/dashboard/components.ts::NAV`
 
 ### Requirement: The session detail view MUST list anchored prompts below memories
 
-The view at `/dashboard/sessions/:id` SHALL render a new `Prompts (N)` section AFTER the existing `Memories (N)` section. The section SHALL list every row of `prompts` whose `session_id` equals the URL id AND `deleted_at IS NULL`, ordered by `created_at ASC`, with columns: short prompt id, title (cascade), content (truncated to 120 chars), tags, created_at. When the session has no prompts, the section SHALL render `<p class="muted">No prompts anchored to this session.</p>` and SHALL still be emitted (so the `<h2>` is visible).
+The view at `/dashboard/sessions/:id` SHALL render a new `Prompts (N)` section AFTER the existing `Memories (N)` section. The section SHALL list every row of `prompts` whose `session_id` equals the URL id AND `deleted_at IS NULL`, ordered by `created_at ASC`, with columns: title (cascade), content (truncated to 120 chars), tags, created_at — no prompt id column. When the session has no prompts, the section SHALL render `<p class="muted">No prompts anchored to this session.</p>` and SHALL still be emitted (so the `<h2>` is visible).
 
 #### Scenario: Session with prompts and memories renders both sections
 
@@ -796,10 +816,11 @@ When the `:id` does not match any row, the page SHALL respond with `404 Not Foun
 - **THEN** each row SHALL contain a `.btn.primary.sm` anchor labelled `VIEW →` inside the row's `.acts` slot, whose `href` is `/dashboard/judgments/{id}` (where `{id}` is the corresponding `memory_relations.id`)
 - **AND** the verdict pill itself SHALL NOT be wrapped in an anchor (no click conflict with the memory links in the row)
 
-#### Scenario: Judgments list id column links to the detail page
+#### Scenario: Judgments list created cell links to the detail page
 
 - **WHEN** the operator navigates to `/dashboard/judgments` with at least one row present
-- **THEN** each row's leftmost `id` cell SHALL contain an `<a href="/dashboard/judgments/{id}">` anchor wrapping the short id, where `{id}` is that row's `memory_relations.id`
+- **THEN** each row's `created` cell SHALL contain an `<a href="/dashboard/judgments/{id}">` anchor wrapping the rendered timestamp, where `{id}` is that row's `memory_relations.id`
+- **AND** the list SHALL NOT render a standalone short-id cell for the judgment's own id
 
 ### Requirement: The dashboard brand block MUST display the running server version
 
@@ -879,3 +900,30 @@ After a one-click update is confirmed, the dashboard SHALL show a progress view 
 
 - **WHEN** the backup or pull step fails
 - **THEN** the progress view SHALL display the failure reason and the dashboard SHALL remain fully functional on the current version
+
+### Requirement: List tables MUST NOT spend a column on row ids
+
+Dashboard list tables SHALL NOT render a dedicated `id` column. Row identity is carried by the row's semantic cell (title, content, or timestamp), and navigation to a detail page — where one exists — is provided by whole-row `data-href` plus exactly one real `<a href>` anchor hosted on that semantic cell, so cmd-click / middle-click / keyboard navigation keep working.
+
+Concretely:
+
+- Sessions list: the `title` cell carries the anchor to `/dashboard/sessions/{id}` (rows keep `data-href`).
+- Memories list, session detail → Memories, memory detail → Predecessors: the `content` cell carries the anchor to `/dashboard/memories/{id}` (rows keep `data-href`).
+- Consolidation runs list: the `started` cell carries the anchor to `/dashboard/consolidation/{id}` (rows keep `data-href`).
+- Judgments list: the `created` cell carries the anchor to `/dashboard/judgments/{id}` (rows gain `data-href`).
+- Projects (active + archived), prompts list, session detail → Prompts, consolidation run detail → Ops: the id column is removed with no replacement anchor — these rows have no detail page. Memory shortId anchors inside the ops table's `affected` / `created` cells are retained: they are cross-navigation, not row identity.
+
+`shortId(...)` rendering remains in use outside list-table columns (detail-page headings such as `Rembric Memory {shortId}.`, ops `affected`/`created` cells, prompt session links).
+
+#### Scenario: A navigable list row keeps exactly one real anchor
+
+- **WHEN** an authenticated operator renders any list whose rows have a detail page (sessions, memories, consolidation runs, judgments, predecessors, session-detail memories)
+- **THEN** each row SHALL carry `data-href` pointing at its detail URL
+- **AND** each row SHALL contain exactly one `<a>` anchor pointing at that same detail URL, hosted on the row's semantic cell
+- **AND** no `<th>` labelled `id` SHALL be present in the table header
+
+#### Scenario: Tables without detail pages drop the id column with no replacement
+
+- **WHEN** an authenticated operator renders the projects, prompts, session-detail prompts, or run-detail ops tables
+- **THEN** no `<th>` labelled `id` SHALL be present and no cell SHALL render the row's own short id
+- **AND** row action forms SHALL keep functioning (they carry the full id in their `action` URLs)


### PR DESCRIPTION
## Summary

Implements (and archives) the OpenSpec change `declutter-table-id-columns` — `openspec/changes/archive/2026-06-07-declutter-table-id-columns/`.

- Remove the `id` column from all ten dashboard list tables (sessions ×2, memories, judgments, consolidation runs + ops, projects ×2, prompts, session-detail memories/prompts, memory predecessors)
- Every whole-row-clickable table keeps exactly one real `<a>` on the row's **semantic cell** (title / content / timestamp) so cmd-click, middle-click and keyboard navigation keep working; `data-href` covers whole-row clicks
- Judgments rows become whole-row clickable (`data-href`), with the detail anchor relocated to the `created` cell; the `ROW_LINK` interactive-element bail-out keeps the `source → target` memory links and the *Mark orphaned* form functional
- Sessions list now sorts `status = 'active'` rows first, then `started_at DESC` — SQL-side (`CASE` expression) so pagination respects it; the soft-deleted table keeps plain date order
- Spec deltas synced into `openspec/specs/dashboard/spec.md` (1 ADDED + 4 MODIFIED requirements); DESIGN.md row-navigation recipe and the stale `content.css` comment updated

## Test plan

- [x] `pnpm run typecheck` / `pnpm run lint` clean
- [x] Full `pnpm test`: 605 passed / 1 skipped (+31 plugin tests)
- [x] New e2e: active-first ordering (old active session renders above newer ended one); judgments list asserts `data-href`, created-cell anchor, no `<th>id</th>`
- [x] Visual smoke against `pnpm run dev:docker:up`: all list pages render without id columns, whole-row click + cmd-click work, action forms inside clickable rows unaffected