### PR TITLE
feat(plugin): add --yes/-y flag to run Claude/Codex marketplace commands headlessly

### DIFF
--- a/apps/plugin/install.sh
+++ b/apps/plugin/install.sh
@@ -38,6 +38,7 @@ ARG_SERVER=0
 ARG_AGENTS=''
 ARG_ACTION=''
 ARG_UP=0
+ARG_YES=0
 ARG_STATUS=0
 ARG_JSON=0
 ARG_TOKEN=''
@@ -52,6 +53,7 @@ for arg in "$@"; do
     --action=*) ARG_ACTION="${arg#--action=}" ;;
     --ref=*) REF="${arg#--ref=}" ;;
     --up) ARG_UP=1 ;;
+    --yes|-y) ARG_YES=1 ;;
     --status) ARG_STATUS=1 ;;
     --json) ARG_JSON=1 ;;
     --token=*) ARG_TOKEN="${arg#--token=}"; ARG_TOKEN_SET=1 ;;
@@ -641,7 +643,14 @@ marketplace_cmds() { # $1 client, $2 action → print (and optionally run) CLI
     update)    say "  Run:"; say "    ${BOLD}$upd${RESET}"; cmd="$upd"; add='' ;;
     uninstall) say "  Run:"; say "    ${BOLD}$rem${RESET}"; cmd="$rem"; add='' ;;
   esac
-  if [ "$NONINTERACTIVE" = "0" ] && [ "$HAVE_TTY" = "1" ] && client_present "$c"; then
+  # --yes is the headless opt-in: run the marketplace command(s) without a
+  # prompt, but only when the client binary is actually present (nothing to run
+  # otherwise). Without --yes, an interactive TTY still gets the [y/N] prompt
+  # and a piped/headless run only prints.
+  if [ "$ARG_YES" = "1" ] && client_present "$c"; then
+    [ -n "${add:-}" ] && eval "$add" || true
+    eval "$cmd" || true
+  elif [ "$NONINTERACTIVE" = "0" ] && [ "$HAVE_TTY" = "1" ] && client_present "$c"; then
     yn=$(ask "  Run these now? [y/N]")
     case "$yn" in
       y|Y)
@@ -722,6 +731,8 @@ Flags:
   --token=<tok>       admin token for --server (default: auto-generate)
   --port=<n>          REMBRIC_PORT for --server (default: 8787)
   --up                run 'docker compose pull && up -d' after --server (needs docker)
+  --yes, -y           run the Claude/Codex marketplace commands when the client
+                      binary is present (headless opt-in; does not start Docker — use --up)
   --ref=<tag>         git ref to install from (default: main)
   -h, --help          this help
 

--- a/install.test.ts
+++ b/install.test.ts
@@ -262,6 +262,82 @@ describe('agent routing', () => {
   });
 });
 
