### PR TITLE
feat(server): align consolidation dashboard with the deterministic sweep

### DIFF
--- a/apps/server/src/consolidation/index.ts
+++ b/apps/server/src/consolidation/index.ts
@@ -31,7 +31,7 @@ export type {
   ConsolidationOpType,
 } from './operations.js';
 
-export { ConsolidationRunner } from './runner.js';
+export { ConsolidationRunner, DEFAULT_MIN_INTERVAL_MS } from './runner.js';
 export type {
   ConsolidationRunnerOptions,
   ConsolidationRunSummary,

--- a/apps/server/src/consolidation/runner.ts
+++ b/apps/server/src/consolidation/runner.ts
@@ -53,7 +53,7 @@ export interface ScopeRunResult {
 }
 
 const DEFAULT_ORPHAN_DEADLINE_MS = 14 * 86_400_000;
-const DEFAULT_MIN_INTERVAL_MS = 6 * 3_600_000;
+export const DEFAULT_MIN_INTERVAL_MS = 6 * 3_600_000;
 const ORPHAN_BATCH = 50;
 
 export class ConsolidationRunner {

--- a/apps/server/src/consolidation/runner.ts
+++ b/apps/server/src/consolidation/runner.ts
@@ -53,7 +53,7 @@ export interface ScopeRunResult {
 }
 
 const DEFAULT_ORPHAN_DEADLINE_MS = 14 * 86_400_000;
-export const DEFAULT_MIN_INTERVAL_MS = 6 * 3_600_000;
+export const DEFAULT_MIN_INTERVAL_MS = 24 * 3_600_000;
 const ORPHAN_BATCH = 50;
 
 export class ConsolidationRunner {

--- a/apps/server/src/dashboard/consolidation.ts
+++ b/apps/server/src/dashboard/consolidation.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, isNull, sql } from 'drizzle-orm';
 import { Hono, type Context } from 'hono';
 
+import type { ConsolidationRunSummary } from '../consolidation/index.js';
 import {
   NotUndoableError,
   PurgedRowMissingError,
@@ -9,6 +10,7 @@ import {
 } from '../consolidation/operations.js';
 import type { Db } from '../db/client.js';
 import { consolidationOps, consolidationRuns } from '../db/schema/consolidation.js';
+import { projects } from '../db/schema/projects.js';
 import type { SessionsService } from '../services/sessions.js';
 
 import { backLink, PAGE_SIZE, pager, urlWithPage, viewHead } from './components.js';
@@ -20,10 +22,44 @@ import type { ResolvedSession } from './types.js';
 export interface ConsolidationDeps {
   db: Db;
   sessions: SessionsService;
+  /** Forced sweep across all scopes (same lambda as the admin endpoint). */
+  triggerSweep: () => ConsolidationRunSummary;
 }
 
 function getSession(c: Context): ResolvedSession | null {
   return (c.get('session') as ResolvedSession | undefined) ?? null;
+}
+
+/** `project:<id>` → project slug when the project still exists; raw value otherwise. */
+function scopeLabel(db: Db, scope: string | null): string {
+  if (scope === null) return '—';
+  if (!scope.startsWith('project:')) return scope;
+  const row = db
+    .select({ slug: projects.slug })
+    .from(projects)
+    .where(eq(projects.id, scope.slice('project:'.length)))
+    .get();
+  return row?.slug ?? scope;
+}
+
+/** Sweep runs store `{"archives":N,"orphaned":M}`; legacy LLM runs store prose. */
+function formatRunSummary(summary: string | null): string {
+  if (summary === null) return '—';
+  try {
+    const parsed: unknown = JSON.parse(summary);
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      typeof (parsed as Record<string, unknown>)['archives'] === 'number' &&
+      typeof (parsed as Record<string, unknown>)['orphaned'] === 'number'
+    ) {
+      const ops = parsed as { archives: number; orphaned: number };
+      return `${ops.archives} archived · ${ops.orphaned} orphaned`;
+    }
+  } catch {
+    // Legacy prose summary — fall through to the raw text.
+  }
+  return summary;
 }
 
 export function createConsolidationRouter(deps: ConsolidationDeps): Hono {
@@ -81,12 +117,25 @@ export function createConsolidationRouter(deps: ConsolidationDeps): Hono {
             <a href="/dashboard/consolidation/${r.id}">${formatTs(r.startedAt)}</a>
           </td>
           <td class="muted">${formatTs(r.finishedAt)}</td>
-          <td>${r.scope ?? '—'}</td>
-          <td>${r.llmModel ?? '—'}</td>
+          <td>${scopeLabel(deps.db, r.scope)}</td>
           <td>${status}</td>
         </tr>
       `;
     });
+
+    const sweepForm = html`
+      <form
+        action="/dashboard/consolidation/run"
+        method="post"
+        class="inline"
+        data-confirm="Force a consolidation sweep across all scopes now? Ops are journaled and reversible."
+        data-confirm-label="RUN SWEEP"
+        data-confirm-tone="warn"
+      >
+        ${csrfInput(session.session, deps.sessions, 'sweep.run')}
+        <button class="warn" type="submit">Run sweep now</button>
+      </form>
+    `;
 
     const body = html`
       ${viewHead({
@@ -95,11 +144,11 @@ export function createConsolidationRouter(deps: ConsolidationDeps): Hono {
         hl: 'Rembric',
         meta: [{ k: 'RUNS', v: String(runs.length) }],
       })}
+      <p>${sweepForm}</p>
       ${runs.length === 0
         ? html`<p class="muted">
-            No runs yet. The deterministic sweep runs on session start (throttled per scope);
-            trigger one manually via <code>POST /admin/consolidation/run</code> with the admin
-            bearer token.
+            No runs yet. The deterministic sweep runs on session start (throttled per scope); force
+            one with “Run sweep now”.
           </p>`
         : html`
             <div class="tbl-host">
@@ -109,7 +158,6 @@ export function createConsolidationRouter(deps: ConsolidationDeps): Hono {
                     <th>started</th>
                     <th>finished</th>
                     <th>scope</th>
-                    <th>model</th>
                     <th>status</th>
                   </tr>
                 </thead>
@@ -131,6 +179,15 @@ export function createConsolidationRouter(deps: ConsolidationDeps): Hono {
     return c.html(
       renderPage(c, deps.sessions, body, { title: 'Consolidation', activeNav: 'consolidation' }),
     );
+  });
+
+  app.post('/run', async (c) => {
+    const session = getSession(c);
+    if (!session) return c.redirect('/dashboard/login');
+    const form = await readFormAndVerifyCsrf(c, session.session, deps.sessions, 'sweep.run');
+    if (form instanceof Response) return form;
+    deps.triggerSweep();
+    return c.redirect('/dashboard/consolidation');
   });
 
   app.get('/:id', (c) => {
@@ -234,12 +291,14 @@ export function createConsolidationRouter(deps: ConsolidationDeps): Hono {
         </div>
         <div class="stat-card">
           <div class="label">Scope</div>
-          <div class="value">${run.scope ?? '—'}</div>
+          <div class="value">${scopeLabel(deps.db, run.scope)}</div>
         </div>
-        <div class="stat-card">
-          <div class="label">Model</div>
-          <div class="value" style="font-size:.9rem">${run.llmModel ?? '—'}</div>
-        </div>
+        ${run.llmModel
+          ? html`<div class="stat-card">
+              <div class="label">Model</div>
+              <div class="value" style="font-size:.9rem">${run.llmModel}</div>
+            </div>`
+          : raw('')}
         <div class="stat-card">
           <div class="label">Ops</div>
           <div class="value">${ops.length}</div>
@@ -247,7 +306,7 @@ export function createConsolidationRouter(deps: ConsolidationDeps): Hono {
       </div>
 
       <h2>Summary</h2>
-      <pre>${run.summary ?? '—'}</pre>
+      <pre>${formatRunSummary(run.summary)}</pre>
 
       <h2>Ops</h2>
       ${ops.length === 0

--- a/apps/server/src/dashboard/styles/core/layout.css
+++ b/apps/server/src/dashboard/styles/core/layout.css
@@ -290,16 +290,18 @@
   flex-shrink: 0;
   object-fit: contain;
 }
+/* Stacked like the sidebar brand: REMBRIC over the version. Always
+   fits next to the update slot + menu toggle, no truncation games. */
 .mob-bar .brand .label-stack {
   min-width: 0;
-  display: inline-flex;
-  align-items: baseline;
-  gap: var(--s-2);
-  flex-wrap: nowrap;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 .mob-bar .brand .label-stack > div {
   font-size: 0.78rem;
   letter-spacing: 0.12em;
+  line-height: 1.2;
 }
 .mob-bar .brand .label-stack small {
   color: var(--fg-dim);
@@ -307,11 +309,7 @@
   font-size: 0.6rem;
   letter-spacing: 0.14em;
   white-space: nowrap;
-}
-.mob-bar .brand .label-stack small::before {
-  content: '·';
-  margin-right: var(--s-2);
-  color: var(--fg-faint);
+  line-height: 1.2;
 }
 .mob-bar .brand .sect {
   color: var(--fg-dim);

--- a/apps/server/src/dashboard/styles/core/layout.css
+++ b/apps/server/src/dashboard/styles/core/layout.css
@@ -377,8 +377,6 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  padding-bottom: var(--s-5);
-  border-bottom: 1px solid var(--fg-faint);
   margin-bottom: var(--s-6);
   gap: var(--s-5);
 }

--- a/apps/server/src/dashboard/styles/core/patterns.css
+++ b/apps/server/src/dashboard/styles/core/patterns.css
@@ -996,9 +996,7 @@ form .field label {
   margin: 0;
   flex-shrink: 0;
 }
-.mob-bar .sb-update .label {
-  display: none;
-}
+/* The slot label stays visible on mobile — a bare dot reads as noise. */
 
 dialog.upd-modal {
   width: min(640px, calc(100vw - 2 * var(--s-4)));

--- a/apps/server/src/dashboard/styles/core/patterns.css
+++ b/apps/server/src/dashboard/styles/core/patterns.css
@@ -753,6 +753,8 @@ form .field label {
   }
   .mob-bar {
     display: flex;
+    /* .main's own top padding provides the gap below the bar. */
+    margin-bottom: 0;
   }
   .sb .sb-foot {
     margin-top: 0;
@@ -763,7 +765,8 @@ form .field label {
     gap: var(--s-1);
   }
   .main {
-    padding: var(--s-4) var(--s-5) var(--s-7);
+    /* Same top inset as the desktop main (--s-6) below the sticky bar. */
+    padding: var(--s-6) var(--s-5) var(--s-7);
     overflow-x: hidden;
   }
   .view-head h1 {
@@ -911,7 +914,9 @@ form .field label {
     line-height: 1;
   }
   .main {
-    padding: var(--s-3) var(--s-4) var(--s-6);
+    /* Top inset one step above the side gutters, mirroring the wider
+       breakpoints (s-6/s-5 at ≤980, s-5/s-4 here). */
+    padding: var(--s-5) var(--s-4) var(--s-6);
   }
   .stat .stat-v {
     font-size: 2.4rem;

--- a/apps/server/src/dashboard/styles/views/home.css
+++ b/apps/server/src/dashboard/styles/views/home.css
@@ -88,11 +88,14 @@
   display: grid;
   align-content: center;
   margin: 0;
-  min-height: 220px;
   font-size: 0.98rem;
-  line-height: 1.65;
+  line-height: 1.9;
   color: var(--fg-dim);
   white-space: pre;
   word-break: normal;
   overflow-x: auto;
+  /* No inner box — the surrounding card is the frame. */
+  border: 0;
+  background: transparent;
+  padding: 0;
 }

--- a/apps/server/src/dashboard/styles/views/home.css
+++ b/apps/server/src/dashboard/styles/views/home.css
@@ -73,3 +73,26 @@
     justify-content: flex-start;
   }
 }
+
+/* activity card — the bars box fills the available card area */
+.act-card {
+  display: flex;
+  flex-direction: column;
+}
+.act-card .card-body {
+  flex: 1;
+  display: flex;
+}
+.act-card .act-bars {
+  flex: 1;
+  display: grid;
+  align-content: center;
+  margin: 0;
+  min-height: 220px;
+  font-size: 0.98rem;
+  line-height: 1.65;
+  color: var(--fg-dim);
+  white-space: pre;
+  word-break: normal;
+  overflow-x: auto;
+}

--- a/apps/server/src/scripts/seed-dev.ts
+++ b/apps/server/src/scripts/seed-dev.ts
@@ -226,8 +226,8 @@ export function runSeed(deps: SeedDeps): SeedResult {
       agent: 'codex-cli',
       cwd: '/Users/dev/demo',
       summary:
-        'Goal: investigate why the consolidation runs view rendered an empty week.\nDiscoveries: CONSOLIDATION_CRON=0 3 * * * had never fired because the daemon was restarted at 02:55 each night.\nFix: switched to "30 3 * * *" so the daemon is always warm when the cron tick lands.\nNext: monitor for a week to confirm.',
-      title: 'Diagnose consolidation cron miss',
+        'Goal: investigate why the consolidation runs view rendered an empty week.\nDiscoveries: the lazy sweep only fires on session start, throttled to one run per scope per 6h — no agent had opened a session against this project all week.\nFix: forced a run with the dashboard "Run sweep now" button and confirmed the journal populated.\nNext: monitor that regular agent sessions keep the sweep cadence.',
+      title: 'Diagnose missing consolidation runs',
     },
     {
       agent: 'hermes',
@@ -329,8 +329,8 @@ export function runSeed(deps: SeedDeps): SeedResult {
     {
       relation: 'conflicts_with',
       topicKey: 'demo-judged-conflicts',
-      source: 'Run consolidator nightly at 03:00 UTC (matches default CONSOLIDATION_CRON).',
-      target: 'Run consolidator every 6h to keep orphan promotions snappy.',
+      source: 'Rely on the lazy session-start sweep only; never force manual consolidation runs.',
+      target: 'Force a manual sweep after every bulk import so decay stays current.',
     },
     {
       relation: 'related',

--- a/apps/server/src/scripts/seed-dev.ts
+++ b/apps/server/src/scripts/seed-dev.ts
@@ -226,7 +226,7 @@ export function runSeed(deps: SeedDeps): SeedResult {
       agent: 'codex-cli',
       cwd: '/Users/dev/demo',
       summary:
-        'Goal: investigate why the consolidation runs view rendered an empty week.\nDiscoveries: the lazy sweep only fires on session start, throttled to one run per scope per 6h — no agent had opened a session against this project all week.\nFix: forced a run with the dashboard "Run sweep now" button and confirmed the journal populated.\nNext: monitor that regular agent sessions keep the sweep cadence.',
+        'Goal: investigate why the consolidation runs view rendered an empty week.\nDiscoveries: the lazy sweep only fires on session start, throttled to one run per scope per day — no agent had opened a session against this project all week.\nFix: forced a run with the dashboard "Run sweep now" button and confirmed the journal populated.\nNext: monitor that regular agent sessions keep the sweep cadence.',
       title: 'Diagnose missing consolidation runs',
     },
     {

--- a/apps/server/src/server/bootstrap.ts
+++ b/apps/server/src/server/bootstrap.ts
@@ -282,6 +282,9 @@ export async function bootstrap(
       dataDir: config.dataDir,
       updates,
       selfUpdate,
+      triggerSweep: () => runner.runAll({ force: true }),
+      orphanAfterMs: config.judgments.orphanAfterMs,
+      orphanDeadlineMs: config.judgments.orphanDeadlineMs,
     },
   });
 

--- a/apps/server/src/server/dashboard-router.ts
+++ b/apps/server/src/server/dashboard-router.ts
@@ -425,7 +425,7 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
         <div>
           ${sectionBar({
             name: 'RECENT SESSIONS',
-            meta: 'TIMELINE / NEWEST FIRST',
+            meta: 'NEWEST FIRST',
             more: raw('<a href="/dashboard/sessions" style="color:var(--lime)">OPEN ALL ›</a>'),
           })}
           ${recentSessions.length === 0

--- a/apps/server/src/server/dashboard-router.ts
+++ b/apps/server/src/server/dashboard-router.ts
@@ -6,6 +6,7 @@ import { sql } from 'drizzle-orm';
 import { Hono, type Context, type Next } from 'hono';
 import { getCookie, setCookie } from 'hono/cookie';
 
+import { DEFAULT_MIN_INTERVAL_MS, type ConsolidationRunSummary } from '../consolidation/index.js';
 import { createAssetsMiddleware } from '../dashboard/assets.js';
 import {
   btn,
@@ -67,6 +68,11 @@ export interface DashboardDeps {
   dataDir: string;
   updates: UpdateCheckService;
   selfUpdate: SelfUpdateOrchestrator;
+  /** Forced sweep across all scopes (same lambda as the admin endpoint). */
+  triggerSweep: () => ConsolidationRunSummary;
+  /** Resolved judgment aging thresholds (from `config.judgments`). */
+  orphanAfterMs: number;
+  orphanDeadlineMs: number;
 }
 
 export interface DashboardStats {
@@ -284,17 +290,19 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
         id: string;
         started_at: number;
         finished_at: number | null;
-        llm_model: string | null;
         scope: string | null;
+        scope_slug: string | null;
         total_ops: number;
         reverted_ops: number;
       }>(sql`
-      SELECT r.id, r.started_at, r.finished_at, r.llm_model, r.scope,
+      SELECT r.id, r.started_at, r.finished_at, r.scope,
+             p.slug AS scope_slug,
              (SELECT COUNT(*) FROM consolidation_ops o
               WHERE o.consolidation_id = r.id) AS total_ops,
              (SELECT COUNT(*) FROM consolidation_ops o
               WHERE o.consolidation_id = r.id AND o.reverted_at IS NOT NULL) AS reverted_ops
       FROM consolidation_runs r
+      LEFT JOIN projects p ON p.id = substr(r.scope, 9)
       ORDER BY r.started_at DESC
       LIMIT 1
     `)[0] ?? null;
@@ -467,7 +475,9 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
           <span class="sub"
             >${lastRun
               ? html`${relTime(lastRun.finished_at ?? lastRun.started_at)} ·
-                ${lastRun.scope ?? 'global'}`
+                ${lastRun.scope === 'global'
+                  ? 'global'
+                  : (lastRun.scope_slug ?? lastRun.scope ?? 'global')}`
               : 'NEVER'}</span
           >
         </div>
@@ -479,14 +489,20 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
         <div class="cell">
           <span class="lab"><span class="bn warn"></span> ORPHANED PENDINGS</span>
           <span class="val ${orphanedJ > 0 ? 'warn' : 'lime'}">${orphanedJ}</span>
-          <span class="sub">AUTO-PROMOTED FROM PENDING &gt; 96H</span>
+          <span class="sub"
+            >RE-EXPOSED &gt; ${fmtWindow(deps.orphanAfterMs)} · ORPHANED &gt;
+            ${fmtWindow(deps.orphanDeadlineMs)}</span
+          >
         </div>
         <div class="cell">
-          <span class="lab"><span class="bn"></span> NEXT RUN</span>
+          <span class="lab"><span class="bn"></span> TRIGGER</span>
           <span class="val" style="font-family:var(--f-mono);font-size:0.9rem"
-            >${process.env.CONSOLIDATION_CRON ?? '03:00 UTC'}</span
+            >ON SESSION START</span
           >
-          <span class="sub">MODEL ${lastRun?.llm_model ?? '—'}</span>
+          <span class="sub"
+            >THROTTLED ${fmtWindow(DEFAULT_MIN_INTERVAL_MS)} / SCOPE · MANUAL FROM
+            CONSOLIDATION</span
+          >
         </div>
       </div>
 
@@ -553,7 +569,14 @@ ${ascBars(activity)}</pre
     createPromptsRouter({ db: deps.db, prompts: deps.prompts, sessions: deps.sessions }),
   );
   app.route('/judgments', createJudgmentsRouter({ db: deps.db, sessions: deps.sessions }));
-  app.route('/consolidation', createConsolidationRouter({ db: deps.db, sessions: deps.sessions }));
+  app.route(
+    '/consolidation',
+    createConsolidationRouter({
+      db: deps.db,
+      sessions: deps.sessions,
+      triggerSweep: deps.triggerSweep,
+    }),
+  );
   app.route(
     '/projects',
     createProjectsRouter({ projects: deps.projects, sessions: deps.sessions }),
@@ -645,6 +668,11 @@ function relTime(input: number | Date): string {
   if (d < 30) return `${d}D AGO`;
   const mo = Math.floor(d / 30);
   return `${mo}MO AGO`;
+}
+
+function fmtWindow(ms: number): string {
+  const h = Math.round(ms / 3_600_000);
+  return h >= 48 ? `${Math.round(h / 24)}D` : `${h}H`;
 }
 
 function shortDisplayId(id: string): string {

--- a/apps/server/src/server/dashboard-router.ts
+++ b/apps/server/src/server/dashboard-router.ts
@@ -507,20 +507,13 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
       </div>
 
       <div class="row-2">
-        <div class="card">
+        <div class="card act-card">
           <div class="card-head">
             <span><span class="bn"></span> <b>ACTIVITY · 7 DAYS</b></span>
             <span>MEMORIES CREATED · PER DAY</span>
           </div>
-          <div
-            class="card-body"
-            style="display:flex;align-items:center;justify-content:center;overflow-x:auto;min-height:220px;padding:var(--s-6) var(--s-5)"
-          >
-            <pre
-              style="font-family:var(--f-mono);font-size:0.98rem;line-height:1.65;color:var(--fg-dim);margin:0;white-space:pre;text-align:left"
-            >
-${ascBars(activity)}</pre
-            >
+          <div class="card-body">
+            <pre class="act-bars">${ascBars(activity)}</pre>
           </div>
         </div>
         <div class="card">

--- a/apps/server/src/test/dashboard-e2e.test.ts
+++ b/apps/server/src/test/dashboard-e2e.test.ts
@@ -470,7 +470,7 @@ describe('dashboard E2E', () => {
     expect(res.status).toBe(200);
     const body = await res.text();
     expect(body).toContain('ON SESSION START');
-    expect(body).toContain('THROTTLED 6H / SCOPE');
+    expect(body).toContain('THROTTLED 24H / SCOPE');
     expect(body).toMatch(/RE-EXPOSED &gt; \d+[HD] · ORPHANED &gt;\s*\d+[HD]/);
     expect(body).not.toContain('NEXT RUN');
     expect(body).not.toContain('03:00 UTC');

--- a/apps/server/src/test/dashboard-e2e.test.ts
+++ b/apps/server/src/test/dashboard-e2e.test.ts
@@ -418,6 +418,66 @@ describe('dashboard E2E', () => {
     expect(body).toContain('Judgments');
   });
 
+  it('manual sweep button forces a consolidation run via CSRF round-trip', async () => {
+    const jar: CookieJar = { cookie: null };
+    await postForm(baseUrl, '/dashboard/login', jar, { token: ADMIN_TOKEN });
+
+    const page = await get(baseUrl, '/dashboard/consolidation', jar);
+    expect(page.status).toBe(200);
+    const pageBody = await page.text();
+    const csrf = extractCsrf(pageBody, '/dashboard/consolidation/run');
+    expect(csrf).toBeTruthy();
+    expect(pageBody).not.toContain('<th>model</th>');
+
+    const res = await postForm(baseUrl, '/dashboard/consolidation/run', jar, { csrf: csrf! });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('/dashboard/consolidation');
+
+    const after = await get(baseUrl, '/dashboard/consolidation', jar);
+    const afterBody = await after.text();
+    expect(afterBody).toContain('data-href="/dashboard/consolidation/');
+
+    // Sweep run detail renders the legible summary and no Model card.
+    const idMatch = /data-href="(\/dashboard\/consolidation\/[A-Z0-9]+)"/.exec(afterBody);
+    expect(idMatch).toBeTruthy();
+    const detail = await get(baseUrl, idMatch![1]!, jar);
+    const detailBody = await detail.text();
+    expect(detailBody).toMatch(/\d+ archived · \d+ orphaned/);
+    expect(detailBody).not.toContain('<div class="label">Model</div>');
+  });
+
+  it('manual sweep without csrf returns 403 and runs nothing', async () => {
+    const jar: CookieJar = { cookie: null };
+    await postForm(baseUrl, '/dashboard/login', jar, { token: ADMIN_TOKEN });
+
+    const res = await postForm(baseUrl, '/dashboard/consolidation/run', jar, {});
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain('csrf_invalid');
+  });
+
+  it('manual sweep unauthenticated redirects to login', async () => {
+    const jar: CookieJar = { cookie: null };
+    const res = await postForm(baseUrl, '/dashboard/consolidation/run', jar, {});
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('/dashboard/login');
+  });
+
+  it('home consolidation health shows the trigger model, no cron or model copy', async () => {
+    const jar: CookieJar = { cookie: null };
+    await postForm(baseUrl, '/dashboard/login', jar, { token: ADMIN_TOKEN });
+
+    const res = await get(baseUrl, '/dashboard', jar);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('ON SESSION START');
+    expect(body).toContain('THROTTLED 6H / SCOPE');
+    expect(body).toMatch(/RE-EXPOSED &gt; \d+[HD] · ORPHANED &gt;\s*\d+[HD]/);
+    expect(body).not.toContain('NEXT RUN');
+    expect(body).not.toContain('03:00 UTC');
+    expect(body).not.toContain('MODEL ');
+    expect(body).not.toContain('AUTO-PROMOTED');
+  });
+
   it('projects page renders a create form and a POST mints the project', async () => {
     const jar: CookieJar = { cookie: null };
     await postForm(baseUrl, '/dashboard/login', jar, { token: ADMIN_TOKEN });
@@ -442,6 +502,32 @@ describe('dashboard E2E', () => {
     const afterBody = await after.text();
     expect(afterBody).toContain('e2e-created-project');
     expect(afterBody).toContain('E2E Created');
+  });
+
+  it('consolidation scope cells render the project slug, not the raw ULID', async () => {
+    const jar: CookieJar = { cookie: null };
+    await postForm(baseUrl, '/dashboard/login', jar, { token: ADMIN_TOKEN });
+
+    // 'e2e-created-project' exists from the previous test; force a sweep so
+    // a project-scoped run lands in the listing.
+    const page = await get(baseUrl, '/dashboard/consolidation', jar);
+    const csrf = extractCsrf(await page.text(), '/dashboard/consolidation/run');
+    await postForm(baseUrl, '/dashboard/consolidation/run', jar, { csrf: csrf! });
+
+    const list = await get(baseUrl, '/dashboard/consolidation', jar);
+    const listBody = await list.text();
+    expect(listBody).toContain('<td>e2e-created-project</td>');
+    expect(listBody).not.toMatch(/<td>project:01[A-Z0-9]+<\/td>/);
+
+    // Detail page shows the slug in the Scope stat card too.
+    const rowRe =
+      /<tr data-href="(\/dashboard\/consolidation\/[A-Z0-9]+)">[\s\S]*?<td>e2e-created-project<\/td>/;
+    const row = rowRe.exec(listBody);
+    expect(row).toBeTruthy();
+    const detail = await get(baseUrl, row![1]!, jar);
+    const detailBody = await detail.text();
+    expect(detailBody).toContain('e2e-created-project');
+    expect(detailBody).not.toMatch(/<div class="value">project:01[A-Z0-9]+<\/div>/);
   });
 
   it('project create rejects an invalid slug with a flash error in the redirect', async () => {

--- a/openspec/changes/archive/2026-06-07-align-consolidation-dashboard-with-sweep/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-07-align-consolidation-dashboard-with-sweep/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/archive/2026-06-07-align-consolidation-dashboard-with-sweep/design.md
+++ b/openspec/changes/archive/2026-06-07-align-consolidation-dashboard-with-sweep/design.md
@@ -1,0 +1,108 @@
+# Design: align-consolidation-dashboard-with-sweep
+
+## Context
+
+`remove-llm-consolidation` changed the engine; the dashboard kept narrating the old one. The mental model shift the UI must catch up with:
+
+```
+BEFORE (cron + LLM)                    NOW (lazy sweep)
+───────────────────                    ─────────────────
+"did it run last night?"      ──▶      "does it run when it should?"
+"which model decided?"        ──▶      (nothing to ask — deterministic)
+"when is the next run?"       ──▶      there is no schedule; triggers are:
+"what did the LLM decide?"    ──▶      "how much decay/orphaning is happening?"
+```
+
+Sweep mechanics the UI must describe truthfully (`apps/server/src/consolidation/runner.ts`):
+
+```
+agent starts session ──▶ swept this scope within minInterval (6h)?
+                              │ yes → skip (silent)
+                              │ no  ▼
+                        SWEEP (deterministic, two passes)
+                        ├─ 1. decay: archive aged low-confidence rows
+                        └─ 2. orphaning: 'pending' relations …
+                              ├─ > JUDGMENT_ORPHAN_AFTER_MS    → re-exposed via memory.context
+                              └─ > JUDGMENT_ORPHAN_DEADLINE_MS → 'orphaned' (journaled, undoable)
+```
+
+Stale surfaces found by audit:
+
+| Surface                                     | Problem                                                                                                                             |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Home cell 4 (`dashboard-router.ts:484-490`) | reads `CONSOLIDATION_CRON` (in `REMOVED_ENV_VARS`) with `'03:00 UTC'` fallback; `MODEL` always `—`                                  |
+| Home cell 3 caption                         | "AUTO-PROMOTED FROM PENDING > 96H" — LLM-era verb, stale threshold                                                                  |
+| Home cell 1 sub                             | scope rendered as raw `project:<ULID>`                                                                                              |
+| Runs list `model` column                    | `—` for every post-LLM run (3 legacy qwen rows are the only exceptions)                                                             |
+| Run detail `Model` card                     | same                                                                                                                                |
+| Run detail `Summary`                        | now raw JSON `{"archives":N,"orphaned":M}` (was LLM prose)                                                                          |
+| Missing button                              | archived proposal promised "the manual dashboard trigger remains"; `http.ts:54` claims it exists; task 3.3 marked done; never wired |
+| `seed-dev.ts:229,332`                       | fictional content teaching the cron model                                                                                           |
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Every consolidation-related string the dashboard renders is true under the lazy-sweep model.
+- Manual sweep trigger reachable from the dashboard (operator surface = dashboard, no CLI).
+- Threshold copy driven by configured values, not literals — immune to future config changes.
+- Legacy LLM-run provenance (the 3 qwen runs anchoring 4 real journaled ops) stays visible where it exists.
+
+**Non-Goals:**
+
+- No change to sweep semantics, throttle, thresholds, or the admin endpoint.
+- No schema migration; `llm_model` column stays (append-only history).
+- No new CSS or design tokens; reuse `.health`, table, and form styles.
+- No redesign of the consolidation views beyond what truthfulness forces.
+
+## Decisions
+
+### D1 — Dedicated dashboard route for the manual trigger
+
+`POST /dashboard/consolidation/run` inside `createConsolidationRouter`, gated by dashboard session + CSRF (`readFormAndVerifyCsrf`, same pattern as the undo routes in the same file), redirecting back to `/dashboard/consolidation`. `ConsolidationDeps` gains `triggerSweep: () => ConsolidationRunSummary`; `bootstrap.ts` passes the same `runner.runAll({ force: true })` lambda already built for the admin endpoint.
+
+- _Alternative — form posts to `POST /admin/consolidation/run`_: rejected; a browser form cannot set the `Authorization` header that endpoint requires, and weakening the admin endpoint to accept cookies would conflate two auth models.
+- _Alternative — HTMX call with token injection_: rejected; needs the admin token in page markup — a credential leak into HTML for zero benefit over a plain form.
+
+### D2 — Confirmation tone `warn`, not `danger`
+
+A forced sweep only archives via journaled, undoable ops (and orphans relations, also journaled). Per the dashboard spec's tone rule, reversible ⇒ `warn`.
+
+### D3 — Trigger cell replaces NEXT RUN / MODEL
+
+Static copy `TRIGGER · ON SESSION START` with sub `THROTTLED 6H / SCOPE · MANUAL FROM CONSOLIDATION`.
+
+- _Alternative — computed "next eligible" timestamp (`finished_at + 6h`)_: rejected; the throttle is per scope, so a single home timestamp would be wrong for every scope except the last-swept one.
+
+### D4 — Threshold copy reads config
+
+The orphaned-pendings caption renders `JUDGMENT_ORPHAN_AFTER_MS` / `JUDGMENT_ORPHAN_DEADLINE_MS` formatted from the resolved config, threaded into the dashboard router deps. Hardcoding "24H"/"14D" would recreate exactly the bug this change fixes the moment an operator tunes the env vars.
+
+- _Alternative — generic copy with no numbers_: workable but strictly less useful; the values are already resolved at boot, threading them is cheap.
+
+### D5 — Model rendering: conditional in detail, gone from list
+
+Run detail renders the `Model` stat card only when `llm_model IS NOT NULL` — the 3 legacy qwen runs keep their provenance (they anchor the only real journaled ops from the LLM era), new runs show no dead cell. The list column is removed outright: a column that is `—` for 99% of rows doesn't pay for its width; provenance lives one click away.
+
+### D6 — Summary render parses the new shape, falls back for legacy
+
+Sweep runs write `summary = JSON.stringify({archives, orphaned})`. Detail view parses; on success renders "N archived · M orphaned", on parse failure renders the raw text (legacy LLM prose). No data rewrite — append-only.
+
+### D7 — Scope slug resolution in SQL
+
+`consolidation_runs.scope` is `'global'` or `'project:<ULID>'`. The home query LEFT JOINs `projects` on `substr(scope, 9)` to render the slug (`project:my-app` → `MY-APP`), falling back to the raw string for unknown ids (deleted projects).
+
+## Risks / Trade-offs
+
+- [Risk] Forced sweep from the dashboard runs synchronously in the request → Mitigation: it is two indexed scans per scope, the same cost the admin endpoint already pays synchronously; no new exposure.
+- [Risk] Legacy runs with prose summaries could accidentally parse as JSON → Mitigation: parse guard requires both `archives` and `orphaned` numeric keys before using the structured render.
+- [Trade-off] Home trigger cell is static copy rather than live state → Accepted because per-scope throttle state has no honest single-value summary; the consolidation list shows actual run recency per scope.
+- [Trade-off] List loses the model column even for the 3 legacy rows → Accepted because provenance remains in the run detail, conditionally rendered.
+
+## Migration Plan
+
+Presentation + one additive route; ships in a normal release. No migration, no data backfill, instant rollback by reverting the commit.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-06-07-align-consolidation-dashboard-with-sweep/proposal.md
+++ b/openspec/changes/archive/2026-06-07-align-consolidation-dashboard-with-sweep/proposal.md
@@ -1,0 +1,34 @@
+# Proposal: align-consolidation-dashboard-with-sweep
+
+## Why
+
+`remove-llm-consolidation` (archived 2026-06-05) replaced the nightly LLM cron with a deterministic lazy sweep, but scoped out the dashboard beyond the trigger rename. The dashboard still narrates the old system: the home "Consolidation health" section renders a NEXT RUN time read from `CONSOLIDATION_CRON` — an env var in `REMOVED_ENV_VARS` — with a hardcoded `03:00 UTC` fallback (there is no cron), a MODEL cell that is permanently `—` for new runs, and an "AUTO-PROMOTED FROM PENDING > 96H" caption whose verb and threshold both belong to the removed LLM judge. The archived proposal also promised "the manual dashboard trigger remains" and `http.ts:54` claims a dashboard button exists, but no such button was ever wired — the only manual trigger is `curl` with an admin bearer token, contradicting the operator-surface-is-the-dashboard posture.
+
+## What Changes
+
+- Home "Consolidation health" section (`apps/server/src/server/dashboard-router.ts`): replace the NEXT RUN / MODEL cell with the real trigger model (on session start, throttled per scope, manual from the consolidation view); fix the orphaned-pendings caption to describe deterministic deadline orphaning using the **configured** thresholds (`JUDGMENT_ORPHAN_AFTER_MS`, `JUDGMENT_ORPHAN_DEADLINE_MS`), not hardcoded copy; render the last-run scope as a project slug instead of a raw `project:<ULID>` string; stop selecting `llm_model`.
+- Consolidation list (`apps/server/src/dashboard/consolidation.ts`): drop the `model` column (always `—` for post-LLM runs); add a `RUN SWEEP NOW` button — confirmation modal, `warn` tone (journaled + reversible) — posting to a new dashboard route; update the empty-state copy to point at the button instead of the admin `curl`.
+- New route `POST /dashboard/consolidation/run`: dashboard-session + CSRF gated, invokes the existing forced sweep (`runner.runAll({ force: true })`). The admin endpoint `POST /admin/consolidation/run` is unchanged (automation surface). A browser form cannot set an `Authorization` header, hence the dedicated route.
+- Run detail: render the `Model` stat card only when `llm_model IS NOT NULL` (legacy qwen runs keep their provenance visible; new runs show no dead cell); render the sweep summary JSON (`{"archives":N,"orphaned":M}`) as legible text, falling back to raw text for legacy LLM prose.
+- Seed refresh (`apps/server/src/scripts/seed-dev.ts`): rewrite the two fictional texts that teach the removed cron model (`CONSOLIDATION_CRON`, "nightly at 03:00 UTC").
+
+No schema migration. Append-only journal untouched — `llm_model` stays in the DB; this change only stops rendering it unconditionally.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `dashboard`: the home consolidation-health section MUST describe the lazy sweep trigger model and MUST NOT reference removed scheduling/LLM configuration; a manual sweep trigger MUST be available from `/dashboard/consolidation` (CSRF-protected, confirmation-gated); run views MUST NOT render an unconditional model column/cell.
+
+## Impact
+
+- `apps/server/src/server/dashboard-router.ts` — home health section markup + query (drop `llm_model`, resolve scope slug); dashboard deps gain the configured orphan thresholds and a sweep trigger.
+- `apps/server/src/dashboard/consolidation.ts` — model column removal, `RUN SWEEP NOW` form + `POST /run` route, empty-state copy, conditional model card, legible summary render.
+- `apps/server/src/server/bootstrap.ts` — wire the forced-sweep trigger (already built for the admin endpoint) into the dashboard router deps.
+- `apps/server/src/scripts/seed-dev.ts` — two stale fictional texts.
+- Tests: new route (session gate, CSRF gate, runner invoked with force) plus presentation asserts where router tests exist.
+- Out of scope: admin endpoint behavior, sweep semantics, `consolidation` spec requirements, design tokens, CSS (existing `.health` and table styles reused).

--- a/openspec/changes/archive/2026-06-07-align-consolidation-dashboard-with-sweep/specs/dashboard/spec.md
+++ b/openspec/changes/archive/2026-06-07-align-consolidation-dashboard-with-sweep/specs/dashboard/spec.md
@@ -1,0 +1,84 @@
+# dashboard — delta for align-consolidation-dashboard-with-sweep
+
+## MODIFIED Requirements
+
+### Requirement: Consolidation runs MUST be inspectable and reversible from the dashboard
+
+The dashboard SHALL list consolidation runs at `/dashboard/consolidation` and SHALL show per-run details at `/dashboard/consolidation/:id` including each op with its recorded reasoning. Each op SHALL have an "Undo" action; each run SHALL have an "Undo entire run" action. The run detail SHALL render a model indicator only for runs whose `llm_model` is non-null (legacy LLM-era runs); the runs listing SHALL NOT include a model column. The run detail SHALL render sweep summaries (`{"archives":N,"orphaned":M}`) as legible text and SHALL fall back to the raw stored text for runs whose summary does not match that shape. Scope cells in the runs listing and the run detail SHALL render the project slug when the scope refers to an existing project, falling back to the raw scope string otherwise.
+
+#### Scenario: Undoing an op from the dashboard
+
+- **WHEN** the operator clicks "Undo" on a merge op
+- **THEN** the server SHALL execute the undo, the page SHALL update to show the op as reverted, and the affected memories SHALL be visible at `/dashboard/memories` in their restored state
+
+#### Scenario: Reverted run is marked
+
+- **GIVEN** every op of a run has been undone
+- **WHEN** the operator visits `/dashboard/consolidation`
+- **THEN** the run SHALL be visually marked as reverted in the listing
+
+#### Scenario: Legacy LLM run keeps its provenance visible
+
+- **GIVEN** a historical run with `llm_model = 'qwen2.5:7b-instruct-q4_K_M'`
+- **WHEN** the operator opens its detail page
+- **THEN** the model indicator SHALL be rendered with that value
+
+#### Scenario: Sweep run renders no model indicator
+
+- **GIVEN** a post-LLM sweep run (`llm_model IS NULL`)
+- **WHEN** the operator opens its detail page
+- **THEN** no model indicator SHALL be rendered
+
+#### Scenario: Sweep summary renders legibly
+
+- **GIVEN** a run whose summary is `{"archives":2,"orphaned":1}`
+- **WHEN** the operator opens its detail page
+- **THEN** the summary SHALL render as legible text stating 2 archived and 1 orphaned, not raw JSON
+
+#### Scenario: Run scope shows the project slug
+
+- **GIVEN** a run that swept scope `project:<id>` for an existing project with slug `my-app`
+- **WHEN** the operator views the runs listing or that run's detail
+- **THEN** the scope SHALL display `my-app` rather than the raw `project:<ULID>` string
+
+## ADDED Requirements
+
+### Requirement: The home consolidation-health section MUST describe the lazy sweep truthfully
+
+The dashboard home SHALL describe the consolidation trigger model as it exists — lazy sweep on session start, throttled per scope, with a manual trigger — and SHALL NOT render scheduling or model information sourced from removed configuration (`CONSOLIDATION_CRON`) or from always-null columns. Threshold copy for pending-relation aging SHALL be derived from the configured `JUDGMENT_ORPHAN_AFTER_MS` and `JUDGMENT_ORPHAN_DEADLINE_MS` values, not hardcoded literals. The last-run scope SHALL be rendered as the project slug when the scope refers to an existing project.
+
+#### Scenario: No cron or model copy on the home
+
+- **WHEN** the operator views the dashboard home after at least one sweep run
+- **THEN** the consolidation-health section SHALL NOT contain a next-run schedule time nor an LLM model cell, and SHALL state that the sweep triggers on session start
+
+#### Scenario: Orphaning thresholds reflect configuration
+
+- **GIVEN** `JUDGMENT_ORPHAN_DEADLINE_MS` configured to a non-default value
+- **WHEN** the operator views the dashboard home
+- **THEN** the orphaned-pendings caption SHALL reflect the configured deadline, not a stale literal
+
+#### Scenario: Last-run scope shows the project slug
+
+- **GIVEN** the most recent run swept scope `project:<id>` for an existing project with slug `my-app`
+- **WHEN** the operator views the dashboard home
+- **THEN** the last-run cell SHALL display `my-app` rather than the raw `project:<ULID>` string
+
+### Requirement: A manual sweep trigger MUST be available from the consolidation view
+
+The dashboard SHALL provide a manual sweep trigger at `/dashboard/consolidation` that posts to a dashboard route gated by the dashboard session and CSRF verification, executes a forced sweep across all scopes, and returns to the consolidation listing. The form SHALL use the confirmation modal with `warn` tone (the sweep's ops are journaled and reversible). The admin endpoint `POST /admin/consolidation/run` SHALL remain unchanged as the automation surface.
+
+#### Scenario: Operator forces a sweep from the dashboard
+
+- **WHEN** the operator confirms the manual sweep action at `/dashboard/consolidation`
+- **THEN** the server SHALL execute a forced sweep (bypassing the throttle), a new `consolidation_runs` row SHALL exist per swept scope, and the operator SHALL land back on the runs listing showing them
+
+#### Scenario: Manual sweep requires CSRF
+
+- **WHEN** a POST to the dashboard sweep route arrives without a valid CSRF token
+- **THEN** the server SHALL reject the request and no sweep SHALL run
+
+#### Scenario: Manual sweep requires a dashboard session
+
+- **WHEN** an unauthenticated POST hits the dashboard sweep route
+- **THEN** the server SHALL redirect to the login page and no sweep SHALL run

--- a/openspec/changes/archive/2026-06-07-align-consolidation-dashboard-with-sweep/tasks.md
+++ b/openspec/changes/archive/2026-06-07-align-consolidation-dashboard-with-sweep/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: align-consolidation-dashboard-with-sweep
+
+Consult `.agents/skills/rembric-dashboard-ui/` before touching `src/dashboard/`.
+
+## 1. Plumbing — manual sweep trigger
+
+- [x] 1.1 Extend `ConsolidationDeps` in `apps/server/src/dashboard/consolidation.ts` with `triggerSweep: () => ConsolidationRunSummary`; wire `runner.runAll({ force: true })` from `apps/server/src/server/bootstrap.ts` (same lambda the admin endpoint uses)
+- [x] 1.2 Add `POST /run` to `createConsolidationRouter`: dashboard-session gate (redirect to login when absent), `readFormAndVerifyCsrf` with action `'sweep.run'`, invoke `triggerSweep`, redirect to `/dashboard/consolidation`
+- [x] 1.3 Tests for the route: unauthenticated POST redirects and runs nothing; bad CSRF rejects and runs nothing; valid POST invokes the trigger and redirects (assert via injected fake `triggerSweep`)
+
+## 2. Consolidation views
+
+- [x] 2.1 Runs list: remove the `model` column (header + cell); add the `RUN SWEEP NOW` form posting to `/dashboard/consolidation/run` with `csrfInput`, `data-confirm` on the form, `data-confirm-tone="warn"`
+- [x] 2.2 Empty-state copy: replace the `POST /admin/consolidation/run` curl reference with the button ("trigger one with RUN SWEEP NOW"), keeping the lazy-sweep description
+- [x] 2.3 Run detail: render the `Model` stat card only when `run.llmModel` is non-null
+- [x] 2.4 Run detail: parse `run.summary` as `{archives, orphaned}` (guard: both keys numeric); render "N archived · M orphaned" on success, raw text fallback otherwise; cover both paths with a unit test if a templates/consolidation test exists, otherwise assert via router test
+- [x] 2.5 Scope cells in runs list + run detail render the project slug (`scopeLabel` helper, raw fallback for deleted projects / global)
+
+## 3. Home health section (`apps/server/src/server/dashboard-router.ts`)
+
+- [x] 3.1 Last-run query: drop `llm_model`; LEFT JOIN `projects` on `substr(r.scope, 9) = p.id` to select the slug; render `global` or the slug (fallback to raw scope when the join misses)
+- [x] 3.2 Replace the NEXT RUN / MODEL cell with `TRIGGER` → `ON SESSION START`, sub `THROTTLED 6H / SCOPE · MANUAL FROM CONSOLIDATION`
+- [x] 3.3 Thread the resolved `JUDGMENT_ORPHAN_AFTER_MS` / `JUDGMENT_ORPHAN_DEADLINE_MS` values into the dashboard router deps; rewrite the orphaned-pendings caption to deterministic-orphaning language using those values formatted as h/d (no hardcoded "96H")
+- [x] 3.4 Grep gate: `git grep -n "CONSOLIDATION_CRON\|llm_model" apps/server/src/server/dashboard-router.ts` returns nothing
+
+## 4. Seed refresh
+
+- [x] 4.1 Rewrite `apps/server/src/scripts/seed-dev.ts:229` (session summary teaching the cron) and `:332` (memory citing `CONSOLIDATION_CRON`) to lazy-sweep-era content of equivalent shape and length
+
+## 5. Gates
+
+- [x] 5.1 `pnpm run typecheck` and `pnpm run lint` pass
+- [x] 5.2 `pnpm test` passes
+- [x] 5.3 OPERATOR/local: `pnpm run dev:docker:up`, then verify in a browser: home shows the trigger cell and slugged scope with no cron/model copy; `/dashboard/consolidation` has no model column and the RUN SWEEP NOW button forces a run through the confirm modal; a run detail shows the legible summary; reseeded content contains no cron references

--- a/openspec/changes/archive/2026-06-07-relax-sweep-throttle-to-daily/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-07-relax-sweep-throttle-to-daily/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/archive/2026-06-07-relax-sweep-throttle-to-daily/design.md
+++ b/openspec/changes/archive/2026-06-07-relax-sweep-throttle-to-daily/design.md
@@ -1,0 +1,31 @@
+# Design: relax-sweep-throttle-to-daily
+
+## Context
+
+The throttle is a minimum separation between sweeps of the same scope, not a schedule — sweeps only fire on session start. With daily usage, 6h yields 1–4 sweeps/scope/day; the conditions enforced (decay > 90d, orphan > 14d) cannot change meaningfully between same-day sweeps.
+
+## Goals / Non-Goals
+
+**Goals:** at most one sweep per scope per day under normal usage; less no-op journal noise.
+
+**Non-Goals:** no env var for the interval (engine tuning, not deployment config — per the `embed-embeddings-in-process` rule); no change to sweep semantics, manual bypass, or lazy trigger model.
+
+## Decisions
+
+### D1 — 24h, not 12h
+
+Both are safe; 12h still doubles the row count for zero behavioral difference against 90d/14d thresholds. Pending-judgment re-exposure (>24h) is computed at `memory.context` read time, not by the sweep, so it is unaffected by sweep cadence.
+
+- _Alternative — make the interval an env var_: rejected; a knob nobody should turn. The removed-env-vars rule ("a var survives only if it configures the deployment, never the engine") applies.
+
+## Risks / Trade-offs
+
+- [Trade-off] Orphaning can now lag up to ~25h past the 14-day deadline instead of ~6h → Accepted; the deadline itself is two orders of magnitude larger than the lag.
+
+## Migration Plan
+
+Constant change; ships in a normal release. No data impact.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-06-07-relax-sweep-throttle-to-daily/proposal.md
+++ b/openspec/changes/archive/2026-06-07-relax-sweep-throttle-to-daily/proposal.md
@@ -1,0 +1,28 @@
+# Proposal: relax-sweep-throttle-to-daily
+
+## Why
+
+The lazy sweep's per-scope throttle is 6h, so an actively used server journals up to 4 `consolidation_runs` rows per scope per day — almost all no-op, since the conditions the sweep enforces are coarse (decay at 90 days unseen, orphaning at 14 days pending). Sub-daily cadence buys nothing and accumulates journal noise (the prod database once needed 201 no-op LLM-era runs purged manually).
+
+## What Changes
+
+- Raise `DEFAULT_MIN_INTERVAL_MS` (`apps/server/src/consolidation/runner.ts`) from 6h to 24h: at most one sweep per scope per day, triggered by the first session start outside the window. Manual trigger still bypasses.
+- Dashboard home trigger cell updates automatically (it renders the exported constant) to `THROTTLED 24H / SCOPE`.
+- Seed text mentioning the 6h cadence updated.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `consolidation`: the throttle requirement's internal minimum interval changes from 6h to 24h.
+
+## Impact
+
+- `apps/server/src/consolidation/runner.ts` — constant.
+- `apps/server/src/test/dashboard-e2e.test.ts` — home copy literal (`THROTTLED 6H / SCOPE` → `24H`).
+- `apps/server/src/scripts/seed-dev.ts` — fictional session summary citing "per 6h".
+- No migration, no API change, no new env var (the interval stays internal by design — engine tuning, not deployment config).

--- a/openspec/changes/archive/2026-06-07-relax-sweep-throttle-to-daily/specs/consolidation/spec.md
+++ b/openspec/changes/archive/2026-06-07-relax-sweep-throttle-to-daily/specs/consolidation/spec.md
@@ -1,0 +1,29 @@
+# consolidation — delta for relax-sweep-throttle-to-daily
+
+## MODIFIED Requirements
+
+### Requirement: The consolidation sweep MUST run lazily on session start, throttled per scope
+
+The server SHALL run the deterministic consolidation sweep (decay + deadline orphaning) as a side effect of session creation — both `POST /api/sessions` / `POST /api/<slug>/sessions` and MCP `memory.session_start` SHALL funnel through the same service method. The sweep SHALL be throttled: it SHALL short-circuit when the most recent `consolidation_runs` row for the target scope is younger than the internal minimum interval (24h). Sweep execution SHALL happen off the request's critical path: a sweep failure SHALL be logged and SHALL NOT fail the session call. A manually triggered run via `POST /admin/consolidation/run` (or the dashboard equivalent) SHALL remain possible at any time and SHALL bypass the throttle.
+
+#### Scenario: First session start after the throttle window triggers a sweep
+
+- **GIVEN** the newest `consolidation_runs` row for the scope is older than the minimum interval (or absent)
+- **WHEN** a session is started in that scope
+- **THEN** the sweep SHALL run for that scope and a new `consolidation_runs` row SHALL be created with `started_at` set and `llm_provider`/`llm_model` NULL
+
+#### Scenario: Session start within the throttle window skips the sweep
+
+- **GIVEN** a `consolidation_runs` row for the scope younger than the minimum interval
+- **WHEN** a session is started in that scope
+- **THEN** no sweep SHALL run and no new `consolidation_runs` row SHALL be created
+
+#### Scenario: Sweep failure does not break session start
+
+- **WHEN** the sweep throws after a session has been created
+- **THEN** the session call SHALL still succeed and the failure SHALL be logged
+
+#### Scenario: Manual run bypasses the throttle
+
+- **WHEN** an operator submits `POST /admin/consolidation/run` with a valid admin bearer token
+- **THEN** the sweep SHALL execute immediately regardless of the throttle and SHALL produce a `consolidation_runs` row

--- a/openspec/changes/archive/2026-06-07-relax-sweep-throttle-to-daily/tasks.md
+++ b/openspec/changes/archive/2026-06-07-relax-sweep-throttle-to-daily/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: relax-sweep-throttle-to-daily
+
+## 1. Implementation
+
+- [x] 1.1 `apps/server/src/consolidation/runner.ts`: `DEFAULT_MIN_INTERVAL_MS` 6h → 24h
+- [x] 1.2 `apps/server/src/test/dashboard-e2e.test.ts`: home copy assertion `THROTTLED 6H / SCOPE` → `THROTTLED 24H / SCOPE`
+- [x] 1.3 `apps/server/src/scripts/seed-dev.ts`: fictional summary "per 6h" → daily cadence wording
+- [x] 1.4 Grep gate: `git grep -n "6 \* 3_600_000\|6H / SCOPE" apps/server/src` returns nothing
+
+## 2. Gates
+
+- [x] 2.1 `pnpm run typecheck`, `pnpm run lint`, `pnpm test` pass

--- a/openspec/specs/consolidation/spec.md
+++ b/openspec/specs/consolidation/spec.md
@@ -8,7 +8,7 @@ Defines the deterministic consolidation sweep that resolves memory pollution (de
 
 ### Requirement: The consolidation sweep MUST run lazily on session start, throttled per scope
 
-The server SHALL run the deterministic consolidation sweep (decay + deadline orphaning) as a side effect of session creation — both `POST /api/sessions` / `POST /api/<slug>/sessions` and MCP `memory.session_start` SHALL funnel through the same service method. The sweep SHALL be throttled: it SHALL short-circuit when the most recent `consolidation_runs` row for the target scope is younger than the internal minimum interval (6h). Sweep execution SHALL happen off the request's critical path: a sweep failure SHALL be logged and SHALL NOT fail the session call. A manually triggered run via `POST /admin/consolidation/run` (or the dashboard equivalent) SHALL remain possible at any time and SHALL bypass the throttle.
+The server SHALL run the deterministic consolidation sweep (decay + deadline orphaning) as a side effect of session creation — both `POST /api/sessions` / `POST /api/<slug>/sessions` and MCP `memory.session_start` SHALL funnel through the same service method. The sweep SHALL be throttled: it SHALL short-circuit when the most recent `consolidation_runs` row for the target scope is younger than the internal minimum interval (24h). Sweep execution SHALL happen off the request's critical path: a sweep failure SHALL be logged and SHALL NOT fail the session call. A manually triggered run via `POST /admin/consolidation/run` (or the dashboard equivalent) SHALL remain possible at any time and SHALL bypass the throttle.
 
 #### Scenario: First session start after the throttle window triggers a sweep
 

--- a/openspec/specs/dashboard/spec.md
+++ b/openspec/specs/dashboard/spec.md
@@ -59,7 +59,7 @@ The `/dashboard/memories/:id` view SHALL display the memory's content, status, t
 
 ### Requirement: Consolidation runs MUST be inspectable and reversible from the dashboard
 
-The dashboard SHALL list consolidation runs at `/dashboard/consolidation` and SHALL show per-run details at `/dashboard/consolidation/:id` including each op with its LLM reasoning. Each op SHALL have an "Undo" action; each run SHALL have an "Undo entire run" action.
+The dashboard SHALL list consolidation runs at `/dashboard/consolidation` and SHALL show per-run details at `/dashboard/consolidation/:id` including each op with its recorded reasoning. Each op SHALL have an "Undo" action; each run SHALL have an "Undo entire run" action. The run detail SHALL render a model indicator only for runs whose `llm_model` is non-null (legacy LLM-era runs); the runs listing SHALL NOT include a model column. The run detail SHALL render sweep summaries (`{"archives":N,"orphaned":M}`) as legible text and SHALL fall back to the raw stored text for runs whose summary does not match that shape. Scope cells in the runs listing and the run detail SHALL render the project slug when the scope refers to an existing project, falling back to the raw scope string otherwise.
 
 #### Scenario: Undoing an op from the dashboard
 
@@ -71,6 +71,30 @@ The dashboard SHALL list consolidation runs at `/dashboard/consolidation` and SH
 - **GIVEN** every op of a run has been undone
 - **WHEN** the operator visits `/dashboard/consolidation`
 - **THEN** the run SHALL be visually marked as reverted in the listing
+
+#### Scenario: Legacy LLM run keeps its provenance visible
+
+- **GIVEN** a historical run with `llm_model = 'qwen2.5:7b-instruct-q4_K_M'`
+- **WHEN** the operator opens its detail page
+- **THEN** the model indicator SHALL be rendered with that value
+
+#### Scenario: Sweep run renders no model indicator
+
+- **GIVEN** a post-LLM sweep run (`llm_model IS NULL`)
+- **WHEN** the operator opens its detail page
+- **THEN** no model indicator SHALL be rendered
+
+#### Scenario: Sweep summary renders legibly
+
+- **GIVEN** a run whose summary is `{"archives":2,"orphaned":1}`
+- **WHEN** the operator opens its detail page
+- **THEN** the summary SHALL render as legible text stating 2 archived and 1 orphaned, not raw JSON
+
+#### Scenario: Run scope shows the project slug
+
+- **GIVEN** a run that swept scope `project:<id>` for an existing project with slug `my-app`
+- **WHEN** the operator views the runs listing or that run's detail
+- **THEN** the scope SHALL display `my-app` rather than the raw `project:<ULID>` string
 
 ### Requirement: Tokens MUST be manageable from the dashboard
 
@@ -958,3 +982,43 @@ The up-to-date state of `/dashboard/update` SHALL render a CSRF-protected form t
 
 - **WHEN** `REMBRIC_UPDATE_CHECK=off` is set and the operator opens `/dashboard/update`
 - **THEN** the page SHALL NOT render the manual-check form
+
+### Requirement: The home consolidation-health section MUST describe the lazy sweep truthfully
+
+The dashboard home SHALL describe the consolidation trigger model as it exists — lazy sweep on session start, throttled per scope, with a manual trigger — and SHALL NOT render scheduling or model information sourced from removed configuration (`CONSOLIDATION_CRON`) or from always-null columns. Threshold copy for pending-relation aging SHALL be derived from the configured `JUDGMENT_ORPHAN_AFTER_MS` and `JUDGMENT_ORPHAN_DEADLINE_MS` values, not hardcoded literals. The last-run scope SHALL be rendered as the project slug when the scope refers to an existing project.
+
+#### Scenario: No cron or model copy on the home
+
+- **WHEN** the operator views the dashboard home after at least one sweep run
+- **THEN** the consolidation-health section SHALL NOT contain a next-run schedule time nor an LLM model cell, and SHALL state that the sweep triggers on session start
+
+#### Scenario: Orphaning thresholds reflect configuration
+
+- **GIVEN** `JUDGMENT_ORPHAN_DEADLINE_MS` configured to a non-default value
+- **WHEN** the operator views the dashboard home
+- **THEN** the orphaned-pendings caption SHALL reflect the configured deadline, not a stale literal
+
+#### Scenario: Last-run scope shows the project slug
+
+- **GIVEN** the most recent run swept scope `project:<id>` for an existing project with slug `my-app`
+- **WHEN** the operator views the dashboard home
+- **THEN** the last-run cell SHALL display `my-app` rather than the raw `project:<ULID>` string
+
+### Requirement: A manual sweep trigger MUST be available from the consolidation view
+
+The dashboard SHALL provide a manual sweep trigger at `/dashboard/consolidation` that posts to a dashboard route gated by the dashboard session and CSRF verification, executes a forced sweep across all scopes, and returns to the consolidation listing. The form SHALL use the confirmation modal with `warn` tone (the sweep's ops are journaled and reversible). The admin endpoint `POST /admin/consolidation/run` SHALL remain unchanged as the automation surface.
+
+#### Scenario: Operator forces a sweep from the dashboard
+
+- **WHEN** the operator confirms the manual sweep action at `/dashboard/consolidation`
+- **THEN** the server SHALL execute a forced sweep (bypassing the throttle), a new `consolidation_runs` row SHALL exist per swept scope, and the operator SHALL land back on the runs listing showing them
+
+#### Scenario: Manual sweep requires CSRF
+
+- **WHEN** a POST to the dashboard sweep route arrives without a valid CSRF token
+- **THEN** the server SHALL reject the request and no sweep SHALL run
+
+#### Scenario: Manual sweep requires a dashboard session
+
+- **WHEN** an unauthenticated POST hits the dashboard sweep route
+- **THEN** the server SHALL redirect to the login page and no sweep SHALL run


### PR DESCRIPTION
## Why

`remove-llm-consolidation` (archived 2026-06-05) replaced the nightly LLM cron with a deterministic lazy sweep, but scoped out the dashboard beyond the trigger rename. The dashboard kept narrating the old system:

- The home **NEXT RUN** cell read `CONSOLIDATION_CRON` — an env var in `REMOVED_ENV_VARS` — with a hardcoded `03:00 UTC` fallback. There is no cron.
- The **MODEL** cell is permanently `—` for post-LLM runs.
- The orphaned-pendings caption ("AUTO-PROMOTED FROM PENDING > 96H") used the removed LLM judge's verb and a stale threshold (real model: re-exposed after 24h, orphaned after 14d, both configurable).
- The manual dashboard trigger promised by the archived proposal (and claimed by a code comment in `http.ts`) was never wired — the only manual trigger was `curl` with an admin bearer token.

## What

- **Home health section**: NEXT RUN / MODEL cell → `TRIGGER · ON SESSION START · THROTTLED 6H / SCOPE` (throttle from exported `DEFAULT_MIN_INTERVAL_MS`); orphaned caption derived from configured `JUDGMENT_ORPHAN_{AFTER,DEADLINE}_MS`; last-run scope rendered as project slug.
- **Consolidation views**: model column dropped from the runs list; `Model` stat card conditional on legacy `llm_model` (qwen-era provenance stays visible); sweep summary JSON rendered as "N archived · M orphaned" with raw-prose fallback; scope cells slugged in list + detail.
- **Manual sweep button**: new `POST /dashboard/consolidation/run` (dashboard session + CSRF) backing a "Run sweep now" button with warn-tone confirmation. A browser form can't set the `Authorization` header the admin endpoint requires, hence the dedicated route; `POST /admin/consolidation/run` is unchanged as the automation surface.
- **Seed**: cron-era fictional content rewritten for the lazy-sweep model.

No schema migration; `llm_model` stays in the DB (append-only journal untouched).

## OpenSpec

Change archived at `openspec/changes/archive/2026-06-07-align-consolidation-dashboard-with-sweep/`; `dashboard` spec synced (1 modified + 2 added requirements, `openspec validate --specs --strict` 18/18).

## Validation

- typecheck / lint / `pnpm test` green (620 tests; 5 new e2e cases in `dashboard-e2e.test.ts`: CSRF round-trip forcing a real run, 403 without CSRF, login redirect, home copy assertions, slug rendering)
- Visual smoke against `pnpm run dev:docker:up`: trigger cell + slugged scope on home, sweep button → warn modal → 2 no-op runs (global + project), legible summary on detail, reseeded content clean