### PR TITLE
test(plugin): derive installer --status versions from the manifest

### DIFF
--- a/install.test.ts
+++ b/install.test.ts
@@ -26,6 +26,19 @@ const REPO_ROOT = dirname(fileURLToPath(import.meta.url));
 const INSTALL_SH = join(REPO_ROOT, 'apps', 'plugin', 'install.sh');
 const ROOT_SHIM = join(REPO_ROOT, 'install.sh');
 
+// The installer reports each agent's "available" plugin version from
+// .release-please-manifest.json per component. Derive expectations from the
+// same source so a release-please bump doesn't break these tests.
+const MANIFEST = JSON.parse(
+  readFileSync(join(REPO_ROOT, '.release-please-manifest.json'), 'utf8'),
+) as Record<string, string>;
+const PLUGIN_VERSION: Record<string, string> = {
+  claude: MANIFEST['apps/plugin/.claude-plugin'],
+  codex: MANIFEST['apps/plugin/.codex-plugin'],
+  hermes: MANIFEST['apps/plugin/.hermes-plugin'],
+  opencode: MANIFEST['apps/plugin/.opencode-plugin'],
+};
+
 interface RunOpts {
   cwd?: string;
   home?: string;
@@ -249,7 +262,7 @@ describe('agent CLI flags', () => {
     expect(data.agents.map((d) => d.agent)).toEqual(['claude', 'codex', 'hermes', 'opencode']);
     for (const d of data.agents) {
       expect(typeof d.present).toBe('boolean');
-      expect(d.available).toBe('0.10.0'); // from .release-please-manifest.json at the ref
+      expect(d.available).toBe(PLUGIN_VERSION[d.agent]); // from .release-please-manifest.json at the ref
       expect(d.installed).toBeNull(); // clean HOME → nothing installed
       expect(typeof d.action).toBe('string');
     }
@@ -280,7 +293,7 @@ describe('agent CLI flags', () => {
     expect(out).toContain('AGENT');
     expect(out).toContain('PLUGIN'); // clarifies the rows are about the plugin, not the agent
     expect(out).toContain('claude');
-    expect(out).toContain('0.10.0');
+    expect(out).toContain(PLUGIN_VERSION.claude);
   });
 
   it('--token sets the admin token verbatim on server install', () => {


### PR DESCRIPTION
## What

The installer's `--status` tests in `install.test.ts` hard-coded every agent's **available** plugin version to `0.10.0`. release-please's `plugin-suite` group bump to `0.11.0` therefore turned the suite release PR (#125) red:

```
× agent CLI flags > --status --json … → expected '0.11.0' to be '0.10.0'
```

## Fix

Read the expected version **per component** from `.release-please-manifest.json` — the same source the installer reads — instead of a frozen literal. The assertions now track whatever the manifest says (`claude`/`codex`/`opencode` → their key, `hermes` → its own key), so future release bumps don't break the suite.

## Why this unblocks #125

`release-please.yml` runs `on: push: branches: [main]`. Once this merges, release-please regenerates the open release PRs against the new `main` — which **auto-resolves the `.release-please-manifest.json` conflict in #125** (keeping `server` at main's `0.21.10` + the suite at `0.11.0`) **and** the `--status` test now passes. No manual edit of the bot's branch needed.

## Validation

`vitest run install.test.ts` → **33/33 pass** against both manifest states:
- main (`0.10.0` across the board)
- the bumped release scenario (`0.11.0` for the suite, `0.10.0` for hermes)

Touches only the test file; no installer/runtime change.