### PR TITLE
feat(dashboard): surface review state on /dashboard/memories

### DIFF
--- a/apps/server/src/dashboard/memories.ts
+++ b/apps/server/src/dashboard/memories.ts
@@ -1,16 +1,26 @@
 import { Hono, type Context } from 'hono';
 
 import type { AdminListMemoriesOpts, Repositories } from '../db/repositories/index.js';
-import type { Memory } from '../db/schema/memory.js';
+import type { Memory, MemoryType } from '../db/schema/memory.js';
 import { DomainError } from '../services/errors.js';
 import type { MemoryService } from '../services/memory.js';
+import { deriveReviewState, REVIEW_TTL_MS, type ReviewState } from '../services/review.js';
 import { projectScope, SCOPE_GLOBAL } from '../services/scope.js';
 import type { SessionsService } from '../services/sessions.js';
 
 import { backLink, PAGE_SIZE, pager, urlWithPage, viewHead } from './components.js';
 import { readFormAndVerifyCsrf, csrfInput } from './csrf.js';
 import { renderPage } from './page-shell.js';
-import { escape, formatTs, html, raw, scopePill, shortId, statusPill } from './templates.js';
+import {
+  escape,
+  formatTs,
+  html,
+  raw,
+  reviewPill,
+  scopePill,
+  shortId,
+  statusPill,
+} from './templates.js';
 import type { ResolvedSession } from './types.js';
 
 export interface MemoriesDeps {
@@ -34,6 +44,8 @@ export function createMemoriesRouter(deps: MemoriesDeps): Hono {
     const projectFilter = url.searchParams.get('project') ?? '';
     const statusFilter = url.searchParams.get('status') ?? 'active';
     const typeFilter = url.searchParams.get('type') ?? '';
+    const reviewFilter = url.searchParams.get('review') ?? '';
+    const wantNeedsReview = reviewFilter === 'needs_review';
     const query = url.searchParams.get('q') ?? '';
     const page = Math.max(0, parseInt(url.searchParams.get('page') ?? '0', 10) || 0);
     const offset = page * PAGE_SIZE;
@@ -50,11 +62,25 @@ export function createMemoriesRouter(deps: MemoriesDeps): Hono {
       if (p) project = { kind: 'project', projectId: p.id };
     }
 
+    const ttlByType = Object.entries(REVIEW_TTL_MS).filter(
+      (e): e is [MemoryType, number] => typeof e[1] === 'number',
+    );
+    const nowMs = Date.now();
+
     let rows: Memory[];
     if (query) {
       rows = deps.repos.memory
         .adminSearchFts(query, PAGE_SIZE, offset)
         .filter((m) => clientSideFilter(m, projectBySlug, projectFilter, statusFilter, typeFilter));
+    } else if (wantNeedsReview) {
+      // needs_review implies active; the SQL path filters + paginates correctly.
+      rows = deps.repos.memory.adminFindNeedsReview({
+        project,
+        nowMs,
+        limit: PAGE_SIZE + 1,
+        offset,
+        ttlByType,
+      });
     } else {
       rows = deps.repos.memory.adminList({
         status: statusFilter as Memory['status'],
@@ -63,6 +89,31 @@ export function createMemoriesRouter(deps: MemoriesDeps): Hono {
         limit: PAGE_SIZE + 1,
         offset,
       });
+    }
+
+    // Derived review state per row for the badge (and to refine the FTS path
+    // when the needs_review filter is combined with a text query).
+    const reviewById = new Map<string, ReviewState | null>();
+    if (rows.length > 0) {
+      const lastConfirmed = deps.repos.memory.latestConfirmationTsByIds(rows.map((m) => m.id));
+      const at = new Date(nowMs);
+      for (const m of rows) {
+        reviewById.set(
+          m.id,
+          deriveReviewState(
+            {
+              type: m.type,
+              createdAt: m.createdAt,
+              status: m.status,
+              lastConfirmedAt: lastConfirmed.get(m.id) ?? null,
+            },
+            at,
+          ).reviewState,
+        );
+      }
+    }
+    if (wantNeedsReview && query) {
+      rows = rows.filter((m) => reviewById.get(m.id) === 'needs_review');
     }
 
     const hasMore = rows.length > PAGE_SIZE;
@@ -79,6 +130,11 @@ export function createMemoriesRouter(deps: MemoriesDeps): Hono {
           <td>${m.type}</td>
           <td><a href="/dashboard/memories/${m.id}">${truncate(m.content, 100)}</a></td>
           <td>${statusPill(m.status)}</td>
+          <td>
+            ${reviewById.get(m.id) === 'needs_review'
+              ? reviewPill()
+              : raw('<span class="muted">—</span>')}
+          </td>
           <td class="muted">${formatTs(m.createdAt)}</td>
         </tr>
       `;
@@ -103,6 +159,12 @@ export function createMemoriesRouter(deps: MemoriesDeps): Hono {
       raw(`<option value="">all types</option>`),
       ...(['user', 'feedback', 'project', 'reference'] as const).map((t) =>
         raw(`<option value="${t}"${typeFilter === t ? ' selected' : ''}>${t}</option>`),
+      ),
+    ];
+    const reviewOptions = [
+      raw(`<option value="">any review</option>`),
+      raw(
+        `<option value="needs_review"${wantNeedsReview ? ' selected' : ''}>needs_review</option>`,
       ),
     ];
 
@@ -144,6 +206,12 @@ export function createMemoriesRouter(deps: MemoriesDeps): Hono {
             ${typeOptions}
           </select>
         </span>
+        <span class="group">
+          <span class="k">REVIEW</span>
+          <select name="review">
+            ${reviewOptions}
+          </select>
+        </span>
         <span class="group search">
           <span class="k">SEARCH</span>
           <input type="search" name="q" value="${query}" placeholder="FTS5 keyword, tag, topic" />
@@ -163,13 +231,14 @@ export function createMemoriesRouter(deps: MemoriesDeps): Hono {
               <th>type</th>
               <th>content</th>
               <th>status</th>
+              <th>review</th>
               <th>created</th>
             </tr>
           </thead>
           <tbody>
             ${visible.length === 0
               ? html`<tr>
-                  <td colspan="6" class="muted">No memories match this filter.</td>
+                  <td colspan="7" class="muted">No memories match this filter.</td>
                 </tr>`
               : rowsHtml}
           </tbody>
@@ -206,6 +275,26 @@ export function createMemoriesRouter(deps: MemoriesDeps): Hono {
     const project = row.projectId ? deps.repos.projects.adminFindById(row.projectId) : null;
     const predecessors = deps.repos.memory.adminGetByIds(row.replaces);
     const confirmCount = deps.repos.memory.adminCountConfirmations(row.id);
+    const lastConfirmedAt =
+      deps.repos.memory.latestConfirmationTsByIds([row.id]).get(row.id) ?? null;
+    const { reviewState, reviewAfter } = deriveReviewState(
+      { type: row.type, createdAt: row.createdAt, status: row.status, lastConfirmedAt },
+      new Date(),
+    );
+    // Shown only for an active row whose type has a TTL (reviewAfter set).
+    const reviewCard =
+      reviewState !== null && reviewAfter !== null
+        ? html`
+            <div class="stat-card">
+              <div class="label">Review</div>
+              <div class="value">
+                ${reviewState === 'needs_review' ? reviewPill() : raw('fresh')}
+              </div>
+              <div class="label" style="margin-top:.4rem">Review after</div>
+              <div class="value" style="font-size:.9rem">${formatTs(reviewAfter)}</div>
+            </div>
+          `
+        : raw('');
 
     const archiveButton =
       row.status === 'active'
@@ -296,6 +385,7 @@ export function createMemoriesRouter(deps: MemoriesDeps): Hono {
           <div class="label">Created</div>
           <div class="value" style="font-size:.9rem">${formatTs(row.createdAt)}</div>
         </div>
+        ${reviewCard}
       </div>
 
       <h2>Content</h2>

--- a/apps/server/src/dashboard/styles/core/atoms.css
+++ b/apps/server/src/dashboard/styles/core/atoms.css
@@ -70,6 +70,13 @@
 .pill.pending::before {
   background: var(--fg-dim);
 }
+.pill.needs_review {
+  color: var(--warn);
+  border-color: color-mix(in oklab, var(--warn), transparent 70%);
+}
+.pill.needs_review::before {
+  background: var(--warn);
+}
 .pill.judged::before {
   background: var(--lime);
 }

--- a/apps/server/src/dashboard/templates.ts
+++ b/apps/server/src/dashboard/templates.ts
@@ -438,6 +438,11 @@ export function statusPill(status: string): SafeHtml {
   return raw(`<span class="pill ${cls}">${cls}</span>`);
 }
 
+/** Badge for the derived `needs_review` state; rendered only when applicable. */
+export function reviewPill(): SafeHtml {
+  return raw('<span class="pill needs_review">needs_review</span>');
+}
+
 export function scopePill(scope: string): SafeHtml {
   const cls = escape(scope);
   const label = scope === 'global' ? 'GLOBAL' : 'PROJECT';

--- a/apps/server/src/db/repositories/memory-repository.ts
+++ b/apps/server/src/db/repositories/memory-repository.ts
@@ -487,9 +487,40 @@ export class MemoryRepository {
       opts.scope === 'global'
         ? and(eq(memory.scope, 'global'), isNull(memory.projectId))
         : and(eq(memory.scope, 'project'), eq(memory.projectId, opts.projectId ?? ''));
+    return this.runNeedsReview(scopeFilter, opts.ttlByType, opts.nowMs, opts.limit, 0);
+  }
 
+  /**
+   * Unscoped sibling of `findNeedsReview` for the operator dashboard. Optional
+   * project filter mirrors `adminList`; `undefined` spans all scopes. Paginates
+   * with limit/offset so the dashboard `review=needs_review` filter is correct.
+   */
+  adminFindNeedsReview(opts: {
+    project?: AdminListMemoriesOpts['project'];
+    nowMs: number;
+    limit: number;
+    offset: number;
+    ttlByType: ReadonlyArray<readonly [MemoryType, number]>;
+  }): Memory[] {
+    if (opts.ttlByType.length === 0 || opts.limit <= 0) return [];
+    let scopeFilter: SQL | undefined;
+    if (opts.project?.kind === 'global') {
+      scopeFilter = and(eq(memory.scope, 'global'), isNull(memory.projectId));
+    } else if (opts.project?.kind === 'project') {
+      scopeFilter = and(eq(memory.scope, 'project'), eq(memory.projectId, opts.project.projectId));
+    }
+    return this.runNeedsReview(scopeFilter, opts.ttlByType, opts.nowMs, opts.limit, opts.offset);
+  }
+
+  private runNeedsReview(
+    scopeFilter: SQL | undefined,
+    ttlByType: ReadonlyArray<readonly [MemoryType, number]>,
+    nowMs: number,
+    limit: number,
+    offset: number,
+  ): Memory[] {
     const ttlCase = sql.join(
-      opts.ttlByType.map(([t, ms]) => sql`WHEN ${memory.type} = ${t} THEN ${ms}`),
+      ttlByType.map(([t, ms]) => sql`WHEN ${memory.type} = ${t} THEN ${ms}`),
       sql` `,
     );
     const ttlExpr = sql`CASE ${ttlCase} ELSE NULL END`;
@@ -503,11 +534,12 @@ export class MemoryRepository {
           eq(memory.status, 'active'),
           scopeFilter,
           sql`${ttlExpr} IS NOT NULL`,
-          sql`${baselineExpr} + ${ttlExpr} <= ${opts.nowMs}`,
+          sql`${baselineExpr} + ${ttlExpr} <= ${nowMs}`,
         ),
       )
       .orderBy(sql`${baselineExpr} ASC`)
-      .limit(opts.limit)
+      .limit(limit)
+      .offset(offset)
       .all();
   }
 

--- a/apps/server/src/scripts/seed-dev.test.ts
+++ b/apps/server/src/scripts/seed-dev.test.ts
@@ -22,7 +22,7 @@ describe('runSeed', () => {
     expect(result.counts).toEqual({
       projects: 1,
       tokens: 3,
-      memories: 31,
+      memories: 35,
       endedSessions: 3,
       activeSessions: 2,
       pendingJudgments: 1,
@@ -64,7 +64,7 @@ describe('runSeed', () => {
     expect(result.refused).toBeUndefined();
     expect(result.counts!.projects).toBe(1);
     expect(result.counts!.tokens).toBe(3);
-    expect(result.counts!.memories).toBe(31);
+    expect(result.counts!.memories).toBe(35);
     expect(result.counts!.pendingJudgments).toBe(1);
   });
 

--- a/apps/server/src/scripts/seed-dev.ts
+++ b/apps/server/src/scripts/seed-dev.ts
@@ -214,6 +214,48 @@ export function runSeed(deps: SeedDeps): SeedResult {
     }
   }
 
+  // 3b. Backdated memories so the derived `needs_review` review state is
+  // visible in the dashboard (badge + `review` filter) on a fresh seed.
+  // A MemoryService with a past clock stamps an old created_at via the
+  // normal save path (no raw UPDATE) — review is derived from that.
+  const DAY = 24 * 60 * 60 * 1000;
+  const staleSeeds: Array<{
+    type: 'project' | 'feedback' | 'user' | 'reference';
+    content: string;
+    ageDays: number;
+  }> = [
+    {
+      type: 'project',
+      content: 'Goal: ship the review-state dashboard surface this sprint.',
+      ageDays: 120,
+    },
+    {
+      type: 'feedback',
+      content: 'Prefer terse PRs; lead with the why, then the diff.',
+      ageDays: 220,
+    },
+    {
+      type: 'user',
+      content: 'Operator is a backend engineer; comfortable with SQLite internals.',
+      ageDays: 400,
+    },
+    {
+      type: 'reference',
+      content: 'Runbook: dashboards live behind Tailscale (no TTL — should stay fresh).',
+      ageDays: 400,
+    },
+  ];
+  for (const s of staleSeeds) {
+    const past = new Date(Date.now() - s.ageDays * DAY);
+    const backdated = new MemoryService(
+      createRepositories(deps.handle.db),
+      deps.handle.db,
+      () => past,
+    );
+    backdated.save({ type: s.type, content: s.content }, scope);
+    memoryCount += 1;
+  }
+
   // 4. Ended sessions with realistic summaries.
   const endedSessions = [
     {

--- a/apps/server/src/server/dashboard-router.ts
+++ b/apps/server/src/server/dashboard-router.ts
@@ -597,7 +597,10 @@ function ascBars(data: number[]): string {
   }
   const lines = data.map((v, i) => {
     const w = Math.round((v / max) * widthMax);
-    return `${labels[i]}  ${'█'.repeat(w)} ${String(v).padStart(3)}`;
+    // Pad the bar region to widthMax so every count lands in the same
+    // right-hand column — otherwise zero-days (no bar) print their value
+    // flush against the label, misaligned with barred days.
+    return `${labels[i]}  ${'█'.repeat(w).padEnd(widthMax)} ${String(v).padStart(3)}`;
   });
   return lines.join('\n');
 }

--- a/apps/server/src/test/dashboard-e2e.test.ts
+++ b/apps/server/src/test/dashboard-e2e.test.ts
@@ -701,6 +701,66 @@ describe('dashboard E2E', () => {
     expect(missing.status).toBe(404);
     expect(await missing.text()).toContain('Judgment not found');
   });
+
+  it('memories review state: needs_review badge, filter, and detail card', async () => {
+    const jar: CookieJar = { cookie: null };
+    await postForm(baseUrl, '/dashboard/login', jar, { token: ADMIN_TOKEN });
+
+    const { createDb } = await import('../db/index.js');
+    const { MemoryService } = await import('../services/memory.js');
+    const { SCOPE_GLOBAL } = await import('../services/scope.js');
+    const handle = createDb({ dataDir: server.config.dataDir });
+    const DAY = 24 * 60 * 60 * 1000;
+    // `project` TTL is 3 months → 120d-old + unaffirmed = needs_review.
+    const staleSvc = new MemoryService(
+      createRepositories(handle.db),
+      handle.db,
+      () => new Date(Date.now() - 120 * DAY),
+    );
+    const freshSvc = new MemoryService(createRepositories(handle.db), handle.db);
+    const stale = staleSvc.save(
+      { type: 'project', content: 'reviewbadge-stale-marker' },
+      SCOPE_GLOBAL,
+    );
+    const fresh = freshSvc.save(
+      { type: 'project', content: 'reviewbadge-fresh-marker' },
+      SCOPE_GLOBAL,
+    );
+    // `reference` has no TTL → never needs review even when ancient.
+    const ref = staleSvc.save(
+      { type: 'reference', content: 'reviewbadge-reference-marker' },
+      SCOPE_GLOBAL,
+    );
+    handle.close();
+
+    // Filter: only the stale project row surfaces; fresh + no-TTL are excluded.
+    const filtered = await get(baseUrl, '/dashboard/memories?review=needs_review', jar);
+    expect(filtered.status).toBe(200);
+    const fbody = await filtered.text();
+    expect(fbody).toContain('reviewbadge-stale-marker');
+    expect(fbody).toContain('pill needs_review');
+    expect(fbody).not.toContain('reviewbadge-fresh-marker');
+    expect(fbody).not.toContain('reviewbadge-reference-marker');
+
+    // The list carries a dedicated review column (separate from status).
+    const list = await get(baseUrl, '/dashboard/memories?review=needs_review', jar);
+    expect(await list.text()).toContain('<th>review</th>');
+
+    // Detail of the stale memory shows the review card; the fresh one does not
+    // render the needs_review badge.
+    const staleDetail = await get(baseUrl, `/dashboard/memories/${stale.id}`, jar);
+    const sdBody = await staleDetail.text();
+    expect(sdBody).toContain('Review');
+    expect(sdBody).toContain('pill needs_review');
+    expect(sdBody).toContain('Review after');
+
+    const freshDetail = await get(baseUrl, `/dashboard/memories/${fresh.id}`, jar);
+    expect(await freshDetail.text()).not.toContain('pill needs_review');
+
+    // No-TTL reference: detail omits the review card entirely.
+    const refDetail = await get(baseUrl, `/dashboard/memories/${ref.id}`, jar);
+    expect(await refDetail.text()).not.toContain('pill needs_review');
+  });
 });
 
 describe('dashboard E2E — self-update surface', () => {

--- a/openspec/changes/archive/2026-06-14-add-review-state-to-dashboard/design.md
+++ b/openspec/changes/archive/2026-06-14-add-review-state-to-dashboard/design.md
@@ -1,0 +1,70 @@
+## Context
+
+`add-memory-review-state` landed the `review` axis as a derived, read-time-only signal: `reviewState` (`fresh` | `needs_review`) computed from `max(created_at, last confirmation) + REVIEW_TTL_MS[type]`, exposed to agents on `memory.search` / `memory.get` and as `memory.context.needsReview`. The operator dashboard was deliberately out of that change's scope.
+
+The dashboard already renders memory `status` as a pill and supports project/type/status/search filters with HTMX (`apps/server/src/dashboard/memories.ts`, requirement "Memory browsing MUST support filters and pagination"). Adding review visibility is a natural extension of that view.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Show `needs_review` per row on `/dashboard/memories` (badge) and let the operator filter to it.
+- Show the derived `reviewState`/`reviewAfter` on the memory detail page.
+- Reuse the existing pure `deriveReviewState` so the dashboard and MCP agree by construction.
+
+**Non-Goals:**
+
+- **No new top-level page.** Review is an attribute of memories, not an entity (contrast `memory_relations` → `/dashboard/judgments`). A `/dashboard/review` page would just be the memories list with one filter pre-applied — rejected as duplication.
+- **No design-token change.** Reuse the `.pill` atom and locked palette. The `dashboard` token contract is untouched, so no token amendment.
+- **No new persisted state.** `reviewState` stays derived; this change adds only reads.
+- **No mutation from the dashboard.** Re-affirming/superseding stays an agent action over MCP; the dashboard only _surfaces_ the signal (operators already cannot `memory.confirm` from the dashboard).
+
+## Decisions
+
+### D1: Extend `/dashboard/memories`, not a new page
+
+Judgments earned a page because `memory_relations` rows have their own lifecycle (pending/judged/orphaned) and verdict actions. `reviewState` is a derived boolean-ish attribute of an existing `memory` row — the same category as `status`. It belongs as a **badge + filter** on the memories list, mirroring `status`.
+
+### D2: Badge derived per listed row; filter via a dedicated admin query
+
+Two paths with different needs:
+
+- **Badge (display):** after `adminList` returns the page of rows, batch-fetch their latest confirmation timestamps and call `deriveReviewState` per row in the handler. Cheap, no pagination interaction.
+- **Filter (`review=needs_review`):** filtering _then_ paginating must happen in SQL, or page counts drift. So the filter path uses an unscoped `adminFindNeedsReview` (the `admin*` sibling of the scoped `findNeedsReview` from `add-memory-review-state`), which already pushes the per-type TTL `CASE` + baseline predicate into SQL with `LIMIT/OFFSET`.
+
+Filtering in the handler _after_ `LIMIT` (the tempting shortcut) is rejected: it would show fewer than `limit` rows per page and break "next page".
+
+### D3: Reuse `deriveReviewState`; new reads carry the `admin*` prefix
+
+The time math has one home (`services/review.ts`). The dashboard imports the pure helper — no duplication. The two new repository reads (`adminLatestConfirmationTsByIds` if a dashboard-only name is preferred, and `adminFindNeedsReview`) carry the `admin*` prefix so the data-access-confinement invariant keeps them callable only from `src/dashboard/` + the dashboard router, and all SQL stays in `db/`.
+
+### D4: `review` filter is orthogonal to `status`
+
+`needs_review` only applies to `active` memories. Selecting `review = needs_review` therefore implies `active`; the form keeps `status` and `review` as separate controls (an operator can still browse `archived` with `review = (any)`), and the two compose. Default `review = (any)` changes nothing.
+
+## Rendering
+
+```
+/dashboard/memories — columns:  SCOPE | PROJECT | TYPE | CONTENT | STATUS | REVIEW | CREATED
+
+   project  demo  project  "ship v1 by Q2…"   [ACTIVE]   [needs_review]   2026-02-01
+   project  demo  reference "runbook…"        [ACTIVE]   —                2026-05-10
+                                                status     review column
+                                                (separate axis: needs_review only on active rows past shelf life)
+
+filter form:  [ scope ▾ ] [ status ▾ ] [ type ▾ ] [ review ▾ ] [ search ____ ]
+                                                    (any | needs_review)
+```
+
+`review` is its **own column**, not a second pill in the `status` cell — `status` is the lifecycle axis (active/superseded/archived) and `review` is the orthogonal freshness axis. Rendering them in one cell read as two competing statuses; a dedicated column makes the orthogonality legible.
+
+Detail page metadata block gains: `REVIEW: needs_review` + `REVIEW AFTER: <ts via formatTs>` (omitted when the type has no TTL or the row is not active).
+
+## Risks / Trade-offs
+
+- **Confirmation lookup on every list render:** one extra grouped query per page of rows. Bounded by page size; same shape as the existing per-page work.
+- **Badge vs filter divergence:** the badge derives in the handler while the filter derives in SQL — both must use the same TTL map and baseline. Mitigated by the SQL `CASE` being generated from `REVIEW_TTL_MS` (already the case in `findNeedsReview`) and the badge using the same helper; a test asserts a row badged `needs_review` also appears under the `needs_review` filter.
+
+## Migration / rollout
+
+None. Read-only dashboard additions; no schema change, no data change.

--- a/openspec/changes/archive/2026-06-14-add-review-state-to-dashboard/proposal.md
+++ b/openspec/changes/archive/2026-06-14-add-review-state-to-dashboard/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The derived `review` axis (`add-memory-review-state`) gives agents a `needs_review` signal over MCP, but the **operator** has no way to see it. Judgments get a dedicated `/dashboard/judgments` view because `memory_relations` is a separate entity with a lifecycle; `reviewState` is **not** an entity — it is a derived attribute of `memory` rows. Its honest home is therefore the existing `/dashboard/memories` view, not a new page: a `needs_review` badge per row plus a filter, exactly mirroring how `status` is already shown and filtered.
+
+This lets an operator answer "what is stale in this project and worth re-verifying?" for hygiene monitoring, reusing the same `deriveReviewState` helper the MCP layer already uses (single source of truth for the time math).
+
+> Depends on `add-memory-review-state` (introduces `apps/server/src/services/review.ts` and `MemoryRepository.{latestConfirmationTsByIds,findNeedsReview}`). This change adds only the dashboard surface.
+
+## What Changes
+
+- `/dashboard/memories` list: a dedicated `review` column (separate from `status`, since review is an orthogonal freshness axis, not a lifecycle value) renders a `needs_review` badge for each `active` row whose derived `reviewState = 'needs_review'`, built from the existing `.pill` atom (no new design token); other rows show a neutral placeholder.
+- `/dashboard/memories` filter form: add a `review` filter (`(any)` default · `needs_review`). When `review = needs_review`, the list SHALL show only `active` memories deriving `needs_review`, server-side, respecting the existing project filter and pagination, and preserving all other active filters across HTMX swaps.
+- `/dashboard/memories/:id` detail: surface the derived `reviewState` and `reviewAfter` (when set) in the metadata block, alongside the existing status/confirmation-count fields.
+- Derivation stays in the handler via the shared pure `deriveReviewState`; confirmation timestamps and the filtered id set come from new **`admin*`** (unscoped) repository reads — no SQL leaves `db/`.
+
+## Capabilities
+
+### New Capabilities
+
+_None._ The change extends already-defined `dashboard` requirements.
+
+### Modified Capabilities
+
+- `dashboard`: the memory-browsing requirement gains a `review` filter and a `needs_review` row badge; the memory-detail requirement gains the derived `reviewState`/`reviewAfter` fields.
+
+## Impact
+
+Affected code:
+
+- `apps/server/src/dashboard/memories.ts` — derive `reviewState` per listed row (batch confirmation lookup) for the badge; add the `review` filter to the form + the filtered query path; render `reviewState`/`reviewAfter` on the detail view.
+- `apps/server/src/db/repositories/memory-repository.ts` — `adminLatestConfirmationTsByIds` (or reuse the existing by-id, scope-agnostic `latestConfirmationTsByIds`) and `adminFindNeedsReview` (unscoped variant of `findNeedsReview`) for the filter path. `admin*` prefix = dashboard-only, grep-enforced.
+- `apps/server/src/dashboard/templates.ts` — a small `reviewPill` helper (or reuse `statusPill`'s pattern) if a dedicated badge renderer is warranted; otherwise inline via `.pill`.
+
+Affected APIs: dashboard HTML only — no MCP/HTTP contract change.
+
+Load-bearing invariants touched: **none.** Read-only dashboard additions; review state stays derived (no column, no mutation). Data-access confinement preserved (new reads carry the `admin*` prefix and live in `db/`).
+
+Design-token contract: respected — the badge reuses the existing `.pill` atom and the locked brutalist palette; **no token change**, so no `dashboard`-spec token amendment is required beyond the two behavioural requirements above.

--- a/openspec/changes/archive/2026-06-14-add-review-state-to-dashboard/specs/dashboard/spec.md
+++ b/openspec/changes/archive/2026-06-14-add-review-state-to-dashboard/specs/dashboard/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Memory browsing MUST support filters and pagination
+
+The `/dashboard/memories` view SHALL support filtering by project, type, status, **review state**, and free-text search, and SHALL paginate results. All filtering SHALL be performed server-side; the form SHALL be progressively enhanced with HTMX so it updates without a full page reload.
+
+The view SHALL render review state in a dedicated `review` column (separate from `status`, because review is an orthogonal axis — a freshness signal, not a lifecycle value): each `active` row whose derived `reviewState = 'needs_review'` (derivation per the `memory` capability) SHALL show a `needs_review` badge in that column; all other rows SHALL show a neutral placeholder. The badge SHALL use the existing `.pill` atom and the locked palette — no new design token is introduced. The filter form SHALL include a `review` control with values `(any)` (default) and `needs_review`; when `review = needs_review` the list SHALL show only `active` memories deriving `needs_review`, computed server-side with the per-type TTL pushed into SQL so pagination is correct, respecting the current project filter and preserving all active filters across HTMX swaps.
+
+#### Scenario: Filtering by status
+
+- **WHEN** the operator selects `status = 'archived'` in the filter form
+- **THEN** the resulting page SHALL show only memories with `status = 'archived'`, respecting the current project filter
+
+#### Scenario: Filtering by review state
+
+- **WHEN** the operator selects `review = needs_review` in the filter form
+- **THEN** the resulting page SHALL show only `active` memories whose derived `reviewState = 'needs_review'`, respecting the current project filter, and SHALL paginate correctly (each page honors `limit`)
+
+#### Scenario: A stale active row shows the needs_review badge
+
+- **GIVEN** an `active` memory whose derived `reviewState = 'needs_review'`
+- **WHEN** the operator views it on `/dashboard/memories` (under any filter that includes it)
+- **THEN** its row SHALL render a `needs_review` badge in the `review` column (distinct from the `status` column)
+- **AND** a `fresh`, `superseded`, `archived`, or no-TTL-type row SHALL show the neutral placeholder, not the badge
+
+#### Scenario: Badge and filter agree
+
+- **GIVEN** a row that renders the `needs_review` badge
+- **WHEN** the operator applies `review = needs_review`
+- **THEN** that row SHALL appear in the filtered result
+
+#### Scenario: Pagination
+
+- **WHEN** the operator clicks "next page"
+- **THEN** the page SHALL reload with the next `limit` rows offset, preserving all active filters (including `review`)
+
+### Requirement: Memory detail MUST display the history chain
+
+The `/dashboard/memories/:id` view SHALL display the memory's content, status, tags, scope, project, source, current confirmation count, and a visualization of the `replaces` chain showing all predecessors with their content snapshots and timestamps. For an `active` head whose type has a review TTL, the view SHALL additionally display the derived `reviewState` and `reviewAfter` (the latter rendered via the shared timestamp helper); these fields SHALL be omitted when the head is not `active` or its type has no TTL.
+
+#### Scenario: Viewing a merged memory
+
+- **WHEN** the operator opens the detail view for a merged memory M
+- **THEN** the page SHALL show M's content, M's predecessor ids and content snapshots ordered chronologically, and an "Archive" action
+
+#### Scenario: Viewing a memory that needs review
+
+- **GIVEN** an `active` memory whose derived `reviewState = 'needs_review'`
+- **WHEN** the operator opens its detail view
+- **THEN** the metadata block SHALL show `reviewState = needs_review` and the `reviewAfter` timestamp (via the shared timestamp helper)

--- a/openspec/changes/archive/2026-06-14-add-review-state-to-dashboard/tasks.md
+++ b/openspec/changes/archive/2026-06-14-add-review-state-to-dashboard/tasks.md
@@ -1,0 +1,28 @@
+## 1. Repository reads (admin, unscoped — dashboard only)
+
+- [x] 1.1 In `apps/server/src/db/repositories/memory-repository.ts`, add `adminFindNeedsReview({ project, nowMs, limit, offset, ttlByType })` — an unscoped sibling of `findNeedsReview` returning full `Memory` rows past their shelf life, with optional project filter (mirroring `adminList`'s project handling) and `LIMIT/OFFSET`. Reuse the same generated per-type TTL `CASE` + baseline predicate.
+- [x] 1.2 Confirm the existing `latestConfirmationTsByIds` (by-id, scope-agnostic) is reusable for the badge path from the dashboard; if a dashboard-only name is preferred for the grep-enforced boundary, add `adminLatestConfirmationTsByIds` delegating to it. Verify the data-access-confinement invariant (`apps/server/src/test/invariants.test.ts`) still passes.
+
+## 2. Memories list — badge + filter
+
+- [x] 2.1 In `apps/server/src/dashboard/memories.ts`, read the `review` query param (`''` default | `needs_review`). When `needs_review`, source rows from `adminFindNeedsReview` (respecting the project filter, `limit`, `offset`); otherwise keep the current `adminList` path.
+- [x] 2.2 For the rendered page of rows, batch-fetch latest confirmation timestamps and compute `reviewState` per row via the pure `deriveReviewState` (`apps/server/src/services/review.ts`). Render a `needs_review` badge next to `statusPill` for `active` rows that derive `needs_review`, using the existing `.pill` atom (no new token).
+- [x] 2.3 Add a `review` `<select>` to the filter form (`(any)` | `needs_review`), selected-state preserved, included in the HTMX-preserved query string alongside project/type/status/search and pagination.
+- [x] 2.4 Ensure pagination ("next page") preserves the `review` filter and that page sizes are correct under the filter (filtering happens in SQL, not post-`LIMIT`).
+
+## 3. Memory detail — derived fields
+
+- [x] 3.1 In the `/dashboard/memories/:id` handler, derive `reviewState`/`reviewAfter` for the active head (reuse `deriveReviewState` + confirmation lookup) and render them in the metadata block. Omit when the row is not `active` or the type has no TTL. Use `formatTs` for `reviewAfter` (never hand-write timestamps).
+
+## 4. Tests
+
+- [x] 4.1 `apps/server/src/dashboard/*.test.ts` (or the dashboard e2e): a `needs_review` active memory renders the badge; a fresh / non-active / no-TTL memory does not.
+- [x] 4.2 Filter: `?review=needs_review` returns only stale active rows, respects the project filter, and paginates correctly (page size honored; next page preserves the filter).
+- [x] 4.3 Consistency: a row that shows the badge also appears under the `needs_review` filter (badge ↔ filter agree).
+- [x] 4.4 Detail page renders `reviewState`/`reviewAfter` for a stale active memory and omits them for a non-active one.
+
+## 5. Validation
+
+- [x] 5.1 `openspec validate add-review-state-to-dashboard --strict` passes.
+- [x] 5.2 `pnpm run typecheck` and `pnpm run lint` pass.
+- [x] 5.3 `pnpm test` passes; consult the `rembric-dashboard-ui` skill for token/markup conventions before finalizing the badge.

--- a/openspec/specs/dashboard/spec.md
+++ b/openspec/specs/dashboard/spec.md
@@ -36,26 +36,52 @@ The dashboard SHALL require a valid signed session cookie to access any route ot
 
 ### Requirement: Memory browsing MUST support filters and pagination
 
-The `/dashboard/memories` view SHALL support filtering by project, type, status, and free-text search, and SHALL paginate results. All filtering SHALL be performed server-side; the form SHALL be progressively enhanced with HTMX so it updates without a full page reload.
+The `/dashboard/memories` view SHALL support filtering by project, type, status, **review state**, and free-text search, and SHALL paginate results. All filtering SHALL be performed server-side; the form SHALL be progressively enhanced with HTMX so it updates without a full page reload.
+
+The view SHALL render review state in a dedicated `review` column (separate from `status`, because review is an orthogonal axis — a freshness signal, not a lifecycle value): each `active` row whose derived `reviewState = 'needs_review'` (derivation per the `memory` capability) SHALL show a `needs_review` badge in that column; all other rows SHALL show a neutral placeholder. The badge SHALL use the existing `.pill` atom and the locked palette — no new design token is introduced. The filter form SHALL include a `review` control with values `(any)` (default) and `needs_review`; when `review = needs_review` the list SHALL show only `active` memories deriving `needs_review`, computed server-side with the per-type TTL pushed into SQL so pagination is correct, respecting the current project filter and preserving all active filters across HTMX swaps.
 
 #### Scenario: Filtering by status
 
 - **WHEN** the operator selects `status = 'archived'` in the filter form
 - **THEN** the resulting page SHALL show only memories with `status = 'archived'`, respecting the current project filter
 
+#### Scenario: Filtering by review state
+
+- **WHEN** the operator selects `review = needs_review` in the filter form
+- **THEN** the resulting page SHALL show only `active` memories whose derived `reviewState = 'needs_review'`, respecting the current project filter, and SHALL paginate correctly (each page honors `limit`)
+
+#### Scenario: A stale active row shows the needs_review badge
+
+- **GIVEN** an `active` memory whose derived `reviewState = 'needs_review'`
+- **WHEN** the operator views it on `/dashboard/memories` (under any filter that includes it)
+- **THEN** its row SHALL render a `needs_review` badge in the `review` column (distinct from the `status` column)
+- **AND** a `fresh`, `superseded`, `archived`, or no-TTL-type row SHALL show the neutral placeholder, not the badge
+
+#### Scenario: Badge and filter agree
+
+- **GIVEN** a row that renders the `needs_review` badge
+- **WHEN** the operator applies `review = needs_review`
+- **THEN** that row SHALL appear in the filtered result
+
 #### Scenario: Pagination
 
 - **WHEN** the operator clicks "next page"
-- **THEN** the page SHALL reload with the next `limit` rows offset, preserving all active filters
+- **THEN** the page SHALL reload with the next `limit` rows offset, preserving all active filters (including `review`)
 
 ### Requirement: Memory detail MUST display the history chain
 
-The `/dashboard/memories/:id` view SHALL display the memory's content, status, tags, scope, project, source, current confirmation count, and a visualization of the `replaces` chain showing all predecessors with their content snapshots and timestamps.
+The `/dashboard/memories/:id` view SHALL display the memory's content, status, tags, scope, project, source, current confirmation count, and a visualization of the `replaces` chain showing all predecessors with their content snapshots and timestamps. For an `active` head whose type has a review TTL, the view SHALL additionally display the derived `reviewState` and `reviewAfter` (the latter rendered via the shared timestamp helper); these fields SHALL be omitted when the head is not `active` or its type has no TTL.
 
 #### Scenario: Viewing a merged memory
 
 - **WHEN** the operator opens the detail view for a merged memory M
 - **THEN** the page SHALL show M's content, M's predecessor ids and content snapshots ordered chronologically, and an "Archive" action
+
+#### Scenario: Viewing a memory that needs review
+
+- **GIVEN** an `active` memory whose derived `reviewState = 'needs_review'`
+- **WHEN** the operator opens its detail view
+- **THEN** the metadata block SHALL show `reviewState = needs_review` and the `reviewAfter` timestamp (via the shared timestamp helper)
 
 ### Requirement: Consolidation runs MUST be inspectable and reversible from the dashboard
 


### PR DESCRIPTION
Re-targets the dashboard review surface at `main`. The original PR #143 was based on the `feat/memory-review-state` feature branch and got squash-merged **into that branch**, not into `main` — so this content never reached `main`. This is the same work (cherry-pick of the #143 squash) rebuilt cleanly on top of `main` (which already has the review axis via #141).

## What

- **`review` filter** (any | needs_review) on `/dashboard/memories`, server-side via `adminFindNeedsReview` (per-type TTL CASE + baseline in SQL with LIMIT/OFFSET → correct pagination).
- **Dedicated `review` column** (separate from `status`): review is an orthogonal freshness axis, not a lifecycle value. `needs_review` rows get a `.pill needs_review` badge (warn tone, existing atom); others show a placeholder.
- **Memory detail**: review card with `reviewState` + `reviewAfter` (via `formatTs`); omitted for non-active / no-TTL rows.
- **dev seed**: 4 backdated memories so the badge/filter are visible on a fresh seed (count 31 → 35).
- Reuses the shared pure `deriveReviewState`; new reads carry the `admin*` prefix (dashboard-only, SQL in `db/`).
- Also includes the small fix `align activity-chart counts in a fixed column` (zero-days no longer print flush against the label).

## Notes

- Implements OpenSpec change `add-review-state-to-dashboard` (archived; `dashboard` spec updated).
- Tests: dashboard e2e (badge, filter, detail card, no-TTL exclusion). typecheck / lint / full suite (736) green on top of `main`.
- Supersedes #143 (which is stranded on the feature branch).