### PR TITLE
fix(plugin): correct the installer's per-agent update flow

### DIFF
--- a/apps/plugin/install.sh
+++ b/apps/plugin/install.sh
@@ -628,15 +628,18 @@ marketplace_cmds() { # $1 client, $2 action → print (and optionally run) CLI
     claude)
       add="claude plugin marketplace add https://github.com/susomejias/rembric.git"
       ins="claude plugin install rembric@rembric"
+      upd="claude plugin update rembric@rembric"
       rem="claude plugin uninstall rembric@rembric" ;;
     codex)
       add="codex plugin marketplace add https://github.com/susomejias/rembric.git"
       ins="codex plugin install rembric"
+      upd="codex plugin marketplace upgrade rembric"
       rem="codex plugin uninstall rembric" ;;
   esac
   case "$action" in
-    install|update) say "  Run:"; say "    ${BOLD}$add${RESET}"; say "    ${BOLD}$ins${RESET}"; cmd="$ins" ;;
-    uninstall)      say "  Run:"; say "    ${BOLD}$rem${RESET}"; cmd="$rem"; add='' ;;
+    install)   say "  Run:"; say "    ${BOLD}$add${RESET}"; say "    ${BOLD}$ins${RESET}"; cmd="$ins" ;;
+    update)    say "  Run:"; say "    ${BOLD}$upd${RESET}"; cmd="$upd"; add='' ;;
+    uninstall) say "  Run:"; say "    ${BOLD}$rem${RESET}"; cmd="$rem"; add='' ;;
   esac
   if [ "$NONINTERACTIVE" = "0" ] && [ "$HAVE_TTY" = "1" ] && client_present "$c"; then
     yn=$(ask "  Run these now? [y/N]")

--- a/apps/plugin/install.sh
+++ b/apps/plugin/install.sh
@@ -656,7 +656,8 @@ marketplace_cmds() { # $1 client, $2 action → print (and optionally run) CLI
 # Required post-install/upgrade steps per agent (the platform bits the installer
 # can't do for you). Surfaced after a successful install/update so the user
 # isn't left with a half-wired plugin. Full walkthrough: docs/agents.md.
-post_install_notes() {
+post_install_notes() { # $1 client, $2 action (install|update)
+  action="${2:-install}"
   case "$1" in
     claude)
       say "  ${BOLD}Next:${RESET} Claude prompts for the server URL + token during install (stored in your keychain). Restart Claude Code." ;;
@@ -667,10 +668,16 @@ post_install_notes() {
       say "    3) export ${BOLD}REMBRIC_SERVER_URL${RESET} + ${BOLD}REMBRIC_API_TOKEN${RESET} in your shell (Codex clears MCP env)"
       say "    ${DIM}details: docs/agents.md${RESET}" ;;
     hermes)
-      say "  ${BOLD}Next:${RESET}"
-      say "    1) ${BOLD}hermes plugins install rembric${RESET}  ${DIM}— prompts for SERVER_URL / API_TOKEN / PROJECT_SLUG → ~/.hermes/.env${RESET}"
-      say "    2) ${BOLD}hermes plugins enable rembric${RESET}"
-      say "    3) ${BOLD}hermes gateway restart${RESET}  ${DIM}— so the gateway loads the (new) plugin${RESET}" ;;
+      # On update the plugin is already installed + enabled — only the gateway
+      # needs to reload the new files. The full wiring is install-only.
+      if [ "$action" = "update" ]; then
+        say "  ${BOLD}Next:${RESET} ${BOLD}hermes gateway restart${RESET}  ${DIM}— reload the gateway so it picks up the updated plugin${RESET}"
+      else
+        say "  ${BOLD}Next:${RESET}"
+        say "    1) ${BOLD}hermes plugins install rembric${RESET}  ${DIM}— prompts for SERVER_URL / API_TOKEN / PROJECT_SLUG → ~/.hermes/.env${RESET}"
+        say "    2) ${BOLD}hermes plugins enable rembric${RESET}"
+        say "    3) ${BOLD}hermes gateway restart${RESET}  ${DIM}— so the gateway loads the (new) plugin${RESET}"
+      fi ;;
     opencode)
       say "  ${BOLD}Next:${RESET} paste the printed MCP block into ~/.config/opencode/opencode.json, export ${BOLD}REMBRIC_SERVER_URL${RESET} + ${BOLD}REMBRIC_API_TOKEN${RESET}, then restart opencode." ;;
   esac
@@ -685,7 +692,7 @@ do_client() { # $1 client, $2 action
       if [ "$action" = "uninstall" ]; then say "  ${DIM}Left in place: operator config, credentials, and .rembric files.${RESET}"; fi ;;
     claude|codex) marketplace_cmds "$c" "$action" ;;
   esac
-  if [ "$action" != "uninstall" ]; then post_install_notes "$c"; fi
+  if [ "$action" != "uninstall" ]; then post_install_notes "$c" "$action"; fi
   return 0
 }
 

--- a/install.test.ts
+++ b/install.test.ts
@@ -221,6 +221,14 @@ describe('agent routing', () => {
     expect(hermes.out).toContain('hermes gateway restart');
   });
 
