### PR TITLE
feat: strengthen the memory protocol nudge (proactive save/recall/summarize) across all four clients

### DIFF
--- a/.agents/skills/rembric-plugin-development/references/per-client-gotchas.md
+++ b/.agents/skills/rembric-plugin-development/references/per-client-gotchas.md
@@ -29,7 +29,7 @@ Hard-won knowledge for each shipped client. Read the relevant section before mod
 - The MCP bridge MUST live OUTSIDE `~/.config/opencode/plugins/` because opencode auto-loads every JS/TS file in that directory as a plugin. Canonical location: `~/.config/rembric/bin/rembric-bridge.mjs`.
 - opencode does NOT support `${env.*}` substitution in `opencode.json::mcp.<name>.url`. Path-scoping via `.rembric` therefore requires the stdio bridge (which builds the URL at spawn time) — `type: "remote"` would force per-project `./opencode.json` files. The shared bridge gives Claude/Codex/opencode identical UX.
 - `session.deleted` fires ONLY on explicit user delete from the UI — NOT on session close or process quit. Treat it as in-memory cleanup, not a server-side end signal.
-- **Sub-agent filtering is mandatory v1**. Detect via `event.properties.info.parentID` (truthy) OR `info.title.endsWith(" subagent)")`. Without the filter, a single conversation spawning sub-agents inflates session count dramatically (engram observed 170 sessions per 1 real conversation; their issue #116).
+- **Sub-agent filtering is mandatory v1**. Detect via `event.properties.info.parentID` (truthy) OR `info.title.endsWith(" subagent)")`. Without the filter, a single conversation spawning sub-agents inflates session count dramatically (a single conversation has been observed producing ~170 session rows in similar memory plugins).
 - Bun's ESM resolver accepts absolute paths in `import` statements. `install.sh` sed-substitutes the dev-time relative import (`from '../bin/rembric-dotenv.mjs'`) with the absolute installed path before copying.
 
 ## All shell-hook clients (Claude + Codex)

--- a/apps/plugin/.hermes-plugin/README.md
+++ b/apps/plugin/.hermes-plugin/README.md
@@ -117,7 +117,9 @@ The provider implements three lifecycle methods that map 1:1 to Rembric's HTTP s
 - `on_pre_compress(messages)` → joins messages into a transcript, caps at 20,000 chars, `POST /api/<slug>/sessions/<id>/summary`.
 - `on_session_end(messages)` → `POST /api/<slug>/sessions/<id>/end`.
 
-The other `MemoryProvider` methods (`prefetch`, `system_prompt_block`, `sync_turn`, `on_memory_write`, `queue_prefetch`) are intentional no-ops — those operations live exclusively on the MCP surface, so the bridge (wired via `mcp_servers.rembric`) handles them when the agent calls `memory.search` / `memory.context` / `memory.save` directly.
+`system_prompt_block()` returns the unified Rembric nudge — the same SAVE/RECALL/SUMMARIZE text the server hands Claude Code / Codex CLI / opencode via the MCP `initialize.instructions` block. Hermes does not consume that MCP block and exposes no per-turn hook, so this method is its only nudging surface; the text is kept byte-identical to the server's `buildInstructions()` BASE.
+
+The remaining `MemoryProvider` methods (`prefetch`, `sync_turn`, `on_memory_write`, `queue_prefetch`) are intentional no-ops — those operations live exclusively on the MCP surface, so the bridge (wired via `mcp_servers.rembric`) handles them when the agent calls `memory.search` / `memory.context` / `memory.save` directly.
 
 ## Troubleshooting
 

--- a/apps/plugin/.hermes-plugin/__init__.py
+++ b/apps/plugin/.hermes-plugin/__init__.py
@@ -305,17 +305,31 @@ class RembricMemoryProvider(MemoryProvider):
         )
 
     def system_prompt_block(self) -> str:
-        # Permanent nudge so the model knows to write a structured summary
-        # before declaring work done, AND to recover detail after /compact
-        # via memory.context. Parity with the MCP server's
-        # initialize.instructions block served to Claude Code / Codex CLI.
-        # Hard cap: ≤300 chars (asserted by tests).
+        # Hermes does NOT consume the MCP server's initialize.instructions and
+        # exposes no per-turn hook, so this is its ONLY nudging surface. It
+        # returns the SAME unified nudge as the server's buildInstructions()
+        # BASE (the SAVE/RECALL/SUMMARIZE flows) — one version for every
+        # client. The text is duplicated across the TS/Python boundary (no
+        # cross-language sharing is possible) and MUST be kept byte-identical
+        # to instructions.ts::BASE; content tests on both sides guard drift.
+        # No cap comes from Hermes (upstream build_system_prompt joins blocks
+        # with no truncation); the ≤1000-char ceiling is our own token budget.
         return (
-            "Rembric: before declaring work done, call "
-            "memory.session_summary({title, summary}). Title ≤100 chars "
-            "describing what was actually worked on. Summary ≤2000 chars "
-            "covers Goal · Discoveries · Accomplished · Next Steps · Files. "
-            "After /compact: call memory.context if detail is missing."
+            "Rembric — persistent memory across sessions. Use these tools "
+            "proactively, not only when asked; each tool's description has the "
+            "exact mechanics.\n\n"
+            "SAVE: the moment it happens — bug fix · decision · discovery · "
+            "config change · pattern · preference — call memory.save (don't "
+            "batch to session end). Evolving a prior topic? pass topic_key to "
+            "supersede it; resolve candidates[] with memory.judge.\n"
+            "RECALL: starting/resuming work, after /compact, or asked \"what "
+            "did we do\"? Call memory.context (memory.search for keyword "
+            "lookup) if you lack prior detail.\n"
+            "SUMMARIZE: before ending any working turn, call "
+            "memory.session_summary({title≤100 (the work, not cwd), "
+            "summary≤2000}) — never end silent: Goal · Discoveries · "
+            "Accomplished · Next Steps · Files.\n"
+            "Update Rembric itself: memory.about."
         )
 
     def prefetch(self, query: str, **kwargs: Any) -> str:

--- a/apps/plugin/.hermes-plugin/tests/test_system_prompt_block.py
+++ b/apps/plugin/.hermes-plugin/tests/test_system_prompt_block.py
@@ -1,8 +1,11 @@
-"""``system_prompt_block`` carries the documented nudge content.
+"""``system_prompt_block`` carries the unified nudge content.
 
