### PR TITLE
feat(server): manual update check from the dashboard

### DIFF
--- a/apps/server/src/dashboard/page-shell.ts
+++ b/apps/server/src/dashboard/page-shell.ts
@@ -40,10 +40,12 @@ export function renderPage(
   const collapsed = getCookie(c, SIDEBAR_COOKIE) === '1';
   const csrf = resolved ? csrfInput(resolved.session, sessionsService, 'sidebar.toggle') : raw('');
   const updateState = (c.get('update' as never) as UpdateViewState | undefined | null) ?? null;
+  const checkEnabled = (c.get('updateCheckEnabled' as never) as boolean | undefined) ?? false;
   const { badge, modal } = updateShellExtras(
     updateState,
     resolved?.session ?? null,
     sessionsService,
+    checkEnabled,
   );
   const sidebar = renderSidebar({
     active: opts.activeNav,

--- a/apps/server/src/dashboard/styles/core/patterns.css
+++ b/apps/server/src/dashboard/styles/core/patterns.css
@@ -974,6 +974,21 @@ form .field label {
 .sb-update:hover .bn {
   background: var(--lime-ink);
 }
+.sb-update.is-quiet {
+  border-color: var(--fg-faint);
+  color: var(--fg-dim);
+}
+.sb-update.is-quiet .bn {
+  background: var(--fg-dim);
+}
+.sb-update.is-quiet:hover {
+  background: transparent;
+  border-color: var(--fg-dim);
+  color: var(--fg);
+}
+.sb-update.is-quiet:hover .bn {
+  background: var(--fg);
+}
 .sb.is-collapsed .sb-update .label {
   display: none;
 }

--- a/apps/server/src/dashboard/styles/views/update.css
+++ b/apps/server/src/dashboard/styles/views/update.css
@@ -4,6 +4,16 @@
 .upd-page {
   max-width: 760px;
 }
+.upd-page .upd-note + .upd-action {
+  margin-top: var(--s-4);
+}
+.upd-last-checked {
+  font-family: var(--f-mono);
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--fg-dim);
+}
 
 .upd-progress {
   max-width: 560px;

--- a/apps/server/src/dashboard/update-modal.ts
+++ b/apps/server/src/dashboard/update-modal.ts
@@ -189,16 +189,30 @@ export function updateBadge(latestVersion: string): SafeHtml {
   `;
 }
 
+/** Quiet brand-block slot: no update known, check enabled. */
+export function upToDateSlot(): SafeHtml {
+  return html`
+    <a class="sb-update is-quiet" href="/dashboard/update" title="Check for updates">
+      <span class="bn"></span>
+      <span class="label">UP TO DATE ›</span>
+    </a>
+  `;
+}
+
 /**
  * Badge + modal pair for the page shell, derived from the per-request
- * update state set by the dashboard auth middleware.
+ * update state set by the dashboard auth middleware. With no update
+ * known the slot degrades to the quiet link (or nothing when the
+ * check is disabled) so `/dashboard/update` stays reachable.
  */
 export function updateShellExtras(
   state: UpdateViewState | null,
   session: DashboardSession | null,
   sessions: SessionsService,
+  checkEnabled = false,
 ): { badge: SafeHtml | null; modal: SafeHtml | undefined } {
-  if (!state || !session) return { badge: null, modal: undefined };
+  if (!session) return { badge: null, modal: undefined };
+  if (!state) return { badge: checkEnabled ? upToDateSlot() : null, modal: undefined };
   return {
     badge: updateBadge(state.info.latestVersion),
     modal: renderUpdateModal(state, session, sessions),

--- a/apps/server/src/dashboard/update.ts
+++ b/apps/server/src/dashboard/update.ts
@@ -11,10 +11,10 @@ import type { SessionsService } from '../services/sessions.js';
 import type { UpdateCheckService } from '../services/update-check.js';
 import { REMBRIC_VERSION } from '../version.js';
 
-import { viewHead } from './components.js';
-import { readFormAndVerifyCsrf } from './csrf.js';
+import { btn, viewHead } from './components.js';
+import { csrfInput, readFormAndVerifyCsrf } from './csrf.js';
 import { renderPage } from './page-shell.js';
-import { html, raw, type SafeHtml } from './templates.js';
+import { formatTs, html, raw, type SafeHtml } from './templates.js';
 import type { ResolvedSession } from './types.js';
 import { updateActionBlock, updateChangelog, updateSummary } from './update-modal.js';
 import type { UpdateViewState } from './update-modal.js';
@@ -172,7 +172,7 @@ export function createUpdateRouter(deps: UpdateDeps): Hono {
 
     if (running) {
       const body = html`
-        ${viewHead({ num: '09', title: 'Updating Rembric.', hl: 'Updating' })}
+        ${viewHead({ num: '09', title: 'Rembric Updates.', hl: 'Rembric' })}
         <div class="upd-progress" data-upd-progress data-initial-version="${REMBRIC_VERSION}">
           <div class="upd-progress-title">
             INSTALLING v${status.targetVersion ?? ''}
@@ -194,15 +194,23 @@ export function createUpdateRouter(deps: UpdateDeps): Hono {
 
     const state = getUpdateState(c);
     const err = c.req.query('err');
+    const checked = c.req.query('checked');
     const flash = err
       ? ({ kind: 'error', text: updateErrorText(err) } as const)
-      : status.phase === 'failed' && status.error
-        ? ({ kind: 'error', text: `Last update attempt failed: ${status.error}` } as const)
-        : undefined;
+      : checked === 'none'
+        ? ({ kind: 'success', text: 'Checked — no newer release is known.' } as const)
+        : checked === 'error'
+          ? ({
+              kind: 'error',
+              text: 'The release check could not reach GitHub (offline or rate-limited) — this is expected on air-gapped hosts.',
+            } as const)
+          : status.phase === 'failed' && status.error
+            ? ({ kind: 'error', text: `Last update attempt failed: ${status.error}` } as const)
+            : undefined;
 
     const body = state
       ? html`
-          ${viewHead({ num: '09', title: 'Update Available.', hl: 'Update' })}
+          ${viewHead({ num: '09', title: 'Rembric Updates.', hl: 'Rembric' })}
           <div class="upd-page" data-upd-watch data-initial-version="${REMBRIC_VERSION}">
             ${updateSummary(state.info)} ${updateChangelog(state.info)}
             ${updateActionBlock(state, session.session, deps.sessions)}
@@ -212,17 +220,8 @@ export function createUpdateRouter(deps: UpdateDeps): Hono {
           </script>
         `
       : html`
-          ${viewHead({ num: '09', title: 'Updates.', hl: 'Updates' })}
-          <div class="upd-page">
-            <div class="upd-note">
-              <span class="lab">UP TO DATE</span>
-              <p>
-                You are running <code>v${REMBRIC_VERSION}</code> — no newer release is known. The
-                check runs at most once a day and can be disabled with
-                <code>REMBRIC_UPDATE_CHECK=off</code>.
-              </p>
-            </div>
-          </div>
+          ${viewHead({ num: '09', title: 'Rembric Updates.', hl: 'Rembric' })}
+          <div class="upd-page">${upToDateBlock(session, deps)}</div>
         `;
 
     return c.html(
@@ -233,6 +232,20 @@ export function createUpdateRouter(deps: UpdateDeps): Hono {
         flash,
       }),
     );
+  });
+
+  app.post('/check', async (c) => {
+    const session = getSession(c);
+    if (!session) return c.redirect('/dashboard/login');
+    const form = await readFormAndVerifyCsrf(c, session.session, deps.sessions, 'update.check');
+    if (form instanceof Response) return form;
+
+    if (!deps.updates.enabled) return c.redirect('/dashboard/update');
+    const { outcome } = await deps.updates.checkNow();
+    // A found update needs no flash — the refreshed cache re-renders the
+    // page as the full "Update Available" view.
+    if (outcome === 'update') return c.redirect('/dashboard/update');
+    return c.redirect(`/dashboard/update?checked=${outcome}`);
   });
 
   app.post('/start', async (c) => {
@@ -261,6 +274,39 @@ export function createUpdateRouter(deps: UpdateDeps): Hono {
   });
 
   return app;
+}
+
+function upToDateBlock(session: ResolvedSession, deps: UpdateDeps): SafeHtml {
+  if (!deps.updates.enabled) {
+    return html`
+      <div class="upd-note">
+        <span class="lab">UPDATE CHECK DISABLED</span>
+        <p>
+          This deployment sets <code>REMBRIC_UPDATE_CHECK=off</code>, so Rembric never contacts
+          GitHub and cannot know whether <code>v${REMBRIC_VERSION}</code> is the latest release.
+          Remove the variable and restart to re-enable the check.
+        </p>
+      </div>
+    `;
+  }
+  const lastChecked = deps.updates.lastCheckedAt;
+  return html`
+    <div class="upd-note">
+      <span class="lab">UP TO DATE</span>
+      <p>
+        You are running <code>v${REMBRIC_VERSION}</code> — no newer release is known. The check runs
+        automatically at most once a day and can be disabled with
+        <code>REMBRIC_UPDATE_CHECK=off</code>.
+      </p>
+      ${lastChecked
+        ? html`<p class="upd-last-checked">LAST CHECKED ${formatTs(lastChecked)}</p>`
+        : raw('')}
+    </div>
+    <form action="/dashboard/update/check" method="post" class="upd-action">
+      ${csrfInput(session.session, deps.sessions, 'update.check')}
+      ${btn({ variant: 'secondary', label: 'CHECK NOW →', type: 'submit' })}
+    </form>
+  `;
 }
 
 function updateErrorText(code: string): string {

--- a/apps/server/src/server/dashboard-router.ts
+++ b/apps/server/src/server/dashboard-router.ts
@@ -174,6 +174,7 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
       };
     }
     c.set('update', update);
+    c.set('updateCheckEnabled', deps.updates.enabled);
     return next();
   });
 