+  it('hermes update only reminds to restart the gateway (already installed/enabled)', () => {
+    const { code, out } = run(['--agent=hermes', '--action=update'], { home });
+    expect(code).toBe(0);
+    expect(out).toContain('hermes gateway restart');
+    // The install-only wiring step must not be suggested on an update.
+    expect(out).not.toContain('hermes plugins install rembric');
+  });
+
   it('uninstall does not print post-install "Next" steps', () => {
     const { out } = run(['--agent=codex', '--action=uninstall'], { home });
     expect(out).not.toContain('Next');

--- a/install.test.ts
+++ b/install.test.ts
@@ -191,6 +191,19 @@ describe('agent routing', () => {
     expect(out).toContain('Left in place');
   });
 
+  it('claude/codex update use their real upgrade commands, not re-install', () => {
+    const claude = run(['--agent=claude', '--action=update'], { home });
+    expect(claude.code).toBe(0);
+    expect(claude.out).toContain('claude plugin update rembric@rembric');
+    expect(claude.out).not.toContain('claude plugin install'); // update ≠ re-install
+    expect(claude.out).not.toContain('marketplace add'); // marketplace already added
+
+    const codex = run(['--agent=codex', '--action=update'], { home });
+    expect(codex.code).toBe(0);
+    expect(codex.out).toContain('codex plugin marketplace upgrade rembric');
+    expect(codex.out).not.toContain('codex plugin install');
+  });
+
   it('a comma-separated --agent list drives multiple agents in one run', () => {
     const { code, out } = run(['--agent=codex,claude', '--action=install'], { home });
     expect(code).toBe(0);

--- a/openspec/specs/tui-installer/spec.md
+++ b/openspec/specs/tui-installer/spec.md
@@ -275,7 +275,7 @@ In colour mode the header SHALL show, under the lime block wordmark, a two-line 
 
 ### Requirement: Per-agent post-install steps are surfaced
 
-After a successful install or update (NOT uninstall), the installer SHALL print the required platform post-install steps for that agent, so the user is not left with a half-wired plugin. At minimum: Codex SHALL show enabling `plugin_hooks` and trusting the 5 hooks via `/hooks`, plus exporting `REMBRIC_*`; Hermes SHALL show `hermes plugins install rembric` (which triggers the `requires_env` credential prompts), then `hermes plugins enable rembric`, then a reminder to run `hermes gateway restart` so it loads the (new) plugin; opencode SHALL point at pasting the printed MCP block and exporting `REMBRIC_*`; Claude SHALL note credentials are prompted at install (keychain). The full walkthrough remains in `docs/agents.md`.
+After a successful install or update (NOT uninstall), the installer SHALL print the required platform post-install steps for that agent, so the user is not left with a half-wired plugin. The steps SHALL reflect the action: install-only wiring (credential prompts, enabling the plugin) SHALL NOT be repeated on update, where the plugin is already installed and enabled. At minimum: Codex SHALL show enabling `plugin_hooks` and trusting the 5 hooks via `/hooks`, plus exporting `REMBRIC_*`; Hermes install SHALL show `hermes plugins install rembric` (which triggers the `requires_env` credential prompts), then `hermes plugins enable rembric`, then a reminder to run `hermes gateway restart` so it loads the (new) plugin, while Hermes **update** SHALL show only `hermes gateway restart`; opencode SHALL point at pasting the printed MCP block and exporting `REMBRIC_*`; Claude SHALL note credentials are prompted at install (keychain). The full walkthrough remains in `docs/agents.md`.
 
 #### Scenario: Codex install prints the hook-enablement steps
 
@@ -286,6 +286,11 @@ After a successful install or update (NOT uninstall), the installer SHALL print 
 
 - **WHEN** `--agent=hermes --action=install` runs
 - **THEN** the output SHALL include `hermes plugins install rembric`, `hermes plugins enable rembric`, and a reminder to run `hermes gateway restart`
+
+#### Scenario: Hermes update only reminds to restart the gateway
+
+- **WHEN** `--agent=hermes --action=update` runs
+- **THEN** the output SHALL include `hermes gateway restart` and SHALL NOT repeat the install-only `hermes plugins install rembric` step
 
 #### Scenario: Uninstall omits post-install steps
 


### PR DESCRIPTION
## What

The TUI installer's **update** action reused the **install** wiring for the marketplace agents and for Hermes, so `--action=update` told users to re-install / re-enable things that updating doesn't touch.

### 1. Claude / Codex — wrong update command
`marketplace_cmds` lumped `install|update` together and printed `claude plugin install` / `codex plugin install` (plus a redundant `marketplace add`). Updating has its own verb:
- **claude** → `claude plugin update rembric@rembric`
- **codex** → `codex plugin marketplace upgrade rembric`

Split the `update` branch out; it no longer re-prints the marketplace-add. Matches the commands already documented in `docs/agents.md`.

### 2. Hermes — update repeated the full install steps
`post_install_notes` printed `hermes plugins install rembric` → `enable` → `gateway restart` for both actions. On an **update** the plugin is already installed and enabled — only `hermes gateway restart` is needed to reload the new files. The notes are now action-aware.

## Spec

Updated `openspec/specs/tui-installer/spec.md` (post-install-steps requirement) to state install-only wiring is not repeated on update, plus a new Hermes-update scenario.

## Tests

`install.test.ts` (+2 cases, **35 pass**):
- claude/codex `--action=update` print their real upgrade commands and **not** `plugin install` / `marketplace add`.
- hermes `--action=update` reminds to `hermes gateway restart` and omits the install-only `hermes plugins install rembric` step.

`sh -n apps/plugin/install.sh` clean; `openspec validate tui-installer --strict` passes. Installer-only change; no runtime/server impact.