-Asserts both the session-close protocol (memory.session_summary + title +
-Goal/Discoveries/Accomplished/Next Steps/Files structure) AND the
-post-compact recovery clause (memory.context). Hard cap: ≤300 chars.
+This block is the SAME text as the server's `buildInstructions()` BASE
+(the SAVE/RECALL/SUMMARIZE flows) — one version for every client. Asserts
+the proactive session-close protocol (memory.session_summary, bound to
+ending a working turn — NOT the literal "done"), the recall/post-compact
+clause (memory.context), and the SAVE flow. Self-imposed cap: ≤1000 chars
+(Hermes itself applies no truncation; the ceiling is token-budget hygiene).
 """
 
 from __future__ import annotations
@@ -32,10 +35,24 @@ class SystemPromptBlockTest(unittest.TestCase):
         block = provider.system_prompt_block()
         self.assertIn("memory.context", block)
 
-    def test_block_is_within_300_char_cap(self) -> None:
+    def test_includes_proactive_save_flow(self) -> None:
         provider = self.mod.RembricMemoryProvider()
         block = provider.system_prompt_block()
-        self.assertLessEqual(len(block), 300, msg=f"block is {len(block)} chars; cap is 300")
+        self.assertIn("memory.save", block)
+
+    def test_session_summary_trigger_is_not_bound_to_the_word_done(self) -> None:
+        provider = self.mod.RembricMemoryProvider()
+        block = provider.system_prompt_block()
+        self.assertIn("before ending any working turn", block)
+        self.assertNotIn('before declaring work done', block)
+
+    def test_block_is_within_1000_char_cap(self) -> None:
+        # Self-imposed token budget — Hermes itself applies no truncation
+        # (upstream build_system_prompt joins blocks verbatim). Mirrors the
+        # server's INSTRUCTIONS_MAX_LENGTH so the two surfaces stay in lock-step.
+        provider = self.mod.RembricMemoryProvider()
+        block = provider.system_prompt_block()
+        self.assertLessEqual(len(block), 1000, msg=f"block is {len(block)} chars; cap is 1000")
 
 
 if __name__ == "__main__":

--- a/apps/server/src/mcp/instructions.test.ts
+++ b/apps/server/src/mcp/instructions.test.ts
@@ -5,12 +5,12 @@ import { SUMMARY_MAX_CHARS } from '../services/agent-sessions.js';
 import { buildInstructions, INSTRUCTIONS_MAX_LENGTH } from './instructions.js';
 
 describe('MCP initialize instructions', () => {
-  it('emits ≤ 800 characters for the unscoped variant', () => {
+  it('emits ≤ 1000 characters for the unscoped variant', () => {
     const text = buildInstructions({ requestedSlug: null });
     expect(text.length).toBeLessThanOrEqual(INSTRUCTIONS_MAX_LENGTH);
   });
 
-  it('emits ≤ 800 characters for the path-scoped variant', () => {
+  it('emits ≤ 1000 characters for the path-scoped variant', () => {
     const text = buildInstructions({ requestedSlug: 'rembric' });
     expect(text.length).toBeLessThanOrEqual(INSTRUCTIONS_MAX_LENGTH);
   });
@@ -87,8 +87,19 @@ describe('MCP initialize instructions', () => {
       buildInstructions({ requestedSlug: 'rembric' }),
     ];
     for (const text of variants) {
-      expect(text).toContain('before ending any turn with real work');
+      expect(text).toContain('before ending any working turn');
       expect(text).not.toContain('before saying "done"');
+    }
+  });
+
+  it('keeps recall on-demand rather than unconditional at session start', () => {
+    const variants = [
+      buildInstructions({ requestedSlug: null }),
+      buildInstructions({ requestedSlug: 'rembric' }),
+    ];
+    for (const text of variants) {
+      expect(text).toContain('memory.context');
+      expect(text).toContain('if you lack prior detail');
     }
   });
 

--- a/apps/server/src/mcp/instructions.ts
+++ b/apps/server/src/mcp/instructions.ts
@@ -1,13 +1,15 @@
 /**
  * Build the MCP `initialize.instructions` block.
  *
- * Supported clients (Claude Code, Codex CLI) inject this string directly
- * into the LLM's system prompt. Hard constraint: ≤ 800 characters per
- * variant — verified by a unit test. Anything longer is either bug or
- * documentation creep.
+ * All four clients (Claude Code, Codex CLI, Hermes Agent, opencode) inject
+ * this string into the LLM's system prompt on connect; for in-process
+ * clients with no per-turn hook it is the ONLY nudging surface. The block
+ * is a directive crib-sheet of three proactive flows (SAVE / RECALL /
+ * SUMMARIZE) that cite their tools; precise mechanics live in each tool's
+ * own `description`.
  *
  * Two variants per scope (project-scoped vs unscoped). The body is the
- * same crib-sheet protocol; only the trailing scope note diverges.
+ * same protocol; only the trailing scope note diverges.
  */
 
 import { SUMMARY_MAX_CHARS } from '../services/agent-sessions.js';
@@ -17,22 +19,27 @@ export interface InstructionsContext {
   requestedSlug: string | null;
 }
 
-const BASE = `Rembric memory.
+const BASE = `Rembric — persistent memory across sessions. Use these tools proactively, not only when asked; each tool's description has the exact mechanics.
 
-Call memory.save after: bug fix · decision · discovery · config change · pattern · preference. Evolving topic? pass topic_key (memory.suggest_topic_key) to supersede the prior row. Close save candidates[] with memory.judge.
-Call memory.search for past work or "what did we do".
-Call memory.session_summary({title, summary≤${SUMMARY_MAX_CHARS} chars}) before ending any turn with real work: title ≤100 chars (real work, not cwd); summary: Goal · Discoveries · Accomplished · Next Steps · Files.
-After /compact: call memory.context if detail is missing.
-To update Rembric: call memory.about.`;
+SAVE: the moment it happens — bug fix · decision · discovery · config change · pattern · preference — call memory.save (don't batch to session end). Evolving a prior topic? pass topic_key to supersede it; resolve candidates[] with memory.judge.
+RECALL: starting/resuming work, after /compact, or asked "what did we do"? Call memory.context (memory.search for keyword lookup) if you lack prior detail.
+SUMMARIZE: before ending any working turn, call memory.session_summary({title≤100 (the work, not cwd), summary≤${SUMMARY_MAX_CHARS}}) — never end silent: Goal · Discoveries · Accomplished · Next Steps · Files.
+Update Rembric itself: memory.about.`;
 
 const PATH_SCOPED_NOTE = (slug: string) =>
   `\n\nThis connection is path-scoped to '${slug}'. scope='global' is rejected; open /mcp for user-wide memory.`;
 
-const UNSCOPED_NOTE = `\n\nProject scope: auto-detected from your client's MCP roots when supported. Otherwise call project.use({slug, create:true}) to pin (and create on first use). project.current reports the active project.`;
+const UNSCOPED_NOTE = `\n\nProject scope: auto-detected from your client's MCP roots when supported. Otherwise call project.use({slug, autocreate:true}) to pin (and create on first use). project.current reports the active project.`;
 
 export function buildInstructions(ctx: InstructionsContext): string {
   return ctx.requestedSlug ? BASE + PATH_SCOPED_NOTE(ctx.requestedSlug) : BASE + UNSCOPED_NOTE;
 }
 
-/** Hard limit; CI test enforces. */
-export const INSTRUCTIONS_MAX_LENGTH = 800;
+/**
+ * Self-imposed token budget, NOT a client or protocol limit: the MCP spec
+ * defines `InitializeResult.instructions` as a free-form string with no max
+ * length, and none of the four clients truncates it. The cap exists only to
+ * keep the system-prompt cost bounded and guard against doc-creep. CI test
+ * (`instructions.test.ts`) enforces it against both variants.
+ */
+export const INSTRUCTIONS_MAX_LENGTH = 1000;

--- a/apps/server/src/mcp/server.ts
+++ b/apps/server/src/mcp/server.ts
@@ -151,7 +151,7 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
     'memory.session_start',
     {
       description:
-        'Start an agent session. Call this once when the user begins a task you intend to wrap with memory.session_summary. Args: { agent?, description?, project? (slug, overrides roots) }. Returns: { sessionId, scope, projectId, startedAt }.',
+        'Start an agent session. In normal operation you do NOT need to call this — the host registers the session automatically (Claude Code/Codex hooks and the Hermes/opencode providers POST to the sessions endpoint on startup). Call it only when running without that host wiring and you need an explicit session to wrap with memory.session_summary. Args: { agent?, description?, project? (slug, overrides roots) }. Returns: { sessionId, scope, projectId, startedAt }.',
       inputSchema: sessionStartSchema,
     },
     sessions.sessionStart,
@@ -169,7 +169,7 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
     'memory.session_summary',
     {
       description:
-        'Save the end-of-session summary AND a short title. Call this BEFORE saying "done"/"listo". Args: { summary (<=2000 chars, server rejects longer with invalid_input — keep it tight), title? (<=100 chars, descriptive of work done) }. Body: Goal · Instructions · Discoveries · Accomplished · Next Steps · Relevant Files. Does NOT end the session — use memory.session_end for that.',
+        'Save the end-of-session summary AND a short title. Call this at the END OF EVERY TURN that did real work — never end a working turn silent; do NOT wait for the literal word "done"/"listo". Args: { summary (<=2000 chars, server rejects longer with invalid_input — keep it tight), title? (<=100 chars, descriptive of work done, NOT the cwd) }. Body: Goal · Instructions · Discoveries · Accomplished · Next Steps · Relevant Files. Does NOT end the session — use memory.session_end for that.',
       inputSchema: sessionSummarySchema,
     },
     sessions.sessionSummary,
@@ -178,7 +178,7 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
     'memory.context',
     {
       description:
-        'Get recent context for this scope: recentSessions (with summaries), recentMemories (sorted by last_seen_at), pendingJudgments (aged unresolved relation pairs to close with memory.judge), and needsReview (active memories past their re-verification shelf life — re-affirm with memory.confirm, supersede with memory.save+topic_key, or judge if they contradict another memory). Call this when starting work on something that might have been touched before. Default sizes are small; the response includes a `clamped:true` flag if you asked for too much.',
+        'Get recent context for this scope: recentSessions (with summaries), recentMemories (sorted by last_seen_at), pendingJudgments (aged unresolved relation pairs to close with memory.judge), and needsReview (active memories past their re-verification shelf life — re-affirm with memory.confirm, supersede with memory.save+topic_key, or judge if they contradict another memory). Call this when starting or resuming work that may have prior context, after a /compact event, or when asked "what did we do" — before acting, but only if you lack the prior detail you need (do not load it speculatively on every session start). Default sizes are small; the response includes a `clamped:true` flag if you asked for too much.',
       inputSchema: contextSchema,
     },
     sessions.context,
@@ -205,7 +205,7 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
     'memory.capture_passive',
     {
       description:
-        'Extract numbered/bulleted items from a `## Key Learnings:` section in the given text and save each as a separate memory (type=reference). No-op when no learnings block is found.',
+        'Bulk-save learnings: extract numbered/bulleted items from a `## Key Learnings:` section in the given text and save each as a separate memory (type=reference). No-op when no learnings block is found. Call this when you have produced (or the user supplied) a Key Learnings list worth persisting — e.g. when wrapping up a task — instead of issuing many individual memory.save calls.',
       inputSchema: capturePassiveSchema,
     },
     sessions.capturePassive,

--- a/apps/server/src/test/mcp-integration.test.ts
+++ b/apps/server/src/test/mcp-integration.test.ts
@@ -117,14 +117,14 @@ describe('MCP protocol conformance', () => {
     const globalInstructions = globalClient.getInstructions();
     expect(globalInstructions).toMatch(/project\.use/);
     expect(globalInstructions).not.toContain('X-Rembric-Project');
-    expect((globalInstructions ?? '').length).toBeLessThanOrEqual(800);
+    expect((globalInstructions ?? '').length).toBeLessThanOrEqual(1000);
     await globalClient.close();
 
     // Path-scoped /mcp/<slug> connection — instructions name the slug.
     const projClient = await connect({ projectSlug: 'integration-proj' });
     const projInstructions = projClient.getInstructions();
     expect(projInstructions).toContain("'integration-proj'");
-    expect((projInstructions ?? '').length).toBeLessThanOrEqual(800);
+    expect((projInstructions ?? '').length).toBeLessThanOrEqual(1000);
     await projClient.close();
   });
 

--- a/openspec/changes/archive/2026-06-14-strengthen-memory-protocol-instructions/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-14-strengthen-memory-protocol-instructions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-14

--- a/openspec/changes/archive/2026-06-14-strengthen-memory-protocol-instructions/design.md
+++ b/openspec/changes/archive/2026-06-14-strengthen-memory-protocol-instructions/design.md
@@ -1,0 +1,82 @@
+## Context
+
+`initialize.instructions` is the only protocol-teaching surface served to all four clients (Claude Code, Codex CLI, Hermes Agent, opencode) on MCP connect — Claude/Codex via hook stdout and the in-process providers via the MCP block itself. Hermes has no per-turn hook, so the MCP block is its _only_ nudging lever. Today the block is terse and binds `memory.session_summary` to the literal word "done"; in practice the agent under-fires save, recall, and summary.
+
+Crucially, the nudge does NOT reach all four clients through one surface. Claude Code, Codex CLI, and opencode consume the MCP `initialize.instructions` block. **Hermes does not** — it injects its own in-process `system_prompt_block()` (a `MemoryProvider` method), a hardcoded string parallel to (and historically drifting from) `initialize.instructions`. Any cross-client nudge change must update BOTH surfaces.
+
+Two delivery surfaces exist for "when to call a tool":
+
+- **`initialize.instructions`** — injected into the system prompt preamble; primes awareness + proactivity; one shared block under a self-imposed character cap.
+- **Each tool's `description`** — read at tool-selection time; no shared budget; the precise "call me when X" home.
+
+The cap (`INSTRUCTIONS_MAX_LENGTH = 800`) is self-imposed. The MCP spec (`InitializeResult.instructions`, 2025-06-18) defines the field as an optional free-form string with **no** maximum length, size limit, or truncation rule, and no consuming client among the four enforces one.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the agent proactively `memory.save` (the moment something noteworthy happens), `memory.context`/`memory.search` (on continuation/recall), and `memory.session_summary` (every working turn).
+- Spend tokens only with reason: recall stays on-demand — no speculative `memory.context` payload loaded at session start.
+- Cover all four clients through the single shared block; no per-client divergence.
+
+**Non-Goals:**
+
+- No hook/script changes, no new HTTP endpoint, no per-prompt network reads.
+- No forced/unconditional `memory.context` load at session start (the speculative-payload "phantom cost" path).
+- No change to any load-bearing invariant.
+- No separate, abbreviated Hermes nudge: both surfaces carry ONE unified text (see D7).
+
+## Decisions
+
+**D1 — Guidance lives in BOTH the instructions preamble and the tool descriptions (belt-and-suspenders).**
+The preamble primes the _self-initiated_ behaviors the agent skips (save, summarize) and frames proactive use; the descriptions carry the precise per-tool triggers read at the decision point. A small amount of duplication between the two _aids_ instruction-following and is accepted deliberately.
+
+- _Alternative — preamble only:_ rejected; the system-prompt block is low-salience for the moment-of decision, which is exactly why the current block under-fires.
+- _Alternative — descriptions only (slim the preamble to a pointer):_ considered and drafted (fit in 601 chars, no cap bump). Rejected in favor of the fuller block because the operator prioritized adherence over token frugality and the descriptions are only read once the model already considers a tool — the preamble is what makes it consider memory at all.
+
+**D2 — Raise `INSTRUCTIONS_MAX_LENGTH` 800 → 1000.**
+Justified because the block is now the primary mechanism and the directive labeled flows need the room (path-scoped 858, unscoped 956). A clarifying comment records that the cap is a self-imposed token budget, not a client/protocol limit, so a future reader does not mistake it for a hard constraint.
+
+- _Alternative — keep 800 and compress:_ the directive three-flow version does not fit 800 in the unscoped variant (the longer scope note leaves ~9 chars). Compressing to fit would sacrifice the clarity that is the whole point.
+- _Alternative — 900:_ sufficient for an earlier draft, but 1000 leaves headroom (≥44 chars) so a minor future wording tweak does not breach the test.
+
+**D3 — Labeled flows SAVE / RECALL / SUMMARIZE.**
+Explicit labels make the three actions scannable as discrete behaviors rather than prose, which reads as higher-priority instruction. Mechanical detail (`scope_locked` codes, `topic_key` semantics, candidate/judge wiring) stays in the descriptions, keeping the preamble behavioral.
+
+**D4 — RECALL is on-demand, never blind-at-start.**
+The continuation trigger fires "before acting, if you lack prior detail" — the expensive `memory.context` payload (~2–4k tokens) loads only when the task is actually a continuation, never speculatively at session start (where the agent cannot yet know the task relates to prior work). This is the resolution of the phantom-token-cost concern.
+
+**D5 — `memory.session_summary` description retriggered off "done".**
+The current "Call this BEFORE saying done/listo" lets the agent evade the summary by simply not saying "done". The new phrasing binds it to "the end of every turn that did real work — never end a working turn silent", aligning the description with the (already-spec'd) intent in `mcp-api` that the trigger must not bind solely to the literal "done".
+
+**D6 — `memory.save` description unchanged.**
+It already reads "Call this IMMEDIATELY after: bug fix · …" — already proactive; touching it would be churn.
+
+**D7 — Hermes's `system_prompt_block()` returns the SAME unified nudge as the server BASE; its cap is raised 300 → 1000 to match.**
+Hermes does not consume `initialize.instructions`, so the server-side rewrite alone would leave Hermes on the old "before declaring work done" phrasing — drift, and the exact "done"-bound trigger we're removing. Since the 300-char cap was verified self-imposed (upstream `agent/memory_manager.py::build_system_prompt` joins provider blocks with NO truncation/length/token cap — it only filters empties and joins), there is no reason to maintain a separate, abbreviated Hermes string. We instead return the byte-identical server `BASE` (the SAVE/RECALL/SUMMARIZE flows, 776 chars) and raise the Hermes cap to 1000 to match `INSTRUCTIONS_MAX_LENGTH`. One canonical nudge for every client.
+
+- _Alternative — keep a separate ≤300 abbreviated Hermes block:_ rejected by the operator — since 300 was our own limit (not a Hermes constraint), maintaining two divergent texts is needless surface for drift. The BASE fits comfortably (776/1000) and Hermes injects it verbatim.
+- _Alternative — truly share one string across TS and Python:_ impossible without a build/codegen or runtime-fetch step (server TS constant vs in-process Python shipped to the client). Rejected as over-engineering; the repo already accepts deliberate cross-language duplication (`parseDotenv`/`SLUG_RE` per CLAUDE.md). We keep the two copies byte-identical and guard drift with content tests on both sides.
+- _Alternative — leave Hermes untouched and ship server-only:_ rejected; it ships a known inconsistency (Hermes keeps the weak "done" trigger) and would force the proposal/design to disclaim Hermes coverage.
+
+**D8 — Fold in two tool-review findings (correctness + description polish).**
+Reviewing all 22 tool descriptions while in this surface surfaced: (a) a real bug — four sites instruct the agent to pass `project.use({create:true})`, but the schema parameter is `autocreate`, so the flag is silently ignored and the project is never created; (b) two descriptions (`memory.capture_passive`, `memory.session_start`) with no clear "when to call" trigger. Both are folded in because they share the same surface and theme (teaching the agent to call the right tool the right way) and the fixes are small.
+
+- The `create→autocreate` runtime fix lands in `instructions.ts` (in scope). The three spec occurrences are corrected as **non-normative accuracy de-drift** via direct edit (the parameter was always `autocreate`; no behavior changes), rather than spinning up delta specs for `claude-code-plugin`/`sessions` for what is a typo-class correction — same treatment as a prior de-brand edit.
+- _Alternative — separate changes for the bug and the polish:_ rejected by the operator; one coherent "tool clarity" pass is cheaper to review than three fragments.
+
+## Risks / Trade-offs
+
+- **[Trade-off] Duplication between preamble and descriptions** → Accepted because redundancy across the priming surface (system prompt) and the decision surface (tool description) measurably helps instruction-following, which the operator explicitly prioritized over token economy here.
+- **[Trade-off] Larger instructions block costs ~150 more tokens per connect, every client, every session** → Accepted: the operator opted into 900–1000 provided it improves quality; recall staying on-demand means the _expensive_ payload cost is unchanged (zero speculative loads).
+- **[Risk] Low salience — instructions are still ambient text the agent may ignore** → Mitigation: this is the cheapest, reversible first intervention; the strengthened descriptions reinforce at the decision point. If telemetry later shows it is insufficient, escalate to higher-salience hook nudges (deliberately deferred, not built now).
+- **[Risk] Two surfaces drift apart again** (the original defect: `initialize.instructions` was improved while Hermes's `system_prompt_block` kept the old "done" phrasing) → Mitigation: both are updated in this change, both are covered by content tests (`instructions.test.ts` + `tests/test_system_prompt_block.py`) that assert the proactive, non-"done" phrasing, so a future regression on either surface fails CI. The two strings can't be DRY-shared (one is server-side TS, the other in-process Python shipped to the client), so test parity is the guard.
+- **[Risk] Cap bump invites future doc-creep back toward an over-long block** → Mitigation: the comment frames 1000 as a budget ceiling, and `instructions.test.ts` keeps both variants gated at ≤1000.
+
+## Migration Plan
+
+Two coordinated string changes plus test updates, on two release tracks: the `initialize.instructions` rewrite ships on the `server` track (Docker image rebuild); the Hermes `system_prompt_block()` rewrite ships on the unified `plugin` track. Rollback = revert the commit; no data, schema, or wire-format implications. No client coordination needed — MCP clients pick up the new instructions on their next connect, and Hermes picks up the new block on its next plugin load.
+
+## Open Questions
+
+(none)

--- a/openspec/changes/archive/2026-06-14-strengthen-memory-protocol-instructions/proposal.md
+++ b/openspec/changes/archive/2026-06-14-strengthen-memory-protocol-instructions/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Across many real sessions the agent ends without saving anything, never loads prior context on a continuation, and skips the end-of-session summary — even though `initialize.instructions` already names the tools. The current block is terse, low-salience, and binds `memory.session_summary` to the literal word "done" (trivially evaded). We want the protocol-teaching surface to drive proactive `memory.save` / `memory.context` / `memory.session_summary` behavior **without** spending tokens pointlessly (recall stays on-demand — no speculative `memory.context` payload at session start).
+
+## What Changes
+
+- **Rewrite `initialize.instructions`** (`apps/server/src/mcp/instructions.ts`) into a directive preamble with three labeled proactive flows — **SAVE** (the moment something noteworthy happens, don't batch to session end), **RECALL** (starting/resuming work, after `/compact`, or "what did we do" — on-demand, only if detail is missing), **SUMMARIZE** (close every working turn, never end silent) — each citing its tool(s): `memory.save`, `memory.context`/`memory.search`, `memory.session_summary`, plus the `memory.about` update pointer. Both variants validated: path-scoped 858, unscoped 956.
+- **Raise `INSTRUCTIONS_MAX_LENGTH` 800 → 1000** with a comment recording that the cap is a self-imposed token budget, NOT a client/protocol limit (the MCP spec defines no max length for `InitializeResult.instructions`).
+- **Strengthen two tool descriptions** (`apps/server/src/mcp/server.ts`): `memory.session_summary` moves from the weak "Call this BEFORE saying done/listo" trigger to "at the end of every turn that did real work — never end a working turn silent"; `memory.context` adds the continuation triggers (starting/resuming work, after `/compact`, "what did we do", load on-demand if detail is missing). `memory.save` is already proactive ("Call this IMMEDIATELY after…") and is left unchanged.
+- **Update `instructions.test.ts`** to assert the new 1000-char cap and the new/required content substrings.
+- **Unify Hermes onto the same nudge text.** Hermes does NOT consume `initialize.instructions`; it injects its own `system_prompt_block()` (`apps/plugin/.hermes-plugin/__init__.py`), a hardcoded string still carrying the old "before declaring work done" phrasing. Rewrite it to return the **byte-identical server `BASE`** (the same SAVE/RECALL/SUMMARIZE flows, 776 chars) and **raise Hermes's self-imposed cap 300 → 1000** to match `INSTRUCTIONS_MAX_LENGTH` — one unified nudge for every client. The 300 was confirmed self-imposed, NOT a Hermes contract: upstream `agent/memory_manager.py::build_system_prompt` joins provider blocks with no truncation/length/token cap, so the full text is injected verbatim.
+
+**Surface coverage (corrected):** Claude Code, Codex CLI, and opencode receive the nudge via the shared MCP `initialize.instructions` block; Hermes receives the same text via its own in-process `system_prompt_block()`. Both surfaces carry ONE unified version under the same 1000-char self-imposed budget. The two copies are byte-identical but physically separate (server TS constant vs in-process Python — no cross-language sharing is possible); content tests on both sides guard against drift.
+
+- **Fix the `create:true` → `autocreate:true` bug** (a tool-review finding). The real `project.use` parameter is `autocreate` (schema + handler + the `tools.ts` error message); four sites told the agent to pass the non-existent `create:true`, silently ignored → the project would NOT be created. Corrected at the runtime surface (`instructions.ts` `UNSCOPED_NOTE`) and three non-normative spec example/scenario lines (`claude-code-plugin/spec.md` ×2, `sessions/spec.md` ×1). The `claude-code-plugin` mid-session-switch example also had the wrong mechanism (switching is `confirmSwitch:true`, not create) and is corrected.
+- **Sharpen two tool descriptions lacking a "when to call" trigger** (tool-review polish): `memory.capture_passive` gains an explicit trigger (wrap-up / Key Learnings list, instead of many `memory.save` calls); `memory.session_start` is clarified to note the host registers the session automatically, so the agent normally should not call it.
+
+No load-bearing invariant is touched (append-only, scope-at-service, `topic_key`, judgment freshness all unaffected).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `mcp-api`: the `initialize.instructions` requirement changes — the character cap moves 800 → 1000; the content requirements are restated to mandate the three labeled proactive flows (SAVE/RECALL/SUMMARIZE), the proactive (non-"done"-bound) session-summary trigger, the continuation/recall + post-compact `memory.context` trigger, and the `memory.about` pointer, all fitting within the new 1000-char cap in both variants.
+- `plugin-session-protocol`: the protocol-nudge requirement is updated to reference the 1000-char cap (was 800) and the proactive, non-"done"-bound `memory.session_summary` phrasing.
+- `hermes-agent-plugin`: the `Provider lifecycle method behavior` requirement is updated so `system_prompt_block` returns the unified nudge (byte-identical to the server `initialize.instructions` BASE — the proactive SAVE/RECALL/SUMMARIZE flows, non-"done"-bound), and its cap is raised 300 → 1000 to match `INSTRUCTIONS_MAX_LENGTH` — now documented as a self-imposed budget (verified against upstream `build_system_prompt`), not a Hermes contract.
+
+## Impact
+
+- `apps/server/src/mcp/instructions.ts` — rewrite `BASE`; raise `INSTRUCTIONS_MAX_LENGTH` to 1000 + clarifying comment.
+- `apps/server/src/mcp/server.ts` — strengthen `memory.session_summary` and `memory.context` tool descriptions.
+- `apps/server/src/mcp/instructions.test.ts` — new cap (1000) + content-substring assertions.
+- `apps/plugin/.hermes-plugin/__init__.py` — `system_prompt_block()` returns the unified BASE text (776 chars, ≤1000), byte-identical to the server.
+- `apps/plugin/.hermes-plugin/tests/test_system_prompt_block.py` — cap 300 → 1000 + proactive/non-"done" content assertions.
+- `apps/plugin/.hermes-plugin/README.md` — corrected the (stale) "system_prompt_block is a no-op" line.
+- `apps/server/src/mcp/server.ts` — also: `create:true`→`autocreate:true` (none here; runtime fix is in `instructions.ts`); sharpened `memory.capture_passive` + `memory.session_start` descriptions.
+- `apps/server/src/mcp/instructions.ts` — `UNSCOPED_NOTE`: `create:true` → `autocreate:true`.
+- `openspec/specs/claude-code-plugin/spec.md`, `openspec/specs/sessions/spec.md` — non-normative accuracy de-drift: `create:true` → `autocreate:true` (and the mid-session-switch example corrected to `confirmSwitch:true`). No behavior change; edited directly (no delta spec), like a typo fix.
+- `openspec/specs/mcp-api/spec.md` — modified instructions requirement + scenarios (800 → 1000).
+- `openspec/specs/plugin-session-protocol/spec.md` — modified nudge requirement (cap 800 → 1000, proactive phrasing).
+- `openspec/specs/hermes-agent-plugin/spec.md` — modified `system_prompt_block` requirement (unified text, cap 300 → 1000, reframed as self-imposed).
+- No runtime behavior beyond the string content; no DB, no migration, no HTTP endpoint. Because it now touches `apps/plugin/`, the change ships on the unified `plugin` release track (not server-only); the server-side string change ships on the `server` track and rebuilds the Docker image as usual.

--- a/openspec/changes/archive/2026-06-14-strengthen-memory-protocol-instructions/specs/hermes-agent-plugin/spec.md
+++ b/openspec/changes/archive/2026-06-14-strengthen-memory-protocol-instructions/specs/hermes-agent-plugin/spec.md
@@ -1,0 +1,78 @@
+## MODIFIED Requirements
+
+### Requirement: Provider lifecycle method behavior
+
+`RembricMemoryProvider` SHALL implement the `MemoryProvider` ABC with these behaviors:
+
+- `name` returns `"rembric"`.
+- `is_available` performs `GET ${REMBRIC_SERVER_URL}/healthz` with `Authorization: Bearer ${REMBRIC_API_TOKEN}` and a 2-second timeout, returning `True` only on HTTP 200. It SHALL return `False` if `REMBRIC_SERVER_URL` or `REMBRIC_API_TOKEN` are unset, or if the request fails for any reason (including HTTP 401 when the token is invalid and HTTP 503 when the server's database is unavailable).
+- `initialize(session_id, **kwargs)` SHALL:
+  - Resolve the project slug via the cascade defined in "Slug resolution cascade".
+  - When a valid slug is resolved, `POST ${REMBRIC_SERVER_URL}/api/<slug>/sessions` with `Authorization: Bearer ${REMBRIC_API_TOKEN}`, `Content-Type: application/json`, and body `{"id": session_id, "cwd": kwargs.get("cwd", os.getcwd()), "agent": "hermes"}`. Timeout 3 seconds. Discard response body. The server writes the placeholder title.
+  - When no slug is resolvable, skip the POST and log a single-line stderr diagnostic of the form `[rembric] no project slug for session <session_id>; skipping session POST`. The provider SHALL still register; subsequent lifecycle calls SHALL silently skip their HTTP work.
+  - Cache the resolved slug, session id, and cwd on the provider instance; subsequent lifecycle calls within the same session SHALL NOT re-resolve.
+- `on_pre_compress(messages, **kwargs)` SHALL, if a slug and session id were cached at `initialize`, build a textual transcript from `messages` via `_format_transcript(messages)` (oldest-first `role: content` lines, truncated from the head if the result exceeds 19,500 characters), and `POST /api/<slug>/sessions/<session_id>/summary` with body `{"summary": <transcript>, "final": false}`. The provider SHALL NOT include `title` in this POST — title derivation is reserved for `on_session_end` and the server-side placeholder. Timeout 3 seconds. Failures are silent stderr diagnostics. The provider SHALL NOT mutate the `messages` argument. The provider's return value SHALL be `""` (empty string — the docstring promises it goes into the compressor prompt; we contribute nothing yet).
+- `on_session_end(messages, **kwargs)` SHALL, if a slug and session id were cached, build a transcript via `_format_transcript(messages)`, derive a title from the first non-empty assistant message in `messages` (truncated to 100 chars; falling back to empty string if no assistant message exists), and `POST /api/<slug>/sessions/<session_id>/end` with body `{"summary": <transcript>, "title": <derived_title>, "final": false}`. When the transcript is empty (no messages), the body SHALL be `{}` (degraded end). Timeout 3 seconds. Failures are silent stderr diagnostics. The provider SHALL NOT call `memory.session_end` over MCP.
+- `on_session_switch(new_session_id, *, parent_session_id="", reset=False, **kwargs)` SHALL override per the "Provider MUST override on_session_switch" requirement.
+- `get_tool_schemas` SHALL return `[]`. The provider contributes no agent-callable tools.
+- `handle_tool_call(name, args)` SHALL return `json.dumps({"error": "unknown_tool", "hint": "register the rembric MCP bridge in mcp_servers.rembric to access memory tools"})`.
+- `system_prompt_block` SHALL return the unified Rembric nudge — the SAME text as the server's `initialize.instructions` BASE (the SAVE/RECALL/SUMMARIZE flows defined by the `mcp-api` capability), kept byte-identical across the TS/Python boundary. It SHALL therefore direct the agent to SAVE proactively (`memory.save` the moment something noteworthy happens, with the `topic_key` supersede and `candidates[]`→`memory.judge` paths), RECALL on-demand (`memory.context`/`memory.search` when starting/resuming work, after `/compact`, or asked "what did we do", only if prior detail is missing), and SUMMARIZE at the end of every working turn (`memory.session_summary({title, summary})`, never ending a working turn silent — the trigger SHALL NOT be bound to the literal word "done"; title ≤100 chars, NOT the cwd; summary follows Goal · Discoveries · Accomplished · Next Steps · Files), plus the `memory.about` update pointer. The block SHALL be ≤1000 chars — a self-imposed token-budget ceiling matching the server's `INSTRUCTIONS_MAX_LENGTH`, NOT a Hermes contract: upstream `agent/memory_manager.py::build_system_prompt` joins provider blocks with no truncation or length cap. Hermes does NOT consume the MCP server's `initialize.instructions` block and exposes no per-turn hook, so this method is its ONLY nudging surface.
+- `prefetch(query, **kwargs)` SHALL return `""`.
+- `queue_prefetch(query, **kwargs)` SHALL be a no-op (return `None`).
+- `sync_turn(user, assistant, **kwargs)` SHALL be a no-op.
+- `on_memory_write(action, target, content, **kwargs)` SHALL be a no-op.
+- `shutdown(**kwargs)` SHALL be a no-op.
+
+The provider SHALL NOT implement `get_config_schema` or `save_config`. Credentials live in `~/.hermes/.env`. The provider SHALL NOT preload any plugin-specific dotenv file.
+
+#### Scenario: is_available with both envs set and a healthy server returns True
+
+(Unchanged from the prior spec.)
+
+#### Scenario: is_available with a missing token returns False without making a request
+
+(Unchanged from the prior spec.)
+
+#### Scenario: is_available with an invalid token returns False
+
+(Unchanged from the prior spec.)
+
+#### Scenario: is_available with the server's database unavailable returns False
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Session initialize POSTs to the sessions endpoint with agent: hermes
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Pre-compress posts a transcript summary
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Session end posts to the end endpoint with summary and derived title
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Session end with empty messages degrades to `{}`
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Session end when model already wrote a final summary
+
+(Unchanged from the prior spec.)
+
+#### Scenario: Lifecycle calls without a resolved slug skip silently
+
+(Unchanged from the prior spec.)
+
+#### Scenario: system_prompt_block emits the proactive session-close protocol AND memory.context recovery guidance
+
+- **WHEN** Hermes calls `provider.system_prompt_block()`
+- **THEN** the returned string SHALL be non-empty and SHALL contain the substring `memory.session_summary`
+- **AND** SHALL contain a reference to `title` and the structure `Goal · Discoveries · Accomplished · Next Steps · Files`
+- **AND** SHALL phrase the trigger as firing at the end of every working turn (never silent) and SHALL NOT bind it solely to the literal word "done"
+- **AND** SHALL contain the substrings `memory.context`, `memory.save`, and `memory.about` (the unified RECALL / SAVE / update flows)
+- **AND** SHALL be ≤1000 chars total (self-imposed budget matching the server's `INSTRUCTIONS_MAX_LENGTH`; Hermes applies no truncation)
+
+#### Scenario: handle_tool_call returns a defensive error
+

--- a/openspec/changes/archive/2026-06-14-strengthen-memory-protocol-instructions/specs/mcp-api/spec.md
+++ b/openspec/changes/archive/2026-06-14-strengthen-memory-protocol-instructions/specs/mcp-api/spec.md
@@ -1,0 +1,59 @@
+## MODIFIED Requirements
+
+### Requirement: The MCP `initialize` response MUST ship a protocol-teaching `instructions` block
+
+When the MCP server is constructed, its `instructions` field SHALL be populated with a scope-aware string that teaches the agent when to call each tool. The string SHALL be 1000 characters or fewer in both variants. This cap is a self-imposed token budget, NOT a client or protocol limit: the MCP specification defines `InitializeResult.instructions` as an optional free-form string with no maximum length or truncation rule, and no consuming client enforces one.
+
+The instructions SHALL be organized as directive, proactively-phrased guidance citing the relevant tools by name, and SHALL include all of:
+
+1. **A proactive save flow** — directing the agent to call `memory.save` the moment something noteworthy happens (bug fix · decision · discovery · config change · pattern · preference) rather than batching to session end, and naming the `topic_key` supersede path and the `candidates[]` → `memory.judge` conflict-resolution path. Mechanical detail (error codes, scope semantics) MAY be deferred to the tool's own `description`.
+2. **A recall flow** — directing the agent that when starting or resuming work, after a `/compact` event, or when asked "what did we do", it SHALL call `memory.context` (or `memory.search` for keyword lookup) BEFORE acting, but ONLY when it lacks the prior detail it needs. The phrasing SHALL keep recall on-demand — it MUST NOT direct an unconditional `memory.context` load at session start.
+3. **A session-close flow** — directing the agent to call `memory.session_summary({title, summary})`. The trigger SHALL be bound to ending a turn in which real work happened — phrased so the agent saves before ending any working turn, and SHALL NOT be evadable by avoiding the literal word "done". The flow SHALL describe the title constraint (≤100 chars, descriptive of what was actually worked on — NOT the cwd, NOT generic), the summary structure (Goal · Discoveries · Accomplished · Next Steps · Files), AND the summary length cap (≤2000 chars). The cap MUST be present inline so the agent budgets for it on the first attempt; this is verified by the same length test that enforces the 1000-character ceiling.
+4. **The update-guidance pointer** — a short clause naming `memory.about` as the tool to call when the operator asks how to update or upgrade Rembric (server or plugins).
+
+#### Scenario: An MCP client connects on `/mcp/<slug>`
+
+- **WHEN** the `initialize` handshake completes against `/mcp/my-project`
+- **THEN** the `InitializeResult.instructions` SHALL contain references to `memory.save`, `memory.search`, `memory.session_summary`, AND `memory.context` plus a note indicating the connection is project-scoped to `'my-project'` and that `scope='global'` will be rejected
+- **AND** the instructions SHALL contain the substring `memory.session_summary` and the substring `title` and a reference to "before" (referring to before ending a working turn)
+- **AND** the instructions SHALL contain the substring `2000` (the summary length cap)
+- **AND** the instructions SHALL contain the substring `memory.context` (the recall flow)
+- **AND** the instructions SHALL contain the substring `memory.about` (the update-guidance pointer)
+
+#### Scenario: The session-summary trigger is bound to ending a working turn
+
+- **WHEN** either variant of `buildInstructions(ctx)` is built
+- **THEN** the instructions SHALL phrase the `memory.session_summary` trigger as firing before ending any turn in which real work happened
+- **AND** the instructions SHALL NOT bind the trigger solely to the literal phrase `before saying "done"`
+
+#### Scenario: Recall guidance is on-demand, not unconditional-at-start
+
+- **WHEN** either variant of `buildInstructions(ctx)` is built
+- **THEN** the `memory.context` recall flow SHALL be conditioned on the agent lacking prior detail (e.g. starting/resuming work, after `/compact`, or "what did we do")
+- **AND** the instructions SHALL NOT direct an unconditional `memory.context` load on every session start
+
+#### Scenario: An MCP client connects on `/mcp` without a project
+
+- **WHEN** the `initialize` handshake completes against `/mcp`
+- **THEN** the `InitializeResult.instructions` SHALL contain the same protocol flows (the proactive save flow, the on-demand recall flow, the session-close flow with the `2000`-char cap, AND the `memory.about` update-guidance pointer) and a note indicating the connection is global-scope and that project memories require opening `/mcp/<slug>` or sending `X-Rembric-Project`
+
+#### Scenario: Instructions length is checked at build time
+
+- **WHEN** the test suite runs against both `/mcp` and `/mcp/<slug>` variants of `buildInstructions(ctx)`
+- **THEN** both outputs SHALL be 1000 characters or fewer (the raised cap — the 2000-char summary cap mention, the recall flow, AND the memory.about pointer MUST all fit within the 1000-char budget)
+- **AND** both outputs SHALL contain the substring `2000`
+- **AND** both outputs SHALL contain the substring `memory.context`
+- **AND** both outputs SHALL contain the substring `memory.about`
+
+#### Scenario: A client that does not consume `instructions` connects
+
+- **WHEN** an MCP client ignores the `instructions` field
+- **THEN** every tool SHALL still function normally (the field is informational only)
+- **AND** `memory.about` SHALL remain discoverable through the MCP tool manifest regardless of whether the client consumed the `instructions` pointer
+
+#### Scenario: instructions.test.ts asserts the protocol flows are present
+
+- **WHEN** `apps/server/src/mcp/instructions.test.ts` runs against `buildInstructions({requestedSlug: 'demo'})` and `buildInstructions({requestedSlug: null})`
+- **THEN** both outputs SHALL contain the substrings `memory.save`, `memory.context`, `memory.session_summary`, AND `memory.about`
+- **AND** both outputs SHALL be ≤1000 chars
+- **AND** existing assertions for `memory.search`, scope notes, the `2000` cap, and the proactive (non-"done"-bound) session-summary phrasing SHALL pass

--- a/openspec/changes/archive/2026-06-14-strengthen-memory-protocol-instructions/specs/plugin-session-protocol/spec.md
+++ b/openspec/changes/archive/2026-06-14-strengthen-memory-protocol-instructions/specs/plugin-session-protocol/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: The protocol nudge MUST be in `initialize.instructions` to cover all three clients uniformly
+
+The MCP server's `initialize.instructions` string (loaded into the model's system prompt on connect) SHALL include a directive flow instructing the model to call `memory.session_summary` with `{title, summary}` at the end of every turn in which real work happened — never ending a working turn silent. The flow SHALL:
+
+- Be present in both the path-scoped and path-less variants of `initialize.instructions`.
+- Stay within the 1000-character cap enforced by `instructions.test.ts` (raised from 800; the cap is a self-imposed token budget, not a client or protocol limit).
+- Be phrased proactively and SHALL NOT bind the trigger solely to the literal word "done".
+- Describe the title constraint (≤100 chars, descriptive of what was worked on) and the summary structure (Goal · Discoveries · Accomplished · Next Steps · Files).
+
+This nudge is the only mechanism that covers the case where Codex CLI cannot inject post-compact instructions and where short sessions never compact; it is likewise the only nudging surface available to in-process clients (e.g. Hermes Agent) that expose no per-turn hook. All clients ship with the same MCP server reachable, so this is the single deployment surface.
+
+#### Scenario: Instructions string contains the protocol nudge
+
+- **WHEN** an MCP client retrieves `initialize.instructions` from either `/mcp` or `/mcp/<slug>`
+- **THEN** the string SHALL contain the substring `memory.session_summary` AND the substring `title` AND the substring `before` (referring to before ending a working turn)
+
+#### Scenario: Instructions string respects the 1000-char cap
+
+- **WHEN** the test suite runs `instructions.test.ts` against both variants
+- **THEN** both outputs SHALL be ≤1000 characters

--- a/openspec/changes/archive/2026-06-14-strengthen-memory-protocol-instructions/tasks.md
+++ b/openspec/changes/archive/2026-06-14-strengthen-memory-protocol-instructions/tasks.md
@@ -1,0 +1,42 @@
+## 1. Instructions block
+
+- [x] 1.1 In `apps/server/src/mcp/instructions.ts`, rewrite `BASE` to the directive three-flow preamble (SAVE / RECALL / SUMMARIZE) citing `memory.save`, `memory.context`/`memory.search`, `memory.session_summary`, and the `memory.about` pointer — final text path-scoped 879, unscoped 977 (summary structure kept inline; `summary≤${SUMMARY_MAX_CHARS}` interpolation preserved).
+- [x] 1.2 Raise `INSTRUCTIONS_MAX_LENGTH` from 800 to 1000.
+- [x] 1.3 Update the file's top comment to state that the cap is a self-imposed token budget, NOT a client/protocol limit (MCP defines no max length for `InitializeResult.instructions`).
+- [x] 1.4 Verified both variants ≤1000 (path 879, unscoped 977) — confirmed by `instructions.test.ts` in task 3.4.
+
+## 2. Tool descriptions
+
+- [x] 2.1 In `apps/server/src/mcp/server.ts`, strengthen the `memory.session_summary` description: replace "Call this BEFORE saying done/listo" with "at the end of every turn that did real work — never end a working turn silent"; keep the Args/Body/`memory.session_end` detail.
+- [x] 2.2 In `apps/server/src/mcp/server.ts`, strengthen the `memory.context` description: add the continuation triggers (starting/resuming work, after `/compact`, "what did we do") and the on-demand condition (only if prior detail is missing).
+- [x] 2.3 Leave the `memory.save` description unchanged (already proactive).
+
+## 3. Tests
+
+- [x] 3.1 Update `apps/server/src/mcp/instructions.test.ts`: change the cap assertion 800 → 1000 for both variants. Also fixed `mcp-integration.test.ts` (two hardcoded `800` → `1000`).
+- [x] 3.2 Update/confirm content-substring assertions: `memory.save`, `memory.context`, `memory.session_summary`, `memory.about`, `memory.search`, `2000`, `title`, `before`, scope notes — plus a new on-demand-recall assertion (`if you lack prior detail`).
+- [x] 3.3 Confirm the assertion that the session-summary trigger is NOT bound solely to the literal "done" (updated to `before ending any working turn`).
+- [x] 3.4 Ran `instructions.test.ts` (12/12) + full `src/mcp` + `mcp-integration.test.ts` (130/130).
+
+## 4. Hermes nudging surface (separate from MCP instructions)
+
+- [x] 4.0a Verify against upstream Hermes source whether `system_prompt_block` is capped/truncated: `agent/memory_manager.py::build_system_prompt` filters empties and joins with no length/token cap → the 300-char cap is self-imposed, not a contract.
+- [x] 4.0b Rewrite `system_prompt_block()` in `apps/plugin/.hermes-plugin/__init__.py` to return the byte-identical server `BASE` (unified SAVE/RECALL/SUMMARIZE flows, 776 chars); update its comment to document the sync requirement.
+- [x] 4.0c Raise Hermes's self-imposed cap 300 → 1000 (test) to match `INSTRUCTIONS_MAX_LENGTH`; update canonical `hermes-agent-plugin/spec.md` (unified text, cap 1000, self-imposed) + add the delta spec.
+- [x] 4.0d Fix the stale "system_prompt_block is a no-op" line in `apps/plugin/.hermes-plugin/README.md`.
+- [x] 4.0e Run `tests/test_system_prompt_block.py` + `tests/test_lifecycle_calls.py` (14/14) with `PYTHONPATH=tests`.
+
+## 5. Tool-review findings (correctness + polish)
+
+- [x] 5.1 Fix `create:true` → `autocreate:true` at the runtime surface (`instructions.ts` `UNSCOPED_NOTE`); confirm both variants still ≤1000 and tests pass.
+- [x] 5.2 De-drift the three non-normative spec occurrences: `claude-code-plugin/spec.md` ×2 (bootstrap + mid-session switch, the latter corrected to `confirmSwitch:true`), `sessions/spec.md` ×1.
+- [x] 5.3 Sharpen `memory.capture_passive` description (explicit wrap-up / Key Learnings trigger).
+- [x] 5.4 Sharpen `memory.session_start` description (host registers the session automatically; agent normally should not call it).
+
+## 6. Validation & sweep
+
+- [x] 6.1 `pnpm run typecheck` + `pnpm run lint` clean.
+- [x] 6.2 `pnpm test` green (full suite: TS workspaces + Hermes Python suite). Re-run after the tool-review edits.
+- [x] 6.3 `openspec validate strengthen-memory-protocol-instructions --strict` passes.
+- [x] 6.4 Byte-identical parity verified between `instructions.ts::BASE` and Hermes `system_prompt_block()` (776 == 776).
+- [x] 6.5 Real initialize handshake covered by `mcp-integration.test.ts`: it boots a live server and connects a real MCP client to both `/mcp` and `/mcp/<slug>`, asserting the `initialize.instructions` content and ≤1000-char length on both variants. The change now also touches `apps/plugin/` (Hermes), exercised by the Hermes Python suite. A full `dev:docker:up` bring-up would only re-confirm the same served strings; available on request.

--- a/openspec/specs/claude-code-plugin/spec.md
+++ b/openspec/specs/claude-code-plugin/spec.md
@@ -233,11 +233,11 @@ The active Rembric project is signalled per directory by a `.rembric` config fil
 
 **Bootstrap for new slugs:**
 
-- The first time the bridge connects with a slug that does not yet correspond to a Rembric project, the agent — guided by the `rembric-memory` skill — can call `project.use({slug, create: true})` once to create it. Subsequent connections find the project already created and skip the bootstrap.
+- The first time the bridge connects with a slug that does not yet correspond to a Rembric project, the agent — guided by the `rembric-memory` skill — can call `project.use({slug, autocreate: true})` once to create it. Subsequent connections find the project already created and skip the bootstrap.
 
 **Manual override during a session:**
 
-- The agent can always call `project.use({slug: 'something-else', create: true})` to switch scope mid-session. This is independent of the bridge's URL path.
+- The agent can call `project.use({slug: 'something-else', confirmSwitch: true})` to switch scope (allowed only when no session is active — close it first via `memory.session_summary`; add `autocreate: true` if the target project does not exist yet). This is independent of the bridge's URL path.
 
 ## Token budget
 

--- a/openspec/specs/hermes-agent-plugin/spec.md
+++ b/openspec/specs/hermes-agent-plugin/spec.md
@@ -76,7 +76,7 @@ The file SHALL expose a module-level `register(ctx)` function that calls `ctx.re
 - `on_session_switch(new_session_id, *, parent_session_id="", reset=False, **kwargs)` SHALL override per the "Provider MUST override on_session_switch" requirement.
 - `get_tool_schemas` SHALL return `[]`. The provider contributes no agent-callable tools.
 - `handle_tool_call(name, args)` SHALL return `json.dumps({"error": "unknown_tool", "hint": "register the rembric MCP bridge in mcp_servers.rembric to access memory tools"})`.
-- `system_prompt_block` SHALL return a single-paragraph block (**≤300 chars**) directing the agent to (a) call `memory.session_summary({title, summary})` before declaring work done — title ≤100 chars descriptive of what was actually worked on; summary follows Goal · Discoveries · Accomplished · Next Steps · Files — AND (b) call `memory.context` after any compaction event when the compact summary lacks detail (file paths, specific decisions, errors). This is the Hermes-side counterpart to Claude/Codex's `initialize.instructions` nudge, which now also carries the memory.context post-compact recovery guidance for symmetry.
+- `system_prompt_block` SHALL return the unified Rembric nudge — the SAME text as the server's `initialize.instructions` BASE (the SAVE/RECALL/SUMMARIZE flows defined by the `mcp-api` capability), kept byte-identical across the TS/Python boundary. It SHALL therefore direct the agent to SAVE proactively (`memory.save` the moment something noteworthy happens, with the `topic_key` supersede and `candidates[]`→`memory.judge` paths), RECALL on-demand (`memory.context`/`memory.search` when starting/resuming work, after `/compact`, or asked "what did we do", only if prior detail is missing), and SUMMARIZE at the end of every working turn (`memory.session_summary({title, summary})`, never ending a working turn silent — the trigger SHALL NOT be bound to the literal word "done"; title ≤100 chars, NOT the cwd; summary follows Goal · Discoveries · Accomplished · Next Steps · Files), plus the `memory.about` update pointer. The block SHALL be ≤1000 chars — a self-imposed token-budget ceiling matching the server's `INSTRUCTIONS_MAX_LENGTH`, NOT a Hermes contract: upstream `agent/memory_manager.py::build_system_prompt` joins provider blocks with no truncation or length cap. Hermes does NOT consume the MCP server's `initialize.instructions` block and exposes no per-turn hook, so this method is its ONLY nudging surface.
 - `prefetch(query, **kwargs)` SHALL return `""`.
 - `queue_prefetch(query, **kwargs)` SHALL be a no-op (return `None`).
 - `sync_turn(user, assistant, **kwargs)` SHALL be a no-op.
@@ -125,13 +125,14 @@ The provider SHALL NOT implement `get_config_schema` or `save_config`. Credentia
 
 (Unchanged from the prior spec.)
 
-#### Scenario: system_prompt_block emits the session-close protocol AND memory.context post-compact guidance
+#### Scenario: system_prompt_block emits the proactive session-close protocol AND memory.context recovery guidance
 
 - **WHEN** Hermes calls `provider.system_prompt_block()`
 - **THEN** the returned string SHALL be non-empty and SHALL contain the substring `memory.session_summary`
 - **AND** SHALL contain a reference to `title` and the structure `Goal · Discoveries · Accomplished · Next Steps · Files`
-- **AND** SHALL contain the substring `memory.context` (new — post-compact recovery guidance)
-- **AND** SHALL be ≤300 chars total (unchanged cap — the new content MUST fit within the existing cap, requiring concise phrasing)
+- **AND** SHALL phrase the trigger as firing at the end of every working turn (never silent) and SHALL NOT bind it solely to the literal word "done"
+- **AND** SHALL contain the substrings `memory.context`, `memory.save`, and `memory.about` (the unified RECALL / SAVE / update flows)
+- **AND** SHALL be ≤1000 chars total (self-imposed budget matching the server's `INSTRUCTIONS_MAX_LENGTH`; Hermes applies no truncation)
 
 #### Scenario: handle_tool_call returns a defensive error
 

--- a/openspec/specs/mcp-api/spec.md
+++ b/openspec/specs/mcp-api/spec.md
@@ -444,21 +444,22 @@ The `/mcp` and `/mcp/<slug>` endpoints SHALL register `project.use`, `project.li
 
 ### Requirement: The MCP `initialize` response MUST ship a protocol-teaching `instructions` block
 
-When the MCP server is constructed, its `instructions` field SHALL be populated with a scope-aware string that teaches the agent when to call each tool. The string SHALL be 800 characters or fewer.
+When the MCP server is constructed, its `instructions` field SHALL be populated with a scope-aware string that teaches the agent when to call each tool. The string SHALL be 1000 characters or fewer in both variants. This cap is a self-imposed token budget, NOT a client or protocol limit: the MCP specification defines `InitializeResult.instructions` as an optional free-form string with no maximum length or truncation rule, and no consuming client enforces one.
 
-The instructions SHALL include:
+The instructions SHALL be organized as directive, proactively-phrased guidance citing the relevant tools by name, and SHALL include all of:
 
-1. The session-close protocol sentence directing the agent to call `memory.session_summary({title, summary})`. The trigger SHALL be bound to ending a turn in which real work happened — phrased so the agent saves before ending any working turn — rather than to the literal word "done" (which the agent can trivially evade by not using it). The sentence SHALL describe the title constraint (≤100 chars, descriptive of what was actually worked on — NOT the cwd, NOT generic), the summary structure (Goal · Discoveries · Accomplished · Next Steps · Files), AND the summary length cap (≤2000 chars). The cap MUST be present inline so the agent budgets for it on the first attempt; this is verified by the same length test that enforces the 800-character ceiling.
-2. **The post-compact recovery clause** — a short instruction directing the agent that after any compaction event, when the compacted summary lacks specific detail (exact file paths, prior decisions, concrete error messages), it MUST call `memory.context` (or `memory.search` for keyword lookup) BEFORE responding to the user's pending prompt. The phrasing SHALL stay concise (≤60 chars of new content) so the total stays under the 800-char cap.
-3. **The update-guidance pointer** — a short clause naming `memory.about` as the tool to call when the operator asks how to update or upgrade Rembric (server or plugins). The phrasing SHALL stay concise (≤40 chars of new content) so the total stays under the 800-char cap.
+1. **A proactive save flow** — directing the agent to call `memory.save` the moment something noteworthy happens (bug fix · decision · discovery · config change · pattern · preference) rather than batching to session end, and naming the `topic_key` supersede path and the `candidates[]` → `memory.judge` conflict-resolution path. Mechanical detail (error codes, scope semantics) MAY be deferred to the tool's own `description`.
+2. **A recall flow** — directing the agent that when starting or resuming work, after a `/compact` event, or when asked "what did we do", it SHALL call `memory.context` (or `memory.search` for keyword lookup) BEFORE acting, but ONLY when it lacks the prior detail it needs. The phrasing SHALL keep recall on-demand — it MUST NOT direct an unconditional `memory.context` load at session start.
+3. **A session-close flow** — directing the agent to call `memory.session_summary({title, summary})`. The trigger SHALL be bound to ending a turn in which real work happened — phrased so the agent saves before ending any working turn, and SHALL NOT be evadable by avoiding the literal word "done". The flow SHALL describe the title constraint (≤100 chars, descriptive of what was actually worked on — NOT the cwd, NOT generic), the summary structure (Goal · Discoveries · Accomplished · Next Steps · Files), AND the summary length cap (≤2000 chars). The cap MUST be present inline so the agent budgets for it on the first attempt; this is verified by the same length test that enforces the 1000-character ceiling.
+4. **The update-guidance pointer** — a short clause naming `memory.about` as the tool to call when the operator asks how to update or upgrade Rembric (server or plugins).
 
 #### Scenario: An MCP client connects on `/mcp/<slug>`
 
 - **WHEN** the `initialize` handshake completes against `/mcp/my-project`
-- **THEN** the `InitializeResult.instructions` SHALL contain references to `memory.save`, `memory.search`, `memory.session_summary`, AND `memory.context` (the new post-compact recovery clause) plus a note indicating the connection is project-scoped to `'my-project'` and that `scope='global'` will be rejected
-- **AND** the instructions SHALL contain the substring `memory.session_summary` and the substring `title` and a reference to "before" (referring to before declaring done)
+- **THEN** the `InitializeResult.instructions` SHALL contain references to `memory.save`, `memory.search`, `memory.session_summary`, AND `memory.context` plus a note indicating the connection is project-scoped to `'my-project'` and that `scope='global'` will be rejected
+- **AND** the instructions SHALL contain the substring `memory.session_summary` and the substring `title` and a reference to "before" (referring to before ending a working turn)
 - **AND** the instructions SHALL contain the substring `2000` (the summary length cap)
-- **AND** the instructions SHALL contain the substring `memory.context` (the post-compact recovery clause)
+- **AND** the instructions SHALL contain the substring `memory.context` (the recall flow)
 - **AND** the instructions SHALL contain the substring `memory.about` (the update-guidance pointer)
 
 #### Scenario: The session-summary trigger is bound to ending a working turn
@@ -467,15 +468,21 @@ The instructions SHALL include:
 - **THEN** the instructions SHALL phrase the `memory.session_summary` trigger as firing before ending any turn in which real work happened
 - **AND** the instructions SHALL NOT bind the trigger solely to the literal phrase `before saying "done"`
 
+#### Scenario: Recall guidance is on-demand, not unconditional-at-start
+
+- **WHEN** either variant of `buildInstructions(ctx)` is built
+- **THEN** the `memory.context` recall flow SHALL be conditioned on the agent lacking prior detail (e.g. starting/resuming work, after `/compact`, or "what did we do")
+- **AND** the instructions SHALL NOT direct an unconditional `memory.context` load on every session start
+
 #### Scenario: An MCP client connects on `/mcp` without a project
 
 - **WHEN** the `initialize` handshake completes against `/mcp`
-- **THEN** the `InitializeResult.instructions` SHALL contain the same protocol triggers (including the session-close protocol sentence, the `2000`-char cap, the memory.context post-compact recovery clause, AND the `memory.about` update-guidance pointer) and a note indicating the connection is global-scope and that project memories require opening `/mcp/<slug>` or sending `X-Rembric-Project`
+- **THEN** the `InitializeResult.instructions` SHALL contain the same protocol flows (the proactive save flow, the on-demand recall flow, the session-close flow with the `2000`-char cap, AND the `memory.about` update-guidance pointer) and a note indicating the connection is global-scope and that project memories require opening `/mcp/<slug>` or sending `X-Rembric-Project`
 
 #### Scenario: Instructions length is checked at build time
 
 - **WHEN** the test suite runs against both `/mcp` and `/mcp/<slug>` variants of `buildInstructions(ctx)`
-- **THEN** both outputs SHALL be 800 characters or fewer (unchanged cap — the 2000-char summary cap mention, the memory.context post-compact clause, AND the memory.about update-guidance pointer MUST all fit within the existing budget)
+- **THEN** both outputs SHALL be 1000 characters or fewer (the raised cap — the 2000-char summary cap mention, the recall flow, AND the memory.about pointer MUST all fit within the 1000-char budget)
 - **AND** both outputs SHALL contain the substring `2000`
 - **AND** both outputs SHALL contain the substring `memory.context`
 - **AND** both outputs SHALL contain the substring `memory.about`
@@ -486,13 +493,12 @@ The instructions SHALL include:
 - **THEN** every tool SHALL still function normally (the field is informational only)
 - **AND** `memory.about` SHALL remain discoverable through the MCP tool manifest regardless of whether the client consumed the `instructions` pointer
 
-#### Scenario: instructions.test.ts asserts the new memory.context clause is present
+#### Scenario: instructions.test.ts asserts the protocol flows are present
 
 - **WHEN** `apps/server/src/mcp/instructions.test.ts` runs against `buildInstructions({requestedSlug: 'demo'})` and `buildInstructions({requestedSlug: null})`
-- **THEN** both outputs SHALL contain the substring `memory.context`
-- **AND** both outputs SHALL contain the substring `memory.about`
-- **AND** both outputs SHALL be ≤800 chars
-- **AND** existing assertions for `memory.session_summary`, `memory.save`, `memory.search`, scope notes, etc. SHALL continue to pass
+- **THEN** both outputs SHALL contain the substrings `memory.save`, `memory.context`, `memory.session_summary`, AND `memory.about`
+- **AND** both outputs SHALL be ≤1000 chars
+- **AND** existing assertions for `memory.search`, scope notes, the `2000` cap, and the proactive (non-"done"-bound) session-summary phrasing SHALL pass
 
 ### Requirement: The MCP server MUST expose `memory.suggest_topic_key`
 

--- a/openspec/specs/opencode-plugin/spec.md
+++ b/openspec/specs/opencode-plugin/spec.md
@@ -214,7 +214,7 @@ Non-sub-agent sessions SHALL be registered exactly once per plugin lifetime via 
 - Adds `id` to `knownSessions`.
 - POSTs `${REMBRIC_SERVER_URL}/api/<slug>/sessions` with body `{"id": <id>, "agent": "opencode", "cwd": <ctx.directory>}` if a slug resolved successfully. The body SHALL OMIT `cwd` entirely (NOT send `null`) when `ctx.directory` is unavailable, matching the bug fix recorded in memory `01KRY3ZAF86NRK5Y8K3N0JJ9M6`.
 
-The handler SHALL emit one stderr diagnostic line per `session.created` event of the form `[rembric] session.created id=<id> parentID=<parentID|""> title=<title|""> subagent=<true|false>`. This is mandatory: it makes engram-style heuristic drift visible in opencode's debug logs (design.md risk register).
+The handler SHALL emit one stderr diagnostic line per `session.created` event of the form `[rembric] session.created id=<id> parentID=<parentID|""> title=<title|""> subagent=<true|false>`. This is mandatory: it makes sub-agent heuristic drift visible in opencode's debug logs (design.md risk register).
 
 #### Scenario: Top-level session is registered exactly once
 

--- a/openspec/specs/plugin-session-protocol/spec.md
+++ b/openspec/specs/plugin-session-protocol/spec.md
@@ -149,23 +149,24 @@ When `cwd` is missing or fails to parse, the placeholder SHALL be `"session · H
 
 ### Requirement: The protocol nudge MUST be in `initialize.instructions` to cover all three clients uniformly
 
-The MCP server's `initialize.instructions` string (loaded into the model's system prompt on connect) SHALL include a sentence directing the model to call `memory.session_summary` with `{title, summary}` before "done" / end of work. The sentence SHALL:
+The MCP server's `initialize.instructions` string (loaded into the model's system prompt on connect) SHALL include a directive flow instructing the model to call `memory.session_summary` with `{title, summary}` at the end of every turn in which real work happened — never ending a working turn silent. The flow SHALL:
 
 - Be present in both the path-scoped and path-less variants of `initialize.instructions`.
-- Stay within the existing 800-character cap enforced by `instructions.test.ts`.
+- Stay within the 1000-character cap enforced by `instructions.test.ts` (raised from 800; the cap is a self-imposed token budget, not a client or protocol limit).
+- Be phrased proactively and SHALL NOT bind the trigger solely to the literal word "done".
 - Describe the title constraint (≤100 chars, descriptive of what was worked on) and the summary structure (Goal · Discoveries · Accomplished · Next Steps · Files).
 
-This nudge is the only mechanism that covers the case where Codex CLI cannot inject post-compact instructions and where short sessions never compact. All three clients ship with the same MCP server reachable, so this is the single deployment surface.
+This nudge is the only mechanism that covers the case where Codex CLI cannot inject post-compact instructions and where short sessions never compact; it is likewise the only nudging surface available to in-process clients (e.g. Hermes Agent) that expose no per-turn hook. All clients ship with the same MCP server reachable, so this is the single deployment surface.
 
 #### Scenario: Instructions string contains the protocol nudge
 
 - **WHEN** an MCP client retrieves `initialize.instructions` from either `/mcp` or `/mcp/<slug>`
-- **THEN** the string SHALL contain the substring `memory.session_summary` AND the substring `title` AND the substring `before` (referring to "before 'done'" / "before finishing")
+- **THEN** the string SHALL contain the substring `memory.session_summary` AND the substring `title` AND the substring `before` (referring to before ending a working turn)
 
-#### Scenario: Instructions string respects the 800-char cap
+#### Scenario: Instructions string respects the 1000-char cap
 
 - **WHEN** the test suite runs `instructions.test.ts` against both variants
-- **THEN** both outputs SHALL be ≤800 characters
+- **THEN** both outputs SHALL be ≤1000 characters
 
 ### Requirement: Per-client lifecycle mapping MUST be honoured
 

--- a/openspec/specs/sessions/spec.md
+++ b/openspec/specs/sessions/spec.md
@@ -292,7 +292,7 @@ A handler that resolves scope using only `ctx.project` and falls through directl
 #### Scenario: Path-less connection with router pin returns project scope
 
 - **GIVEN** a token connected to `/mcp` (path-less)
-- **AND** an agent has called `project.use({slug: 'foo', create: true})` successfully
+- **AND** an agent has called `project.use({slug: 'foo', autocreate: true})` successfully
 - **WHEN** the agent calls `memory.context`
 - **THEN** the response SHALL include `scope: "project:<foo.id>"` and the project's recent memories
 


### PR DESCRIPTION
## Why

Across many sessions the agent ends without saving, never loads prior context on a continuation, and skips the end-of-session summary — even though the tools are named in the protocol surface. The guidance was terse, low-salience, and bound `memory.session_summary` to the literal word "done" (trivially evaded). This makes the protocol-teaching surfaces drive proactive `memory.save` / `memory.context` / `memory.session_summary` behavior **without spending tokens pointlessly** (recall stays on-demand — no speculative `memory.context` payload at session start).

## What changed

**MCP `initialize.instructions`** (`apps/server/src/mcp/instructions.ts`) rewritten into a directive preamble with three labeled proactive flows — **SAVE** / **RECALL** / **SUMMARIZE** — each citing its tools. Cap raised **800 → 1000** (a self-imposed token budget, **not** a client/protocol limit: the MCP spec defines no max length for `InitializeResult.instructions`).

**Tool descriptions sharpened** (`apps/server/src/mcp/server.ts`):
- `memory.session_summary`: fire at the **end of every working turn, never silent** — no longer bound to "done".
- `memory.context`: continuation triggers (start/resume, `/compact`, "what did we do"), loaded **on-demand** only when detail is missing.
- `memory.capture_passive`: explicit wrap-up / Key Learnings trigger.
- `memory.session_start`: clarified that the host registers the session automatically.

**Hermes unified onto the same nudge.** Hermes does **not** consume `initialize.instructions`; it injects its own `system_prompt_block()`, which had drifted to the old "done" phrasing. It now returns the **byte-identical** server `BASE`, cap raised **300 → 1000**. The 300 cap was verified self-imposed against upstream [`agent/memory_manager.py::build_system_prompt`](https://github.com/NousResearch/hermes-agent/blob/main/agent/memory_manager.py) (joins provider blocks with no truncation).

**Bug fix (tool review):** `project.use` parameter is `autocreate`, not `create` — four sites told the agent to pass the non-existent `create:true` (silently ignored → project never created). Fixed at runtime + three non-normative spec examples; the mid-session-switch example now correctly uses `confirmSwitch`.

## Surface coverage

| Client | Surface | Cap |
|---|---|---|
| Claude Code / Codex / opencode | MCP `initialize.instructions` | 1000 (self-imposed) |
| Hermes | in-process `system_prompt_block()` (byte-identical text) | 1000 (self-imposed) |

Two physically separate copies (server TS vs in-process Python — no cross-language sharing possible), guarded against drift by content tests on both sides.

## Release tracks

- `feat(server)` → **server** track (Docker image rebuild).
- `feat(plugin)` → unified **plugin** track.

## Verification

- `pnpm run typecheck` ✓ · `pnpm run lint` ✓
- TS suite: 737 passed (1 skipped) — incl. `mcp-integration.test.ts` booting a live server + real MCP client on `/mcp` and `/mcp/<slug>`
- Hermes Python suite: 35 passed
- Byte-identical parity verified (`instructions.ts::BASE` == Hermes `system_prompt_block()`, 776 == 776)
- `openspec validate --strict` ✓ (change `strengthen-memory-protocol-instructions`, archived)

## OpenSpec

Modified capabilities: `mcp-api`, `plugin-session-protocol`, `hermes-agent-plugin`. Non-normative accuracy de-drift in `claude-code-plugin` / `sessions`. Change archived at `openspec/changes/archive/2026-06-14-strengthen-memory-protocol-instructions/`.