+describe('--yes runs the marketplace command (stubbed client binary)', () => {
+  // A fake `claude`/`codex` first on PATH lets us assert the run-through
+  // headlessly: the stub echoes a sentinel with its args so we can tell
+  // "executed" from "merely printed". Core tools live in /usr/bin:/bin, so the
+  // absent-binary case points PATH there (claude/codex are not system bins).
+  const CORE_PATH = '/usr/bin:/bin';
+  function fakeClientBinDir(name: 'claude' | 'codex'): string {
+    const d = mkdtempSync(join(tmpdir(), 'rembric-fakeclient-'));
+    writeFileSync(join(d, name), `#!/bin/sh\necho "RAN:${name} $*"\n`);
+    chmodSync(join(d, name), 0o755);
+    return d;
+  }
+
+  it('--yes executes the claude update command when the claude binary is present', () => {
+    const bin = fakeClientBinDir('claude');
+    const { code, out } = run(['--agent=claude', '--action=update', '--yes'], {
+      home,
+      path: `${bin}:${CORE_PATH}`,
+    });
+    rmSync(bin, { recursive: true, force: true });
+    expect(code).toBe(0);
+    expect(out).toContain('claude plugin update rembric@rembric'); // still printed
+    expect(out).toContain('RAN:claude plugin update rembric@rembric'); // and executed
+  });
+
+  it('-y is an alias for --yes', () => {
+    const bin = fakeClientBinDir('claude');
+    const { code, out } = run(['--agent=claude', '--action=update', '-y'], {
+      home,
+      path: `${bin}:${CORE_PATH}`,
+    });
+    rmSync(bin, { recursive: true, force: true });
+    expect(code).toBe(0);
+    expect(out).toContain('RAN:claude plugin update rembric@rembric');
+  });
+
+  it('--yes executes the codex upgrade command when the codex binary is present', () => {
+    const bin = fakeClientBinDir('codex');
+    const { code, out } = run(['--agent=codex', '--action=update', '--yes'], {
+      home,
+      path: `${bin}:${CORE_PATH}`,
+    });
+    rmSync(bin, { recursive: true, force: true });
+    expect(code).toBe(0);
+    expect(out).toContain('RAN:codex plugin marketplace upgrade rembric');
+  });
+
+  it('without --yes a headless run only prints, never executes', () => {
+    const bin = fakeClientBinDir('claude');
+    const { code, out } = run(['--agent=claude', '--action=update'], {
+      home,
+      path: `${bin}:${CORE_PATH}`,
+    });
+    rmSync(bin, { recursive: true, force: true });
+    expect(code).toBe(0);
+    expect(out).toContain('claude plugin update rembric@rembric'); // printed
+    expect(out).not.toContain('RAN:claude'); // not executed
+  });
+
+  it('--yes with an absent client binary prints but executes nothing', () => {
+    const { code, out } = run(['--agent=codex', '--action=update', '--yes'], {
+      home,
+      path: CORE_PATH, // no codex on PATH
+    });
+    expect(code).toBe(0);
+    expect(out).toContain('codex plugin marketplace upgrade rembric'); // printed
+    expect(out).not.toContain('RAN:codex'); // nothing ran
+  });
+
+  it('--help documents the --yes / -y flag', () => {
+    const { out } = run(['--help']);
+    expect(out).toContain('--yes');
+    expect(out).toContain('-y');
+  });
+});
+
 describe('root install.sh shim', () => {
   it('--help is identical to the plugin installer (pure forwarder)', () => {
     const root = run(['--help'], { script: ROOT_SHIM });

--- a/openspec/changes/archive/2026-06-13-add-installer-yes-flag/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-13-add-installer-yes-flag/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-13

--- a/openspec/changes/archive/2026-06-13-add-installer-yes-flag/design.md
+++ b/openspec/changes/archive/2026-06-13-add-installer-yes-flag/design.md
@@ -1,0 +1,64 @@
+## Context
+
+`marketplace_cmds()` in `apps/plugin/install.sh` prints the Claude/Codex marketplace commands and conditionally runs them:
+
+```sh
+if [ "$NONINTERACTIVE" = "0" ] && [ "$HAVE_TTY" = "1" ] && client_present "$c"; then
+  yn=$(ask "  Run these now? [y/N]")
+  case "$yn" in y|Y) [ -n "${add:-}" ] && eval "$add" || true; eval "$cmd" || true ;; esac
+fi
+```
+
+`HAVE_TTY` is set from `{ true >/dev/tty; } 2>/dev/null && { [ -t 0 ] || [ -t 1 ]; }`. Under `curl … | sh` there is no controlling terminal, so `HAVE_TTY=0` and the block is skipped — the commands are only printed. opencode/Hermes are unaffected (they delegate to a file-copying `install.sh`, no prompt). This is the gap: no headless path executes the marketplace command.
+
+Constraints: POSIX `sh` under `set -eu`, `sh -n`-clean, no bashisms; the orchestrator must keep delegating (no inlined client logic); the root shim must pass the new flag through unchanged (it already forwards `"$@"` verbatim, so no shim edit is needed).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A single opt-in flag (`--yes`, alias `-y`) that makes headless runs execute the Claude/Codex marketplace command for the requested action when the binary is present.
+- Zero change to every existing invocation: no flag → identical behavior (print-only headless, `[y/N]` on a TTY).
+- Headless test coverage of the new path.
+
+**Non-Goals:**
+
+- Auto-confirming the server bring-up (stays on `--up`).
+- Running anything for opencode/Hermes via `--yes` (they have no marketplace prompt; their delegation already runs unconditionally).
+- Executing marketplace commands when the binary is absent (nothing to update; keep printing).
+
+## Decisions
+
+**1. New flag `--yes` / `-y` → `ARG_YES` (default 0).** Parsed in the existing `for arg in "$@"` loop alongside `--up`/`--status`. Chosen over reusing `REMBRIC_NONINTERACTIVE` because that env var means "no TTY / flag-driven", which is orthogonal to "I consent to side effects". A dedicated opt-in keeps the safe default and reads clearly in automation. `-y` alias matches the universal convention.
+
+**2. Re-shape the run-gate as `if … elif`, not a new branch.**
+
+```sh
+if [ "$ARG_YES" = "1" ] && client_present "$c"; then
+  [ -n "${add:-}" ] && eval "$add" || true
+  eval "$cmd" || true
+elif [ "$NONINTERACTIVE" = "0" ] && [ "$HAVE_TTY" = "1" ] && client_present "$c"; then
+  yn=$(ask "  Run these now? [y/N]")
+  case "$yn" in y|Y) [ -n "${add:-}" ] && eval "$add" || true; eval "$cmd" || true ;; esac
+fi
+```
+
+`--yes` takes precedence so a TTY user passing `-y` is not re-prompted. The `client_present` guard is duplicated into both arms intentionally — when `--yes` is set but the binary is absent, the `if` is false and the `elif` is also false under headless (HAVE_TTY=0), so nothing runs and only the earlier `say "  Run:"` print stands. Alternative considered (single `RUN=1` variable computed up front) rejected: the two arms differ (prompt vs. no prompt), so the branch is clearer than a flag-and-prompt combo.
+
+**3. `set -e` safety.** Both arms already terminate in `eval … || true` or a closed `case … esac`; the function still ends with `return 0`. The new `if`/`elif` test expressions never leave a bare false `[ … ]` as the function's last command. No regression to the menu-abort invariant.
+
+**4. Scope `--yes` to `marketplace_cmds` only.** The server bring-up is already a separate gate (`--up`), so `--yes` deliberately does not touch it. This keeps "consent to run a plugin CLI" distinct from "consent to start Docker".
+
+## Risks / Trade-offs
+
+- [A user passes `--yes` expecting it to also bring the server up] → `--help` text scopes `--yes` to the marketplace run-through and names `--up` for the server; the spec records the non-goal.
+- [`eval` on the marketplace command in automation runs a real CLI side effect] → It is opt-in and gated on `command -v <binary>`; the command string is a fixed literal (`marketplace_cmds` builds `$cmd` from hardcoded strings, no user interpolation), so there is no injection surface beyond what the user already types as `--agent`/`--action`.
+- [Test executing a real `claude`/`codex`] → Tests put a fake binary (a shell script echoing a sentinel) first on `PATH`, mirroring the existing `fakeDockerDir` pattern; no real client is invoked.
+
+## Migration Plan
+
+Pure additive flag; no data, no migration, no rollback concern. Shipping it is landing the edited `install.sh` + tests. The repo-root shim forwards `"$@"`, so it needs no change. Validate with the `rembric-tui-installer-e2e` headless layer (`install.test.ts` + `sh -n`) before merge.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-06-13-add-installer-yes-flag/proposal.md
+++ b/openspec/changes/archive/2026-06-13-add-installer-yes-flag/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The installer prints the Claude Code / Codex marketplace commands but only offers to run them when a real TTY is present. The canonical invocation is `curl … | sh`, where the script's stdin is the pipe, so `HAVE_TTY=0` and the interactive `Run these now? [y/N]` prompt never fires. There is currently no headless way to make the installer actually execute the marketplace command — agents and `curl|sh` users are always told to run it by hand. An opt-in flag closes that gap without changing the safe default.
+
+## What Changes
+
+- Add an opt-in `--yes` flag (alias `-y`) parsed into `ARG_YES`.
+- In `marketplace_cmds` (Claude / Codex), when `--yes` is set **and** the client binary is present on `PATH`, execute the marketplace command(s) for the action directly — no prompt — in addition to printing them.
+- Preserve the existing interactive path unchanged: when `--yes` is absent, a real TTY still shows the `[y/N]` prompt; headless without `--yes` still only prints.
+- `--yes` with an **absent** client binary executes nothing (there is nothing to update) and only prints the commands — same conservative behavior as today.
+- Document `--yes`/`-y` in `--help`/usage.
+- The flag is scoped to the marketplace run-through; it does not auto-confirm the server bring-up (that stays gated on `--up`).
+
+No breaking changes: every existing invocation behaves identically. This touches no append-only / scope / topic_key / judgment invariant — it is purely installer orchestration surface.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `tui-installer`: the "Per-client install / update / uninstall routing" requirement gains a headless opt-in (`--yes`) for the Claude/Codex marketplace run-through, still gated on binary presence; the "Headless agent CLI surface" requirement adds `--yes`/`-y` to the documented flag set and `--help`.
+
+## Impact
+
+- `apps/plugin/install.sh` — flag parsing (`ARG_YES`), the run-gate in `marketplace_cmds`, and the `usage` text.
+- `install.test.ts` (repo root) — new headless cases using the existing fake-binary-on-PATH pattern (mirror `fakeDockerDir`): `--yes` executes when the `claude`/`codex` binary is present; without `--yes` it only prints; `--yes` with an absent binary executes nothing.
+- `openspec/specs/tui-installer/spec.md` — delta on the two requirements above.
+- Docs that publish the headless flag set (`README.md`, `apps/plugin/README.md`, `docs/agents.md`) gain a mention of `--yes` where the flag list lives.
+- No new dependency, lifecycle script, or published binary. Orchestrator model preserved — still delegates to the marketplace CLIs, does not reimplement client logic. POSIX `sh`, `set -eu`, `sh -n`-clean.

--- a/openspec/changes/archive/2026-06-13-add-installer-yes-flag/specs/tui-installer/spec.md
+++ b/openspec/changes/archive/2026-06-13-add-installer-yes-flag/specs/tui-installer/spec.md
@@ -1,0 +1,79 @@
+## MODIFIED Requirements
+
+### Requirement: Per-client install / update / uninstall routing
+
+For each present client the installer SHALL offer Install, Update, and Uninstall, routing each to that client's real primitive. For opencode and Hermes, install/update SHALL delegate to the client `install.sh` (re-running it performs an update) and uninstall SHALL delegate to the client `uninstall.sh`. For Claude Code and Codex, the installer SHALL print the client's marketplace CLI commands for each action and, only when the client binary is detected on `PATH`, MAY offer to run them; the installer SHALL NOT create or rely on a repo-side install script for these two clients. The offer to run the marketplace commands SHALL be presented as an interactive `[y/N]` prompt when a controlling terminal is available; in addition, when the opt-in `--yes` flag (alias `-y`) is set the installer SHALL execute those commands directly without prompting, including under headless invocation (e.g. `curl … | sh`), but still ONLY when the client binary is detected on `PATH`. When `--yes` is set but the client binary is absent, the installer SHALL print the commands and SHALL NOT execute anything. When `--yes` is not set and there is no controlling terminal, the installer SHALL only print the commands, as today.
+
+#### Scenario: opencode update re-runs its installer
+
+- **WHEN** the user selects Update for opencode
+- **THEN** the installer SHALL invoke the opencode `install.sh` (which overwrites the installed files)
+
+#### Scenario: Marketplace client prints CLI commands
+
+- **WHEN** the user selects Install for Codex
+- **THEN** the installer SHALL print `codex plugin marketplace add …` and `codex plugin install rembric`
+- **AND** it SHALL NOT attempt to copy plugin files itself
+
+#### Scenario: Marketplace client run-through gated on binary presence
+
+- **WHEN** the user selects Install for Claude Code and the `claude` binary is on `PATH`
+- **THEN** the installer MAY offer to run the `/plugin marketplace add` + `/plugin install` commands
+- **AND** when the binary is absent, the installer SHALL print the commands for the user to run manually
+
+#### Scenario: --yes executes the marketplace command headlessly when the binary is present
+
+- **WHEN** the installer runs headless as `--agent=claude --action=update --yes` (or `-y`) and the `claude` binary is on `PATH`
+- **THEN** it SHALL execute `claude plugin update rembric@rembric` directly without any prompt
+- **AND** the same SHALL hold for Codex (`codex plugin marketplace upgrade rembric`) and for the install/uninstall actions of both clients
+
+#### Scenario: --yes with an absent binary executes nothing
+
+- **WHEN** the installer runs headless as `--agent=codex --action=update --yes` and the `codex` binary is NOT on `PATH`
+- **THEN** it SHALL print the marketplace command(s) and SHALL NOT execute anything
+
+#### Scenario: Without --yes a headless run only prints
+
+- **WHEN** the installer runs headless as `--agent=claude --action=update` (no `--yes`) and the `claude` binary is on `PATH`
+- **THEN** it SHALL only print the marketplace command and SHALL NOT execute it
+
+### Requirement: Headless agent CLI surface
+
+The installer SHALL be fully drivable headlessly as a CLI so agents/automation can use it without the interactive TUI. Beyond the existing `--server` / `--agent=<list>` / `--action=install|update|uninstall` / `--up` / `--ref=<tag>` flags and `REMBRIC_NONINTERACTIVE`, it SHALL provide:
+
+- `--status` — print the server status and the per-agent Rembric-plugin table (columns `AGENT` · `DETECTED` = agent found on this machine · `PLUGIN` = installed plugin version · `LATEST` = latest plugin version · `ACTION`) headlessly and exit, without entering the menu and without a banner. A caption SHALL make clear the action targets the plugin, not the agent.
+- `--json` — with `--status`, emit a machine-readable object `{ "server": {…}, "agents": [...] }` and nothing else on stdout so it parses cleanly. The `server` object carries `state` (docker container state: `running`/`exited`/`paused`/`created`/`dead`/`absent`/`unknown`), `version` (the running/stopped container's image tag, or null), and `latest_release` (the newest published server release from GitHub Releases — tag `server-v<semver>` — or null). Each `agents` entry carries `agent`, `present` boolean, `installed` (semver or null), `available` (semver or null), `action`.
+- `--token=<value>` — set `REMBRIC_ADMIN_TOKEN` for `--server` install verbatim instead of auto-generating; the value SHALL be written safely regardless of special characters, and a value shorter than 16 characters SHALL be refused with a clear error (the server's minimum) rather than producing a crash-looping server.
+- `--port=<n>` — set `REMBRIC_PORT` in the generated `.env` for `--server`, and the printed dashboard URL SHALL reflect it.
+- `--yes` (alias `-y`) — opt-in auto-confirm for the Claude Code / Codex marketplace run-through. When set, the installer SHALL execute the marketplace command(s) for the requested `--action` directly (no prompt), but ONLY when the client binary is detected on `PATH`; with an absent binary it prints and executes nothing. The flag SHALL default to off, so omitting it preserves the print-only headless behavior and the interactive `[y/N]` prompt on a real TTY. `--yes` SHALL NOT auto-start the Docker bring-up (that stays gated on `--up`).
+
+The `--up` bring-up SHALL honour `REMBRIC_NO_PULL=1` to skip `docker compose pull` and use the locally-present image as-is (air-gapped operators, and the CI end-to-end test that brings the freshly-built image up). The installer SHALL report the server status (docker-observable state + running image tag) in `--status` and in the interactive Server screen. It SHALL also surface `latest_release` — the newest published server release from the GitHub Releases API (tag `server-v<semver>`), the same source the dashboard's update-check uses — on a **best-effort** basis: a single short-timeout `curl` (overridable via `REMBRIC_RELEASES_URL`), silently omitted when offline, rate-limited, `curl`-less, or when `REMBRIC_UPDATE_CHECK=off`. Because a running `:latest` image cannot be compared to a release without a digest, `latest_release` is informational; an "update available" hint is shown ONLY when the running tag is itself a semver older than `latest_release`. The server's "available" is NOT taken from the repo manifest (that is the source-tree version, not a published release). `--status` SHALL work regardless of TTY. An unknown flag SHALL exit non-zero with an error. `--help` SHALL document the full flag set, including `--yes`/`-y`.
+
+#### Scenario: `--status --json` is clean machine-readable output
+
+- **WHEN** an agent runs `install.sh --status --json`
+- **THEN** stdout SHALL be a single JSON object with a `server` block (`state`/`version`/`latest_release`) and an `agents` array (one object per agent: `claude`, `codex`, `hermes`, `opencode`)
+- **AND** no banner, prompt, or colour escape SHALL precede or follow it
+
+#### Scenario: Server state is reported from docker, best-effort
+
+- **WHEN** `--status` runs and a `rembric` container exists
+- **THEN** the reported server `state` SHALL be the docker container state (e.g. `running`, `exited`) and `version` its image tag
+- **AND** when docker is unavailable or its daemon is unreachable, `state` SHALL be `unknown` (never a crash)
+
+#### Scenario: latest_release comes from GitHub Releases, best-effort
+
+- **WHEN** `--status` runs with update-checking enabled and the releases endpoint lists `server-v<semver>` tags
+- **THEN** `latest_release` SHALL be the highest such semver (plugin-release tags ignored)
+- **AND** when offline / rate-limited / `REMBRIC_UPDATE_CHECK=off`, `latest_release` SHALL be null and the rest of `--status` SHALL still render
+
+#### Scenario: `--token` and `--port` configure the server non-interactively
+
+- **WHEN** an agent runs `install.sh --server --action=install --token=<tok> --port=<n>` headless
+- **THEN** `./.env` SHALL contain `REMBRIC_ADMIN_TOKEN=<tok>` (verbatim) and `REMBRIC_PORT=<n>`
+- **AND** no prompt SHALL be shown
+
+#### Scenario: `--help` documents the `--yes` flag
+
+- **WHEN** a user runs `install.sh --help`
+- **THEN** the usage output SHALL list `--yes` (and its `-y` alias) and describe it as the opt-in that runs the Claude/Codex marketplace commands when the binary is present

--- a/openspec/changes/archive/2026-06-13-add-installer-yes-flag/tasks.md
+++ b/openspec/changes/archive/2026-06-13-add-installer-yes-flag/tasks.md
@@ -1,0 +1,34 @@
+## 1. Flag parsing
+
+- [x] 1.1 In `apps/plugin/install.sh`, add `ARG_YES=0` to the flag defaults block (alongside `ARG_UP=0`).
+- [x] 1.2 In the `for arg in "$@"` parse loop, add `--yes|-y) ARG_YES=1 ;;` (before the catch-all `*)` error arm).
+
+## 2. Run-gate in marketplace_cmds
+
+- [x] 2.1 In `marketplace_cmds()`, replace the single TTY-gated run block with an `if … elif`: the `if [ "$ARG_YES" = "1" ] && client_present "$c"` arm `eval`s `$add` (when set) then `$cmd` with no prompt; the `elif [ "$NONINTERACTIVE" = "0" ] && [ "$HAVE_TTY" = "1" ] && client_present "$c"` arm keeps the existing `ask`/`[y/N]` path verbatim.
+- [x] 2.2 Confirm the function still ends with `return 0` and neither arm leaves a bare false `[ … ]` as the last command (so `set -e` does not abort the menu).
+
+## 3. Usage / help text
+
+- [x] 3.1 Add `--yes, -y` to the `Flags:` list in `usage()` with a one-line description: opt-in that runs the Claude/Codex marketplace commands when the binary is present (does not start Docker — use `--up`).
+
+## 4. Tests (install.test.ts)
+
+- [x] 4.1 Add a `fakeClientBinDir(name)` helper (mirroring `fakeDockerDir`) that writes an executable shell script named `claude`/`codex` echoing a sentinel like `RAN:$*`, returns its dir, and is placed first on `PATH`.
+- [x] 4.2 Test: `--agent=claude --action=update --yes` with the fake `claude` on PATH → output contains the executed sentinel (`RAN:plugin update rembric@rembric`).
+- [x] 4.3 Test: `-y` alias behaves identically to `--yes` for the same case.
+- [x] 4.4 Test: `--agent=codex --action=update --yes` with the fake `codex` on PATH → output contains the executed sentinel for `codex plugin marketplace upgrade rembric`.
+- [x] 4.5 Test: `--agent=claude --action=update` WITHOUT `--yes` (fake `claude` on PATH) → output contains the printed command but NOT the executed sentinel.
+- [x] 4.6 Test: `--agent=codex --action=update --yes` with NO `codex` on PATH (scrubbed PATH) → output prints the command but contains no executed sentinel.
+- [x] 4.7 Test: `--help` output contains `--yes` and `-y`.
+
+## 5. Docs
+
+- [x] 5.1 Add `--yes`/`-y` to the headless flag list wherever it is enumerated in `README.md`, `apps/plugin/README.md`, and `docs/agents.md` (search for `--action=` / `--status` flag tables; only the flag-list spots, not a new section).
+
+## 6. Validation
+
+- [x] 6.1 `sh -n apps/plugin/install.sh` and `sh -n install.sh` (root shim) are clean.
+- [x] 6.2 `pnpm vitest run install.test.ts` passes, including the new cases.
+- [x] 6.3 `pnpm run lint` and `pnpm run typecheck` pass.
+- [x] 6.4 Run the `rembric-tui-installer-e2e` headless layer per the skill (the `install.test.ts` suite is the CI gate); record the result.

--- a/openspec/specs/tui-installer/spec.md
+++ b/openspec/specs/tui-installer/spec.md
@@ -152,7 +152,7 @@ For each of the four clients the installer SHALL determine (a) whether the clien
 
 ### Requirement: Per-client install / update / uninstall routing
 
-For each present client the installer SHALL offer Install, Update, and Uninstall, routing each to that client's real primitive. For opencode and Hermes, install/update SHALL delegate to the client `install.sh` (re-running it performs an update) and uninstall SHALL delegate to the client `uninstall.sh`. For Claude Code and Codex, the installer SHALL print the client's marketplace CLI commands for each action and, only when the client binary is detected on `PATH`, MAY offer to run them; the installer SHALL NOT create or rely on a repo-side install script for these two clients.
+For each present client the installer SHALL offer Install, Update, and Uninstall, routing each to that client's real primitive. For opencode and Hermes, install/update SHALL delegate to the client `install.sh` (re-running it performs an update) and uninstall SHALL delegate to the client `uninstall.sh`. For Claude Code and Codex, the installer SHALL print the client's marketplace CLI commands for each action and, only when the client binary is detected on `PATH`, MAY offer to run them; the installer SHALL NOT create or rely on a repo-side install script for these two clients. The offer to run the marketplace commands SHALL be presented as an interactive `[y/N]` prompt when a controlling terminal is available; in addition, when the opt-in `--yes` flag (alias `-y`) is set the installer SHALL execute those commands directly without prompting, including under headless invocation (e.g. `curl … | sh`), but still ONLY when the client binary is detected on `PATH`. When `--yes` is set but the client binary is absent, the installer SHALL print the commands and SHALL NOT execute anything. When `--yes` is not set and there is no controlling terminal, the installer SHALL only print the commands, as today.
 
 #### Scenario: opencode update re-runs its installer
 
@@ -170,6 +170,22 @@ For each present client the installer SHALL offer Install, Update, and Uninstall
 - **WHEN** the user selects Install for Claude Code and the `claude` binary is on `PATH`
 - **THEN** the installer MAY offer to run the `/plugin marketplace add` + `/plugin install` commands
 - **AND** when the binary is absent, the installer SHALL print the commands for the user to run manually
+
+#### Scenario: --yes executes the marketplace command headlessly when the binary is present
+
+- **WHEN** the installer runs headless as `--agent=claude --action=update --yes` (or `-y`) and the `claude` binary is on `PATH`
+- **THEN** it SHALL execute `claude plugin update rembric@rembric` directly without any prompt
+- **AND** the same SHALL hold for Codex (`codex plugin marketplace upgrade rembric`) and for the install/uninstall actions of both clients
+
+#### Scenario: --yes with an absent binary executes nothing
+
+- **WHEN** the installer runs headless as `--agent=codex --action=update --yes` and the `codex` binary is NOT on `PATH`
+- **THEN** it SHALL print the marketplace command(s) and SHALL NOT execute anything
+
+#### Scenario: Without --yes a headless run only prints
+
+- **WHEN** the installer runs headless as `--agent=claude --action=update` (no `--yes`) and the `claude` binary is on `PATH`
+- **THEN** it SHALL only print the marketplace command and SHALL NOT execute it
 
 ### Requirement: Conservative uninstall across clients
 
@@ -232,8 +248,9 @@ The installer SHALL be fully drivable headlessly as a CLI so agents/automation c
 - `--json` — with `--status`, emit a machine-readable object `{ "server": {…}, "agents": [...] }` and nothing else on stdout so it parses cleanly. The `server` object carries `state` (docker container state: `running`/`exited`/`paused`/`created`/`dead`/`absent`/`unknown`), `version` (the running/stopped container's image tag, or null), and `latest_release` (the newest published server release from GitHub Releases — tag `server-v<semver>` — or null). Each `agents` entry carries `agent`, `present` boolean, `installed` (semver or null), `available` (semver or null), `action`.
 - `--token=<value>` — set `REMBRIC_ADMIN_TOKEN` for `--server` install verbatim instead of auto-generating; the value SHALL be written safely regardless of special characters, and a value shorter than 16 characters SHALL be refused with a clear error (the server's minimum) rather than producing a crash-looping server.
 - `--port=<n>` — set `REMBRIC_PORT` in the generated `.env` for `--server`, and the printed dashboard URL SHALL reflect it.
+- `--yes` (alias `-y`) — opt-in auto-confirm for the Claude Code / Codex marketplace run-through. When set, the installer SHALL execute the marketplace command(s) for the requested `--action` directly (no prompt), but ONLY when the client binary is detected on `PATH`; with an absent binary it prints and executes nothing. The flag SHALL default to off, so omitting it preserves the print-only headless behavior and the interactive `[y/N]` prompt on a real TTY. `--yes` SHALL NOT auto-start the Docker bring-up (that stays gated on `--up`).
 
-The `--up` bring-up SHALL honour `REMBRIC_NO_PULL=1` to skip `docker compose pull` and use the locally-present image as-is (air-gapped operators, and the CI end-to-end test that brings the freshly-built image up). The installer SHALL report the server status (docker-observable state + running image tag) in `--status` and in the interactive Server screen. It SHALL also surface `latest_release` — the newest published server release from the GitHub Releases API (tag `server-v<semver>`), the same source the dashboard's update-check uses — on a **best-effort** basis: a single short-timeout `curl` (overridable via `REMBRIC_RELEASES_URL`), silently omitted when offline, rate-limited, `curl`-less, or when `REMBRIC_UPDATE_CHECK=off`. Because a running `:latest` image cannot be compared to a release without a digest, `latest_release` is informational; an "update available" hint is shown ONLY when the running tag is itself a semver older than `latest_release`. The server's "available" is NOT taken from the repo manifest (that is the source-tree version, not a published release). `--status` SHALL work regardless of TTY. An unknown flag SHALL exit non-zero with an error. `--help` SHALL document the full flag set.
+The `--up` bring-up SHALL honour `REMBRIC_NO_PULL=1` to skip `docker compose pull` and use the locally-present image as-is (air-gapped operators, and the CI end-to-end test that brings the freshly-built image up). The installer SHALL report the server status (docker-observable state + running image tag) in `--status` and in the interactive Server screen. It SHALL also surface `latest_release` — the newest published server release from the GitHub Releases API (tag `server-v<semver>`), the same source the dashboard's update-check uses — on a **best-effort** basis: a single short-timeout `curl` (overridable via `REMBRIC_RELEASES_URL`), silently omitted when offline, rate-limited, `curl`-less, or when `REMBRIC_UPDATE_CHECK=off`. Because a running `:latest` image cannot be compared to a release without a digest, `latest_release` is informational; an "update available" hint is shown ONLY when the running tag is itself a semver older than `latest_release`. The server's "available" is NOT taken from the repo manifest (that is the source-tree version, not a published release). `--status` SHALL work regardless of TTY. An unknown flag SHALL exit non-zero with an error. `--help` SHALL document the full flag set, including `--yes`/`-y`.
 
 #### Scenario: `--status --json` is clean machine-readable output
 
@@ -258,6 +275,11 @@ The `--up` bring-up SHALL honour `REMBRIC_NO_PULL=1` to skip `docker compose pul
 - **WHEN** an agent runs `install.sh --server --action=install --token=<tok> --port=<n>` headless
 - **THEN** `./.env` SHALL contain `REMBRIC_ADMIN_TOKEN=<tok>` (verbatim) and `REMBRIC_PORT=<n>`
 - **AND** no prompt SHALL be shown
+
+#### Scenario: `--help` documents the `--yes` flag
+
+- **WHEN** a user runs `install.sh --help`
+- **THEN** the usage output SHALL list `--yes` (and its `-y` alias) and describe it as the opt-in that runs the Claude/Codex marketplace commands when the binary is present
 
 ### Requirement: Hero tagline and one-time banner reveal
 


### PR DESCRIPTION
## Why

The installer prints the Claude/Codex marketplace commands but only offers to run them on a real TTY. The canonical invocation is `curl … | sh`, where stdin is the pipe → `HAVE_TTY=0` → the interactive `Run these now? [y/N]` prompt never fires. There was **no headless way** to make the installer actually execute the marketplace command; agents and `curl|sh` users were always told to run it by hand.

## What changed

- New opt-in flag **`--yes`** (alias **`-y`**) → `ARG_YES`.
- In `marketplace_cmds` (Claude/Codex), an `if/elif`: with `--yes` **and** the client binary present, run the command(s) for the action with no prompt; otherwise the existing TTY `[y/N]` path is unchanged.
- `--yes` with an **absent** binary executes nothing (nothing to update) — only prints.
- Scoped to the marketplace run-through: it does **not** start Docker (that stays gated on `--up`).
- Documented in `--help`.

Safe default: every existing invocation behaves identically. Touches no append-only / scope / topic_key / judgment invariant — pure installer orchestration. Orchestrator model preserved (still delegates to the marketplace CLIs).

### Example

```sh
curl -fsSL https://raw.githubusercontent.com/susomejias/rembric/main/install.sh \
  | sh -s -- --action=update --agent=claude,codex,opencode --yes
```

## Tests

6 new headless cases in `install.test.ts` using the existing fake-binary-on-PATH pattern (mirrors `fakeDockerDir`): `--yes` executes for claude/codex, `-y` alias, no-`--yes` only prints, absent-binary executes nothing, `--help` documents the flag. **42/42 pass**; `pnpm run lint` + `typecheck` + `sh -n` clean.

## OpenSpec

Change `add-installer-yes-flag` (archived under `openspec/changes/archive/2026-06-13-add-installer-yes-flag/`). Synced to `openspec/specs/tui-installer/spec.md`: MODIFIED *Per-client install / update / uninstall routing* and *Headless agent CLI surface* (+4 scenarios). `openspec validate --strict` passes.