@@ -201,7 +202,12 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
     const counters = { pendingJudgments: stats.pendingJudgments };
     const csrf = csrfInput(session.session, deps.sessions, 'sidebar.toggle');
     const updateState = (c.get('update' as never) as UpdateViewState | undefined | null) ?? null;
-    const updateExtras = updateShellExtras(updateState, session.session, deps.sessions);
+    const updateExtras = updateShellExtras(
+      updateState,
+      session.session,
+      deps.sessions,
+      deps.updates.enabled,
+    );
     const sidebar = renderSidebar({
       active: 'home',
       counters,

--- a/apps/server/src/services/update-check.test.ts
+++ b/apps/server/src/services/update-check.test.ts
@@ -127,6 +127,70 @@ describe('UpdateCheckService', () => {
     expect(calls[1]?.headers['if-none-match']).toBe('W/"abc"');
   });
 
+  it('checkNow bypasses the 24h window and reports update', async () => {
+    let t = 0;
+    const { fetchImpl, calls } = fakeFetch([
+      { status: 200, body: [release({ tag_name: 'server-v0.21.1' })] },
+      { status: 200, body: [release()] },
+    ]);
+    const s = svc({ fetchImpl, now: () => t, intervalMs: 1000 });
+    expect(await s.checkNow()).toEqual({ outcome: 'none', info: null });
+    t = 1; // deep inside the interval — peek would not refetch
+    const second = await s.checkNow();
+    expect(calls.length).toBe(2);
+    expect(second.outcome).toBe('update');
+    expect(second.info?.latestVersion).toBe('0.22.0');
+    expect(s.peek()?.latestVersion).toBe('0.22.0');
+  });
+
+  it('checkNow reports none on same/older release and on 304', async () => {
+    const { fetchImpl } = fakeFetch([
+      { status: 200, body: [release({ tag_name: 'server-v0.21.1' })], etag: 'W/"abc"' },
+      { status: 304 },
+    ]);
+    const s = svc({ fetchImpl });
+    expect((await s.checkNow()).outcome).toBe('none');
+    expect((await s.checkNow()).outcome).toBe('none');
+  });
+
+  it('checkNow reports error on network failure and non-OK status', async () => {
+    const failing = svc({ fetchImpl: () => Promise.reject(new Error('offline')) });
+    expect((await failing.checkNow()).outcome).toBe('error');
+
+    const rateLimited = svc({ fetchImpl: fakeFetch([{ status: 403, body: {} }]).fetchImpl });
+    expect((await rateLimited.checkNow()).outcome).toBe('error');
+  });
+
+  it('checkNow error does not lose a previously cached update', async () => {
+    const { fetchImpl } = fakeFetch([{ status: 200, body: [release()] }, { status: 500 }]);
+    const s = svc({ fetchImpl });
+    expect((await s.checkNow()).outcome).toBe('update');
+    const after = await s.checkNow();
+    expect(after.outcome).toBe('error');
+    expect(after.info?.latestVersion).toBe('0.22.0');
+  });
+
+  it('checkNow on a disabled service never fetches', async () => {
+    const { fetchImpl, calls } = fakeFetch([{ status: 200, body: [release()] }]);
+    const s = svc({ fetchImpl, enabled: false });
+    expect(await s.checkNow()).toEqual({ outcome: 'none', info: null });
+    expect(calls.length).toBe(0);
+    expect(s.enabled).toBe(false);
+  });
+
+  it('lastCheckedAt reflects manual and automatic checks', async () => {
+    let t = 5000;
+    const { fetchImpl } = fakeFetch([{ status: 200, body: [release()] }]);
+    const s = svc({ fetchImpl, now: () => t, intervalMs: 1000 });
+    expect(s.lastCheckedAt).toBeNull();
+    await s.checkNow();
+    expect(s.lastCheckedAt?.getTime()).toBe(5000);
+    t = 7000;
+    s.peek(); // stale — background refresh fires
+    await new Promise((r) => setTimeout(r, 0));
+    expect(s.lastCheckedAt?.getTime()).toBe(7000);
+  });
+
   it('peek respects the 24h interval', async () => {
     let t = 0;
     const { fetchImpl, calls } = fakeFetch([{ status: 200, body: [release()] }]);

--- a/apps/server/src/services/update-check.ts
+++ b/apps/server/src/services/update-check.ts
@@ -42,6 +42,8 @@ export interface UpdateCheckOptions {
   now?: () => number;
 }
 
+export type ManualCheckOutcome = 'update' | 'none' | 'error';
+
 export function parseSemver(v: string): [number, number, number] | null {
   const m = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(v.trim());
   if (!m) return null;
@@ -62,24 +64,34 @@ export function semverGt(a: string, b: string): boolean {
 
 export class UpdateCheckService {
   private readonly currentVersion: string;
-  private readonly enabled: boolean;
+  private readonly checkEnabled: boolean;
   private readonly fetchImpl: typeof fetch;
   private readonly releasesUrl: string;
   private readonly intervalMs: number;
   private readonly now: () => number;
 
   private cache: UpdateInfo | null = null;
-  private lastCheckedAt = 0;
+  private lastCheckedAtMs = 0;
+  private lastFetchFailed = false;
   private etag: string | null = null;
   private inflight: Promise<UpdateInfo | null> | null = null;
 
   constructor(opts: UpdateCheckOptions = {}) {
     this.currentVersion = opts.currentVersion ?? REMBRIC_VERSION;
-    this.enabled = opts.enabled ?? process.env['REMBRIC_UPDATE_CHECK'] !== 'off';
+    this.checkEnabled = opts.enabled ?? process.env['REMBRIC_UPDATE_CHECK'] !== 'off';
     this.fetchImpl = opts.fetchImpl ?? fetch;
     this.releasesUrl = opts.releasesUrl ?? DEFAULT_RELEASES_URL;
     this.intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
     this.now = opts.now ?? Date.now;
+  }
+
+  get enabled(): boolean {
+    return this.checkEnabled;
+  }
+
+  /** Most recent check (manual or automatic) this process lifetime. */
+  get lastCheckedAt(): Date | null {
+    return this.lastCheckedAtMs ? new Date(this.lastCheckedAtMs) : null;
   }
 
   /**
@@ -87,8 +99,8 @@ export class UpdateCheckService {
    * `null` until a refresh has found a strictly newer version.
    */
   peek(): UpdateInfo | null {
-    if (!this.enabled) return null;
-    if (this.now() - this.lastCheckedAt >= this.intervalMs && !this.inflight) {
+    if (!this.checkEnabled) return null;
+    if (this.now() - this.lastCheckedAtMs >= this.intervalMs && !this.inflight) {
       // Background kick; silent-failure contract means errors are dropped.
       void this.refresh().catch(() => {});
     }
@@ -97,7 +109,7 @@ export class UpdateCheckService {
 
   /** Refresh now (awaitable; used by tests and the update view). */
   async refresh(): Promise<UpdateInfo | null> {
-    if (!this.enabled) return null;
+    if (!this.checkEnabled) return null;
     if (this.inflight) return this.inflight;
     this.inflight = this.doRefresh().finally(() => {
       this.inflight = null;
@@ -105,17 +117,38 @@ export class UpdateCheckService {
     return this.inflight;
   }
 
+  /**
+   * Operator-initiated check: bypasses the 24h window and, unlike the
+   * automatic path, reports whether GitHub was actually reached.
+   */
+  async checkNow(): Promise<{ outcome: ManualCheckOutcome; info: UpdateInfo | null }> {
+    if (!this.checkEnabled) return { outcome: 'none', info: null };
+    const info = await this.refresh();
+    if (this.lastFetchFailed) return { outcome: 'error', info };
+    return { outcome: info ? 'update' : 'none', info };
+  }
+
   private async doRefresh(): Promise<UpdateInfo | null> {
-    this.lastCheckedAt = this.now();
+    this.lastCheckedAtMs = this.now();
     try {
       const headers: Record<string, string> = { accept: 'application/vnd.github+json' };
       if (this.etag) headers['if-none-match'] = this.etag;
       const res = await this.fetchImpl(this.releasesUrl, { headers });
-      if (res.status === 304) return this.cache;
-      if (!res.ok) return this.cache;
+      if (res.status === 304) {
+        this.lastFetchFailed = false;
+        return this.cache;
+      }
+      if (!res.ok) {
+        this.lastFetchFailed = true;
+        return this.cache;
+      }
       this.etag = res.headers.get('etag');
       const releases = (await res.json()) as GithubRelease[];
-      if (!Array.isArray(releases)) return this.cache;
+      if (!Array.isArray(releases)) {
+        this.lastFetchFailed = true;
+        return this.cache;
+      }
+      this.lastFetchFailed = false;
       const latest = releases.find(
         (r) =>
           !r.draft &&
@@ -137,6 +170,7 @@ export class UpdateCheckService {
         : null;
       return this.cache;
     } catch {
+      this.lastFetchFailed = true;
       return this.cache;
     }
   }

--- a/apps/server/src/test/dashboard-e2e.test.ts
+++ b/apps/server/src/test/dashboard-e2e.test.ts
@@ -796,6 +796,147 @@ describe('dashboard E2E — self-update surface', () => {
   });
 });
 
+describe('dashboard E2E — manual update check', () => {
+  let server: BootstrappedServer;
+  let baseUrl: string;
+  const ADMIN_TOKEN = 'integration-admin-token-with-enough-entropy-chk';
+
+  // Mutable release feed the fake fetch serves — tests flip outcomes.
+  const feed = { mode: 'old' as 'old' | 'new' | 'fail' };
+
+  beforeAll(async () => {
+    const { UpdateCheckService } = await import('../services/update-check.js');
+    const { SelfUpdateOrchestrator } = await import('../services/self-update/orchestrator.js');
+
+    const tmp = createTestDb();
+    tmp.cleanup();
+    const port = await findFreePort();
+
+    const fakeFetch = (() => {
+      if (feed.mode === 'fail') return Promise.reject(new Error('offline'));
+      const tag = feed.mode === 'new' ? 'server-v9.9.9' : 'server-v0.0.1';
+      return Promise.resolve(
+        new Response(
+          JSON.stringify([
+            {
+              tag_name: tag,
+              body: '## manual-check changelog',
+              html_url: 'https://github.com/susomejias/rembric/releases',
+              published_at: '2026-06-01T00:00:00Z',
+              prerelease: false,
+              draft: false,
+            },
+          ]),
+          { status: 200 },
+        ),
+      );
+    }) as typeof fetch;
+    const updates = new UpdateCheckService({ enabled: true, fetchImpl: fakeFetch });
+
+    const fakeDetector = {
+      detect: () => Promise.resolve({ state: 'manual', reason: 'no-socket' }),
+      detectCached: () => Promise.resolve({ state: 'manual', reason: 'no-socket' }),
+    } as unknown as ConstructorParameters<typeof SelfUpdateOrchestrator>[0]['capability'];
+    const selfUpdate = new SelfUpdateOrchestrator({
+      capability: fakeDetector,
+      engineFactory: () => {
+        throw new Error('engine must not be reached in these tests');
+      },
+      backup: () => {
+        throw new Error('backup must not be reached in these tests');
+      },
+      log: () => {},
+    });
+
+    server = await createServer(
+      {
+        REMBRIC_HOST: '127.0.0.1',
+        REMBRIC_PORT: String(port),
+        REMBRIC_DATA_DIR: tmp.dataDir,
+        REMBRIC_ADMIN_TOKEN: ADMIN_TOKEN,
+      },
+      { embedder: new FakeEmbedder(), updates, selfUpdate },
+    );
+    baseUrl = `http://127.0.0.1:${port}`;
+  }, 30_000);
+
+  afterAll(async () => {
+    await server.shutdown();
+  });
+
+  async function login(): Promise<CookieJar> {
+    const jar: CookieJar = { cookie: null };
+    await postForm(baseUrl, '/dashboard/login', jar, { token: ADMIN_TOKEN });
+    return jar;
+  }
+
+  async function armCsrf(jar: CookieJar): Promise<string> {
+    const page = await get(baseUrl, '/dashboard/update', jar);
+    const csrf = extractCsrf(await page.text(), '/dashboard/update/check');
+    expect(csrf).toBeTruthy();
+    return csrf!;
+  }
+
+  it('renders the quiet UP TO DATE slot in sidebar and mobile bar when no update is known', async () => {
+    const jar = await login();
+    const home = await get(baseUrl, '/dashboard', jar);
+    const body = await home.text();
+    expect(body.match(/sb-update is-quiet/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(body).toContain('UP TO DATE ›');
+    expect(body).not.toContain('id="rbr-update"');
+  });
+
+  it('up-to-date page offers CHECK NOW with CSRF and shows last-checked', async () => {
+    const jar = await login();
+    const page = await get(baseUrl, '/dashboard/update', jar);
+    const body = await page.text();
+    expect(body).toContain('UP TO DATE');
+    expect(body).toContain('action="/dashboard/update/check"');
+    expect(body).toContain('CHECK NOW');
+    expect(body).toContain('LAST CHECKED');
+    // Read-only action — no confirmation modal on the form itself.
+    const formTag = /<form[^>]*action="\/dashboard\/update\/check"[^>]*>/.exec(body)?.[0];
+    expect(formTag).toBeTruthy();
+    expect(formTag).not.toContain('data-confirm');
+    expect(extractCsrf(body, '/dashboard/update/check')).toBeTruthy();
+  });
+
+  it('check without CSRF returns 403', async () => {
+    const jar = await login();
+    const res = await postForm(baseUrl, '/dashboard/update/check', jar, {});
+    expect(res.status).toBe(403);
+  });
+
+  it('manual check walks none → error → update', async () => {
+    const jar = await login();
+
+    feed.mode = 'old';
+    let res = await postForm(baseUrl, '/dashboard/update/check', jar, { csrf: await armCsrf(jar) });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('checked=none');
+    let body = await (await get(baseUrl, '/dashboard/update?checked=none', jar)).text();
+    expect(body).toContain('no newer release is known');
+
+    feed.mode = 'fail';
+    res = await postForm(baseUrl, '/dashboard/update/check', jar, { csrf: await armCsrf(jar) });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('checked=error');
+    body = await (await get(baseUrl, '/dashboard/update?checked=error', jar)).text();
+    expect(body).toContain('could not reach GitHub');
+
+    feed.mode = 'new';
+    res = await postForm(baseUrl, '/dashboard/update/check', jar, { csrf: await armCsrf(jar) });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).not.toContain('checked=');
+    body = await (await get(baseUrl, '/dashboard/update', jar)).text();
+    expect(body).toContain('v9.9.9');
+    expect(body).toContain('manual-check changelog');
+    expect(body).not.toContain('action="/dashboard/update/check"');
+    expect(body).toContain('sb-update');
+    expect(body).not.toContain('is-quiet');
+  });
+});
+
 describe('dashboard E2E — zero-action compatibility', () => {
   // openspec/specs/self-update: a deployment without the Docker socket and
   // without any new configuration boots and operates identically, with the
@@ -842,9 +983,13 @@ describe('dashboard E2E — zero-action compatibility', () => {
     expect(body).not.toContain('sb-update');
     expect(body).not.toContain('id="rbr-update"');
 
-    // The update page itself degrades to the up-to-date notice.
+    // The update page itself degrades to the disabled notice — no
+    // manual-check form, no claim about being up to date.
     const page = await get(baseUrl, '/dashboard/update', jar);
     expect(page.status).toBe(200);
-    expect(await page.text()).toContain('UP TO DATE');
+    const pageBody = await page.text();
+    expect(pageBody).toContain('UPDATE CHECK DISABLED');
+    expect(pageBody).not.toContain('action="/dashboard/update/check"');
+    expect(pageBody).not.toContain('UP TO DATE');
   });
 });

--- a/openspec/changes/archive/2026-06-07-add-manual-update-check/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-07-add-manual-update-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/archive/2026-06-07-add-manual-update-check/design.md
+++ b/openspec/changes/archive/2026-06-07-add-manual-update-check/design.md
@@ -1,0 +1,78 @@
+# Design: add-manual-update-check
+
+## Context
+
+`UpdateCheckService` (`apps/server/src/services/update-check.ts`) already has a public, awaitable `refresh()` that ignores the 24-hour interval, dedupes concurrent calls (`inflight`), and is ETag-aware — a no-change re-check is a `304`. What's missing is purely surface: no dashboard action invokes it, and `refresh()` cannot tell the caller whether it actually reached GitHub (the silent-failure contract makes `null` mean both "no newer release" and "fetch failed").
+
+Discoverability gap: the brand-block slot rendered by `updateShellExtras` (`update-modal.ts`) returns `badge: null` when no update is known, and `/dashboard/update` is not in `NAV` — the page's "UP TO DATE" state is reachable only by typing the URL. The exact scenario this change targets (operator learns a release shipped, wants to force the check) happens _before_ any badge exists.
+
+Prior art in this dashboard genre (Portainer, Pi-hole, Arcane — the original UX reference): the version/update affordance lives in the brand/footer block and links to the updates surface.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Operator can force a release check from the dashboard and see an honest outcome (update found / still up to date / check failed).
+- `/dashboard/update` is always reachable from the shell via the brand-block slot.
+- Zero behavior change for the automatic path: same cadence, same silent-failure contract, same badge when an update is known.
+
+**Non-Goals:**
+
+- No change to one-click execution, capability detection, or the modal.
+- No persistence of check state (stays in-memory, as decided in the original change's D5).
+- No nav item for the update page (rarely-visited page; the brand slot is the entry point).
+- No rate limiting beyond what already exists (`inflight` dedupe) — single-operator authenticated surface.
+
+## Decisions
+
+### D1 — Force-check reports outcome; the silent-failure contract stays scoped to the automatic path
+
+`UpdateCheckService` gains `checkNow(): Promise<{ outcome: 'update' | 'none' | 'error'; info: UpdateInfo | null }>` (and a `lastCheckedAt` accessor). Internally `doRefresh` records whether the fetch succeeded; `checkNow` forces a refresh and maps the result. `peek()` and the background kick are untouched — automatic failures stay silent per spec.
+
+- _Alternative: reuse `refresh()` as-is and flash "still up to date" on `null`._ Rejected: on an air-gapped or rate-limited host the button would claim "up to date" when it never reached GitHub — a manual action must not lie about having checked.
+- _Alternative: surface errors everywhere (drop silent failure)._ Rejected: the silent contract exists for unattended deployments; only an explicit operator action earns an error message.
+
+### D2 — `POST /dashboard/update/check` + redirect with outcome query param
+
+New route in `update.ts` following the `/start` pattern exactly: session guard, `readFormAndVerifyCsrf` (action `update.check`), `await deps.updates.checkNow()`, redirect to `/dashboard/update?checked=<outcome>` for `none`/`error` (plain redirect for `update` — the refreshed cache makes the GET render the full "Update Available" view via the middleware's `peek()`). The GET handler maps `checked=none` to an info flash ("Checked — still up to date") and `checked=error` to an error flash ("The check could not reach GitHub..."), mirroring the existing `?err=` mapping.
+
+- _Alternative: HTMX partial swap instead of POST-redirect-GET._ Rejected: the update page is plain SSR today; PRG reuses the flash machinery and survives the "found an update" case (full re-render into a different view) without special-casing.
+
+### D3 — Persistent brand-block slot: badge when update known, quiet link otherwise, nothing when disabled
+
+`updateShellExtras` currently returns `badge: null` when there is no update state. It will instead render a quiet `UP TO DATE ›` link (`href="/dashboard/update"`, muted styling, same slot/position as the lime badge) — completing the half-built component rather than turning the decorative `v<version>` text into a hidden link. Three states:
+
+| Check state                    | Slot renders                                       |
+| ------------------------------ | -------------------------------------------------- |
+| newer version known            | existing lime `UPDATE v<latest>` badge (unchanged) |
+| no update known, check enabled | quiet `UP TO DATE ›` link                          |
+| `REMBRIC_UPDATE_CHECK=off`     | nothing                                            |
+
+The disabled case renders nothing because "UP TO DATE" would be a claim the server cannot make (it never checks), and the operator explicitly opted out of update UX. This requires the shell to distinguish "no update" from "check disabled": `UpdateCheckService` exposes `enabled` (trivial getter), threaded through the router middleware alongside the existing state.
+
+- _Alternative: make the `<small>v…</small>` brand text a link._ Rejected: zero affordance — a decorative label that is secretly clickable is an easter egg, not UI.
+- _Alternative: permanent NAV item under ADMIN._ Rejected: a fixed nav entry for a page that says "up to date" 95% of the time is noise; the sidebar already carries 7+ items.
+- _Alternative: render the quiet link even when disabled._ Rejected: dishonest label, and the operator who set `REMBRIC_UPDATE_CHECK=off` asked for exactly this absence.
+
+New CSS class for the quiet state in `dashboard/styles/` (locked design tokens, no inline styles), reusing the `.sb-update` layout with a muted variant.
+
+### D4 — CHECK NOW placement and the last-checked line
+
+The button lives only on `/dashboard/update`'s up-to-date state (where the cadence text already is), as a CSRF-protected form. No `data-confirm` — the action is read-only and reversible (one conditional GET). A "Last checked" line renders via `formatTs(lastCheckedAt)` when a check has run this process lifetime; omitted otherwise (fresh boot). When the check is disabled, the button and line are replaced by the existing disabled-note copy.
+
+- _Alternative: also add a re-check affordance on the "Update Available" view._ Rejected: once an update shows, re-checking adds nothing (a newer-still release within the same window is an edge case not worth a button); the next 24h cycle or a page on the new version covers it.
+
+## Risks / Trade-offs
+
+- **[Risk] Manual checks burn the anonymous GitHub rate limit (60 req/h/IP) if hammered.** → ETag makes unchanged responses `304` (still counted, but the button is behind auth on a single-operator dashboard, and `inflight` dedupes concurrency). Accepted without a cooldown; revisit only if real deployments report 403s.
+- **[Risk] `checked=error` flash on hosts where the automatic check also fails (air-gapped) may read as "something is broken".** → Copy states it plainly ("could not reach GitHub — this is expected on air-gapped hosts") and links nothing; no log noise added.
+- **[Trade-off] `lastCheckedAt` resets on every container restart (in-memory).** → Accepted: consistent with the original D5 decision (no persistence for check state); the line simply doesn't render until the first check.
+- **[Trade-off] The quiet slot adds a permanent element to the sidebar for a rarely-needed action.** → Accepted: it doubles as the only discovery path to `/dashboard/update` and replaces nothing — the slot was already reserved for the badge.
+
+## Migration Plan
+
+Nothing migrates. Pure additive dashboard surface; deployments see the quiet link after updating. Rollback = previous image.
+
+## Open Questions
+
+- Exact quiet-link label (`UP TO DATE ›` vs `UPDATES ›`) — decided at implementation against the brutalist style; user explicitly wants to iterate on the rendered UI.

--- a/openspec/changes/archive/2026-06-07-add-manual-update-check/proposal.md
+++ b/openspec/changes/archive/2026-06-07-add-manual-update-check/proposal.md
@@ -1,0 +1,34 @@
+# Proposal: add-manual-update-check
+
+## Why
+
+The release check runs lazily at most once per 24 hours, so an operator who learns a new version shipped (release announcement, GitHub notification) can wait up to a day before the dashboard reflects it — and there is no way to force a check. Worse, when no update is known there is no visible path to `/dashboard/update` at all: the brand-block badge only renders once a newer version is already cached, so the page where a manual check would live is reachable only by typing the URL.
+
+## What Changes
+
+- New `POST /dashboard/update/check` dashboard route (session + CSRF) that forces an immediate release check, bypassing the 24-hour interval, then redirects back to `/dashboard/update`. If the check finds a newer version, the existing "Update Available" view renders; otherwise a flash reports the outcome ("still up to date" vs. "check failed to reach GitHub").
+- `UpdateCheckService` gains an operator-initiated force-check path that reports its outcome (`update` / `none` / `error`) instead of swallowing failures — the silent-failure contract stays intact for the automatic background path only. It also exposes the last-checked timestamp.
+- "CHECK NOW" button on the up-to-date state of `/dashboard/update`, alongside a "Last checked" line (`formatTs`). Hidden when `REMBRIC_UPDATE_CHECK=off`.
+- The brand-block update slot (sidebar + mobile bar) becomes persistent: when a newer version is known it renders the existing lime `UPDATE v<latest>` badge (unchanged); when none is known it renders a quiet `UP TO DATE ›` link to `/dashboard/update`. When the check is disabled, the slot renders nothing (as today).
+
+No schema changes, no MCP changes, no new dependencies, no change to the one-click execution path or capability detection.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `self-update`: the update-check requirement gains an operator-initiated manual check that bypasses the 24-hour window (still ETag-aware, still ≤1 concurrent request); the silent-failure contract is scoped to the automatic path, with the manual path reporting its outcome to the operator.
+- `dashboard`: the brand-block update slot becomes persistent (quiet `UP TO DATE` link when no update is known, existing badge when one is, nothing when the check is disabled); `/dashboard/update`'s up-to-date state gains the CHECK NOW action and a last-checked timestamp.
+
+## Impact
+
+- `apps/server/src/services/update-check.ts` — force-check method with outcome reporting; `lastCheckedAt` exposure.
+- `apps/server/src/dashboard/update.ts` — `POST /check` route; CHECK NOW form, last-checked line, and outcome flash on the up-to-date state.
+- `apps/server/src/dashboard/update-modal.ts` — `updateShellExtras` / new quiet-slot renderer for the no-update state.
+- `apps/server/src/server/dashboard-router.ts` — thread the persistent slot through the page shell (today `badge` is `null` when no update).
+- `apps/server/src/dashboard/components.ts` — none expected (slot is injected via the existing `update` option); CSS for the quiet slot state in `apps/server/src/dashboard/styles/` (no inline styles, locked design tokens).
+- Tests co-located with each of the above.

--- a/openspec/changes/archive/2026-06-07-add-manual-update-check/specs/dashboard/spec.md
+++ b/openspec/changes/archive/2026-06-07-add-manual-update-check/specs/dashboard/spec.md
@@ -1,0 +1,50 @@
+# dashboard — delta for add-manual-update-check
+
+## MODIFIED Requirements
+
+### Requirement: The dashboard MUST surface update availability as a badge in the brand block
+
+When the update check reports a newer version, the dashboard SHALL render an update badge adjacent to the running-version line in the brand block (sidebar, mobile bar) showing the latest available version. The badge SHALL persist across visits until the deployment runs the newer version and SHALL NOT be affected by modal dismissal.
+
+When no newer version is known and the update check is enabled, the same brand-block slot SHALL render a quiet link (muted styling, no lime accent) to `/dashboard/update`, so the update page is always reachable from the shell. When the update check is disabled (`REMBRIC_UPDATE_CHECK=off`), the slot SHALL render nothing.
+
+#### Scenario: Update available
+
+- **WHEN** an authenticated operator loads any dashboard page while a newer version is known
+- **THEN** the brand block SHALL show an update badge with the latest version next to the running version
+
+#### Scenario: No update known, check enabled
+
+- **WHEN** an authenticated operator loads any dashboard page while no newer version is known and the update check is enabled
+- **THEN** the brand-block slot SHALL render a quiet link to `/dashboard/update` in place of the badge
+
+#### Scenario: Check disabled
+
+- **WHEN** `REMBRIC_UPDATE_CHECK=off` is set
+- **THEN** the brand-block slot SHALL render neither a badge nor a quiet link
+
+## ADDED Requirements
+
+### Requirement: The update page MUST offer a manual check with an honest outcome
+
+The up-to-date state of `/dashboard/update` SHALL render a CSRF-protected form that triggers the manual release check and, when a check has run in the current process lifetime, a last-checked timestamp rendered via `formatTs`. After the manual check: if a newer version was found, the page SHALL render the existing update-available view; if no newer version is known, the page SHALL show a flash stating the deployment is still up to date; if the check could not reach the GitHub API, the page SHALL show an error flash that names the failure (distinct from "up to date") and notes this is expected on air-gapped hosts. The manual-check form SHALL NOT render when the update check is disabled; a disabled note naming `REMBRIC_UPDATE_CHECK=off` SHALL render instead, and the page SHALL NOT claim the deployment is up to date (the server never checks, so it cannot know). The manual check action SHALL NOT require a `data-confirm` modal (read-only, reversible).
+
+#### Scenario: Manual check finds an update
+
+- **WHEN** the operator triggers the manual check and a newer release exists
+- **THEN** `/dashboard/update` SHALL render the update-available view (version diff, changelog, capability-appropriate action) and the brand-block badge SHALL appear on subsequent page loads
+
+#### Scenario: Manual check, still up to date
+
+- **WHEN** the operator triggers the manual check and no newer release exists
+- **THEN** `/dashboard/update` SHALL show a flash stating no newer version is known and remain on the up-to-date state
+
+#### Scenario: Manual check fails
+
+- **WHEN** the operator triggers the manual check and the GitHub API is unreachable
+- **THEN** `/dashboard/update` SHALL show an error flash that distinguishes the failure from being up to date
+
+#### Scenario: Check disabled hides the action
+
+- **WHEN** `REMBRIC_UPDATE_CHECK=off` is set and the operator opens `/dashboard/update`
+- **THEN** the page SHALL NOT render the manual-check form

--- a/openspec/changes/archive/2026-06-07-add-manual-update-check/specs/self-update/spec.md
+++ b/openspec/changes/archive/2026-06-07-add-manual-update-check/specs/self-update/spec.md
@@ -1,0 +1,50 @@
+# self-update — delta for add-manual-update-check
+
+## MODIFIED Requirements
+
+### Requirement: The server MUST check for new releases at most once per 24 hours, default-on with an opt-out
+
+The server SHALL determine the latest published release of Rembric by querying the GitHub Releases API for the distribution repository, automatically at most once per 24-hour window, lazily (triggered by dashboard activity, not a timer), using conditional requests (ETag) where possible. The result SHALL be cached in memory together with the release changelog body. Setting `REMBRIC_UPDATE_CHECK=off` SHALL disable the check entirely. Any failure of the automatic check (network unreachable, rate-limited, malformed response) SHALL be silent: no error logs above debug level, no dashboard warnings, and all other functionality unaffected. Prerelease versions SHALL be ignored.
+
+The 24-hour cadence bounds the automatic path only; an operator-initiated manual check (see the manual-check requirement) MAY run at any time and SHALL reset the window.
+
+#### Scenario: New version detected
+
+- **WHEN** the running version is `0.21.1` and the GitHub Releases API reports latest release `server-v0.22.0`
+- **THEN** the server SHALL expose update availability (current version, latest version, publication date, changelog body) to the dashboard layer
+
+#### Scenario: Check disabled by operator
+
+- **WHEN** `REMBRIC_UPDATE_CHECK=off` is set
+- **THEN** the server SHALL NOT contact the GitHub API and the dashboard SHALL render with no update badge or modal
+
+#### Scenario: Air-gapped host
+
+- **WHEN** the GitHub API is unreachable
+- **THEN** the server SHALL behave as if no update is available, without surfacing errors or warnings to the operator
+
+## ADDED Requirements
+
+### Requirement: An operator MUST be able to force an immediate release check that reports its outcome
+
+The server SHALL expose an operator-initiated manual check that performs the release query immediately, bypassing the 24-hour window, while reusing the conditional-request (ETag) cache and deduplicating against any in-flight check. Unlike the automatic path, the manual check SHALL report its outcome to the caller as one of: a newer version was found, no newer version is known, or the check failed to reach the GitHub API. The manual check SHALL be unavailable when `REMBRIC_UPDATE_CHECK=off`. The server SHALL expose the timestamp of the most recent check (manual or automatic) within the current process lifetime.
+
+#### Scenario: Manual check finds a new release
+
+- **WHEN** an operator triggers a manual check and the GitHub Releases API reports a release newer than the running version
+- **THEN** the check SHALL report the update outcome and the cached update availability SHALL reflect the new release immediately
+
+#### Scenario: Manual check on an up-to-date deployment
+
+- **WHEN** an operator triggers a manual check and no newer release exists
+- **THEN** the check SHALL report that no newer version is known, without claiming more than the API returned
+
+#### Scenario: Manual check cannot reach GitHub
+
+- **WHEN** an operator triggers a manual check and the GitHub API is unreachable or returns an error
+- **THEN** the check SHALL report the failure outcome to the operator (distinct from "no newer version") while the automatic path's silent-failure behavior remains unchanged
+
+#### Scenario: Manual check while disabled
+
+- **WHEN** `REMBRIC_UPDATE_CHECK=off` is set
+- **THEN** the manual check SHALL NOT contact the GitHub API and SHALL NOT be offered in the dashboard

--- a/openspec/changes/archive/2026-06-07-add-manual-update-check/tasks.md
+++ b/openspec/changes/archive/2026-06-07-add-manual-update-check/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: add-manual-update-check
+
+## 1. Service: force-check with outcome
+
+- [x] 1.1 Add `checkNow(): Promise<{ outcome: 'update' | 'none' | 'error'; info: UpdateInfo | null }>` to `UpdateCheckService` (`apps/server/src/services/update-check.ts`): forces a refresh bypassing the interval, dedupes against `inflight`, maps fetch failure to `'error'` and a non-newer result to `'none'`; returns `'none'`-shaped no-op when disabled. Expose `lastCheckedAt` (null until first check) and `enabled` as readonly accessors. Automatic `peek()` path byte-for-byte unchanged.
+- [x] 1.2 Tests in `apps/server/src/services/update-check.test.ts`: `checkNow` bypasses the 24h window; outcome `update` on newer release; `none` on same/older release and on 304; `error` on network failure and non-OK status; disabled service never fetches; `lastCheckedAt` reflects both manual and automatic checks. Verify with `pnpm vitest run apps/server/src/services/update-check.test.ts`.
+
+## 2. Route: POST /dashboard/update/check
+
+- [x] 2.1 Add `POST /check` to `createUpdateRouter` (`apps/server/src/dashboard/update.ts`) following the `/start` pattern: session guard, `readFormAndVerifyCsrf` with action `update.check`, `await deps.updates.checkNow()`, redirect to `/dashboard/update` (plain on `update`, `?checked=none` / `?checked=error` otherwise). Reject (redirect, no fetch) when the service is disabled.
+- [x] 2.2 Map `checked=none` to an info flash ("Checked — no newer release is known.") and `checked=error` to an error flash naming the GitHub fetch failure and noting it is expected on air-gapped hosts, alongside the existing `?err=` mapping in the GET handler.
+- [x] 2.3 Router tests in `apps/server/src/dashboard/update.test.ts` (extend existing): POST requires session + CSRF; outcome→redirect mapping; flash rendering for both query params; disabled service short-circuits without fetching.
+
+## 3. Update page: CHECK NOW + last checked
+
+- [x] 3.1 In the up-to-date branch of `GET /dashboard/update`, render the CSRF-protected CHECK NOW form (no `data-confirm`) and, when `lastCheckedAt` is non-null, a "Last checked" line via `formatTs`. When the check is disabled, render the existing disabled-note copy with no form.
+- [x] 3.2 View tests: up-to-date state contains the form posting to `/dashboard/update/check`; last-checked line renders only after a check; disabled state has no form.
+
+## 4. Brand-block slot: persistent
+
+- [x] 4.1 Add a quiet-slot renderer next to `updateBadge` in `apps/server/src/dashboard/update-modal.ts` (muted link to `/dashboard/update`, label decided against the brutalist style — e.g. `UP TO DATE ›`). Extend `updateShellExtras` to return it when no update state exists and the check is enabled, and `null` when disabled; thread the `enabled` signal through `apps/server/src/server/dashboard-router.ts`.
+- [x] 4.2 CSS for the muted variant in `apps/server/src/dashboard/styles/` reusing the `.sb-update` layout and locked design tokens (no inline styles, no new fonts/colors).
+- [x] 4.3 Shell tests (`apps/server/src/dashboard/components.test.ts` / router tests): badge renders when update known (unchanged assertions); quiet link renders when none known and check enabled; nothing renders when `REMBRIC_UPDATE_CHECK=off`. Verify sidebar and mobile bar both carry the slot.
+
+## 5. Verification
+
+- [x] 5.1 `pnpm run typecheck && pnpm run lint && pnpm test` clean.
+- [x] 5.2 Smoke against the dev stack (`pnpm run dev:docker:up`, see rembric-smoke-tests skill): quiet link visible in sidebar + mobile bar, CHECK NOW round-trips with the "no newer release" flash, simulate a newer release (point the service at a stub or temporarily lower `currentVersion`) to see the update view + badge, `REMBRIC_UPDATE_CHECK=off` hides slot and form. Iterate on the quiet-slot UI with the operator before archiving — label/styling is explicitly open for review.

--- a/openspec/specs/dashboard/spec.md
+++ b/openspec/specs/dashboard/spec.md
@@ -843,17 +843,24 @@ The dashboard SHALL render the running server version (the `version` field of th
 
 ### Requirement: The dashboard MUST surface update availability as a badge in the brand block
 
-When the update check reports a newer version, the dashboard SHALL render an update badge adjacent to the running-version line in the brand block (sidebar, mobile bar) showing the latest available version. The badge SHALL persist across visits until the deployment runs the newer version and SHALL NOT be affected by modal dismissal. When no update is available, or the update check is disabled or failed, no badge SHALL render.
+When the update check reports a newer version, the dashboard SHALL render an update badge adjacent to the running-version line in the brand block (sidebar, mobile bar) showing the latest available version. The badge SHALL persist across visits until the deployment runs the newer version and SHALL NOT be affected by modal dismissal.
+
+When no newer version is known and the update check is enabled, the same brand-block slot SHALL render a quiet link (muted styling, no lime accent) to `/dashboard/update`, so the update page is always reachable from the shell. When the update check is disabled (`REMBRIC_UPDATE_CHECK=off`), the slot SHALL render nothing.
 
 #### Scenario: Update available
 
 - **WHEN** an authenticated operator loads any dashboard page while a newer version is known
 - **THEN** the brand block SHALL show an update badge with the latest version next to the running version
 
-#### Scenario: No update information
+#### Scenario: No update known, check enabled
 
-- **WHEN** the update check is disabled or has no result
-- **THEN** the brand block SHALL render exactly as it does today (running version only)
+- **WHEN** an authenticated operator loads any dashboard page while no newer version is known and the update check is enabled
+- **THEN** the brand-block slot SHALL render a quiet link to `/dashboard/update` in place of the badge
+
+#### Scenario: Check disabled
+
+- **WHEN** `REMBRIC_UPDATE_CHECK=off` is set
+- **THEN** the brand-block slot SHALL render neither a badge nor a quiet link
 
 ### Requirement: The dashboard MUST present a per-version dismissable update modal with the release changelog
 
@@ -927,3 +934,27 @@ Concretely:
 - **WHEN** an authenticated operator renders the projects, prompts, session-detail prompts, or run-detail ops tables
 - **THEN** no `<th>` labelled `id` SHALL be present and no cell SHALL render the row's own short id
 - **AND** row action forms SHALL keep functioning (they carry the full id in their `action` URLs)
+
+### Requirement: The update page MUST offer a manual check with an honest outcome
+
+The up-to-date state of `/dashboard/update` SHALL render a CSRF-protected form that triggers the manual release check and, when a check has run in the current process lifetime, a last-checked timestamp rendered via `formatTs`. After the manual check: if a newer version was found, the page SHALL render the existing update-available view; if no newer version is known, the page SHALL show a flash stating the deployment is still up to date; if the check could not reach the GitHub API, the page SHALL show an error flash that names the failure (distinct from "up to date") and notes this is expected on air-gapped hosts. The manual-check form SHALL NOT render when the update check is disabled; a disabled note naming `REMBRIC_UPDATE_CHECK=off` SHALL render instead, and the page SHALL NOT claim the deployment is up to date (the server never checks, so it cannot know). The manual check action SHALL NOT require a `data-confirm` modal (read-only, reversible).
+
+#### Scenario: Manual check finds an update
+
+- **WHEN** the operator triggers the manual check and a newer release exists
+- **THEN** `/dashboard/update` SHALL render the update-available view (version diff, changelog, capability-appropriate action) and the brand-block badge SHALL appear on subsequent page loads
+
+#### Scenario: Manual check, still up to date
+
+- **WHEN** the operator triggers the manual check and no newer release exists
+- **THEN** `/dashboard/update` SHALL show a flash stating no newer version is known and remain on the up-to-date state
+
+#### Scenario: Manual check fails
+
+- **WHEN** the operator triggers the manual check and the GitHub API is unreachable
+- **THEN** `/dashboard/update` SHALL show an error flash that distinguishes the failure from being up to date
+
+#### Scenario: Check disabled hides the action
+
+- **WHEN** `REMBRIC_UPDATE_CHECK=off` is set and the operator opens `/dashboard/update`
+- **THEN** the page SHALL NOT render the manual-check form

--- a/openspec/specs/self-update/spec.md
+++ b/openspec/specs/self-update/spec.md
@@ -8,7 +8,9 @@ Defines how Rembric detects new releases and updates its own container from the 
 
 ### Requirement: The server MUST check for new releases at most once per 24 hours, default-on with an opt-out
 
-The server SHALL determine the latest published release of Rembric by querying the GitHub Releases API for the distribution repository, at most once per 24-hour window, lazily (triggered by dashboard activity, not a timer), using conditional requests (ETag) where possible. The result SHALL be cached in memory together with the release changelog body. Setting `REMBRIC_UPDATE_CHECK=off` SHALL disable the check entirely. Any failure of the check (network unreachable, rate-limited, malformed response) SHALL be silent: no error logs above debug level, no dashboard warnings, and all other functionality unaffected. Prerelease versions SHALL be ignored.
+The server SHALL determine the latest published release of Rembric by querying the GitHub Releases API for the distribution repository, automatically at most once per 24-hour window, lazily (triggered by dashboard activity, not a timer), using conditional requests (ETag) where possible. The result SHALL be cached in memory together with the release changelog body. Setting `REMBRIC_UPDATE_CHECK=off` SHALL disable the check entirely. Any failure of the automatic check (network unreachable, rate-limited, malformed response) SHALL be silent: no error logs above debug level, no dashboard warnings, and all other functionality unaffected. Prerelease versions SHALL be ignored.
+
+The 24-hour cadence bounds the automatic path only; an operator-initiated manual check (see the manual-check requirement) MAY run at any time and SHALL reset the window.
 
 #### Scenario: New version detected
 
@@ -24,6 +26,30 @@ The server SHALL determine the latest published release of Rembric by querying t
 
 - **WHEN** the GitHub API is unreachable
 - **THEN** the server SHALL behave as if no update is available, without surfacing errors or warnings to the operator
+
+### Requirement: An operator MUST be able to force an immediate release check that reports its outcome
+
+The server SHALL expose an operator-initiated manual check that performs the release query immediately, bypassing the 24-hour window, while reusing the conditional-request (ETag) cache and deduplicating against any in-flight check. Unlike the automatic path, the manual check SHALL report its outcome to the caller as one of: a newer version was found, no newer version is known, or the check failed to reach the GitHub API. The manual check SHALL be unavailable when `REMBRIC_UPDATE_CHECK=off`. The server SHALL expose the timestamp of the most recent check (manual or automatic) within the current process lifetime.
+
+#### Scenario: Manual check finds a new release
+
+- **WHEN** an operator triggers a manual check and the GitHub Releases API reports a release newer than the running version
+- **THEN** the check SHALL report the update outcome and the cached update availability SHALL reflect the new release immediately
+
+#### Scenario: Manual check on an up-to-date deployment
+
+- **WHEN** an operator triggers a manual check and no newer release exists
+- **THEN** the check SHALL report that no newer version is known, without claiming more than the API returned
+
+#### Scenario: Manual check cannot reach GitHub
+
+- **WHEN** an operator triggers a manual check and the GitHub API is unreachable or returns an error
+- **THEN** the check SHALL report the failure outcome to the operator (distinct from "no newer version") while the automatic path's silent-failure behavior remains unchanged
+
+#### Scenario: Manual check while disabled
+
+- **WHEN** `REMBRIC_UPDATE_CHECK=off` is set
+- **THEN** the manual check SHALL NOT contact the GitHub API and SHALL NOT be offered in the dashboard
 
 ### Requirement: Self-update capability MUST be detected at runtime and never assumed
 


### PR DESCRIPTION
## Why

The release check runs lazily at most once per 24h, so an operator who learns a release shipped had no way to force a check — and when no update is known there was no visible path to `/dashboard/update` at all (the badge only renders once a newer version is already cached).

## What

- **`UpdateCheckService.checkNow()`** — bypasses the 24h window (ETag-aware, inflight-deduped) and reports an honest outcome: `update` / `none` / `error`. The silent-failure contract stays scoped to the automatic path; a manual action never claims "up to date" when GitHub was unreachable. Also exposes `lastCheckedAt` and `enabled`.
- **`POST /dashboard/update/check`** — session + CSRF, PRG with outcome flashes (`checked=none` / `checked=error`; a found update re-renders the existing Update Available view).
- **CHECK NOW** button + LAST CHECKED timestamp on the up-to-date state of `/dashboard/update`; honest `UPDATE CHECK DISABLED` note when `REMBRIC_UPDATE_CHECK=off` (the page no longer claims "up to date" when it never checks).
- **Persistent brand-block slot** (sidebar + mobile bar): lime `UPDATE v<latest>` badge when a release is known (unchanged), quiet `UP TO DATE ›` link to the update page otherwise, nothing when the check is disabled.
- Update views now follow the canonical `Rembric <Page>.` header pattern (fixes the two pre-existing violations too).

No schema changes, no MCP changes, no new dependencies, no change to the one-click execution path or capability detection.

## OpenSpec

`add-manual-update-check` archived; `self-update` and `dashboard` specs synced (manual-check requirement added, 24h cadence re-scoped to the automatic path, brand-slot requirement updated to three states).

## Testing

- 614 unit/e2e tests green (15 service + 4 e2e added)
- Smoke against `dev:docker:up` with a stubbed release feed (`REMBRIC_UPDATE_CHECK_URL`): quiet slot ×2, CHECK NOW round-trip (`none`), GitHub-down (`error` flash), release found (update view + badge), `REMBRIC_UPDATE_CHECK=off` (no slot, no form), CSRF-less POST → 403