### PR TITLE
docs: cover one-click update socket permissions in troubleshooting

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,6 +51,35 @@ Three causes:
 
 Each migration runs in one transaction, so partial migrations roll back. If startup still fails: restore the latest backup (see `docs/backup.md`), reset `_migrations` to drop the failed row, restart.
 
+## One-click updates
+
+### Dashboard still shows "Manual update" with the Docker socket mounted
+
+The container runs as the unprivileged `rembric` user, and on most Linux hosts `/var/run/docker.sock` is `root:docker` mode `660` — mounted but unreadable. The logs confirm it:
+
+```
+ℹ docker socket at /var/run/docker.sock is mounted but not usable (check group_add); one-click updates disabled
+```
+
+Grant the socket's group to the container and recreate it:
+
+```bash
+stat -c '%g' /var/run/docker.sock   # e.g. 991
+```
+
+```yaml
+services:
+  rembric:
+    group_add:
+      - '991'
+```
+
+Capability detection is cached for 30 s — reload the dashboard after `docker compose up -d`.
+
+### Update button missing on a pinned version
+
+If `.env` pins `REMBRIC_VERSION=x.y.z`, one-click is refused by design (the next `docker compose up` would silently revert a self-update). The modal explains the pin; see [docs/updates.md](./updates.md#pinned-versions-disable-one-click).
+
 ## MCP transport
 
 ### Pending judgments piling up in search annotations

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -31,9 +31,9 @@ services:
     volumes:
       - ./data:/data
       - /var/run/docker.sock:/var/run/docker.sock
-    # Only needed if the socket is not world-accessible on your host:
-    # group_add:
-    #   - '<docker-gid>'   # stat -c '%g' /var/run/docker.sock
+    # Required on most Linux hosts (socket is root:docker mode 660):
+    group_add:
+      - '<docker-gid>' # stat -c '%g' /var/run/docker.sock
 ```
 
 Then `docker compose up -d` once. The dashboard detects the socket at runtime — no flag, no restart loop.
@@ -41,7 +41,7 @@ Then `docker compose up -d` once. The dashboard detects the socket at runtime �
 > [!WARNING]
 > **Mounting the Docker socket is root-equivalent on the host.** Anyone who obtains your admin token can then control Docker on the machine, not just your memory data. Only enable this on hosts where you accept that trade, keep the port off the public internet (Tailscale/WireGuard/reverse proxy), and consider the loopback-only override from the README when agent and server share a host.
 
-The container itself keeps running as the unprivileged `rembric` user. If the socket is mounted but not readable by that user (the usual cause is the docker group id), the dashboard degrades to the copy-paste flow and logs a single hint about `group_add`.
+The container itself keeps running as the unprivileged `rembric` user. If the socket is mounted but not readable by that user, the dashboard degrades to the copy-paste flow and logs a single hint about `group_add` — see [troubleshooting](./troubleshooting.md#dashboard-still-shows-manual-update-with-the-docker-socket-mounted).
 
 ### Pinned versions disable one-click
 


### PR DESCRIPTION
## Why

A prod deployment followed the `docs/updates.md` example verbatim — socket mounted, `group_add` left commented out — and the dashboard silently degraded to the manual flow. On most Linux hosts `/var/run/docker.sock` is `root:docker` mode `660`, so `group_add` is needed in the *typical* case, not the exceptional one the docs implied. The only breadcrumb was a single log line.

## What

- `docs/updates.md`: the compose snippet now ships `group_add` uncommented, labeled as required on most Linux hosts; the degradation paragraph links to the new troubleshooting entry.
- `docs/troubleshooting.md`: new **One-click updates** section —
  - *Dashboard still shows "Manual update" with the Docker socket mounted* → maps the exact `check group_add` log line to `stat -c '%g' /var/run/docker.sock` + `group_add`, with the 30s capability-cache note.
  - *Update button missing on a pinned version* → one-liner pointing at the pinned-tag explanation.

Docs only, no behavior changes. A follow-up could surface the `socket-unusable` reason directly in the update modal (would go through OpenSpec).