### PR TITLE
fix(self-update): use absolute /nodejs/bin/node in distroless image

### DIFF
--- a/apps/server/src/services/self-update/orchestrator.ts
+++ b/apps/server/src/services/self-update/orchestrator.ts
@@ -175,7 +175,14 @@ export class SelfUpdateOrchestrator {
     const name = `rembric-upgrader-${this.now()}`;
     const created = await engine.createContainer(name, {
       Image: imageRef,
-      Entrypoint: this.deps.helperEntrypoint ?? ['node', '/app/dist/scripts/upgrade-helper.js'],
+      // Absolute node path: the new image is distroless (gcr.io/distroless/nodejs22),
+      // which ships node at /nodejs/bin/node and puts NO bare `node` on PATH. A bare
+      // `node` here fails the upgrader with "exec: node: not found" (regressed the
+      // self-update when the runtime image moved to distroless).
+      Entrypoint: this.deps.helperEntrypoint ?? [
+        '/nodejs/bin/node',
+        '/app/dist/scripts/upgrade-helper.js',
+      ],
       // Root inside the one-shot upgrader sidesteps host docker-GID
       // mismatches; it only ever talks to the socket it is handed.
       User: 'root',

--- a/apps/server/src/test/invariants.test.ts
+++ b/apps/server/src/test/invariants.test.ts
@@ -289,6 +289,54 @@ describe('image packaging invariants', () => {
 });
 
 /**
+ * Distroless node-path invariant.
+ *
+ * The runtime image is distroless (gcr.io/distroless/nodejs22): node lives at
+ * /nodejs/bin/node and there is NO bare `node` on PATH. Every place that execs
+ * node *against the runtime image* must use the absolute path or it dies with
+ * `exec: "node": executable file not found in $PATH`. This regressed in prod
+ * (self-update upgrader + compose healthcheck) when the image moved to
+ * distroless — these tests pin each call site so it can't happen again.
+ */
+describe('distroless runtime node-path invariants', () => {
+  const NODE = '/nodejs/bin/node';
+
+  it('runtime stage is distroless AND its ENTRYPOINT + HEALTHCHECK use the absolute node path', () => {
+    const dockerfile = readFileSync(join(repoRoot, 'apps/server/Dockerfile'), 'utf8');
+    const runtimeIdx = dockerfile.search(/^FROM\s+\S+\s+AS\s+runtime\b/m);
+    expect(runtimeIdx).toBeGreaterThan(-1);
+    const runtime = dockerfile.slice(runtimeIdx);
+    // The reason node isn't on PATH — if this ever changes, revisit every NODE path below.
+    expect(/^FROM\s+\S*distroless\S*/.test(runtime.split('\n')[0] ?? '')).toBe(true);
+
+    const entry = runtime.match(/^ENTRYPOINT\s+(\[.*\])/m);
+    expect(entry).not.toBeNull();
+    expect(entry![1]).toContain(NODE);
+
+    const health = runtime.match(/HEALTHCHECK[\s\S]*?CMD\s+(\[.*\])/);
+    expect(health).not.toBeNull();
+    expect(health![1]).toContain(NODE);
+
+    // No bare-`node` exec form anywhere in the runtime stage.
+    expect(/\[\s*"node"\s*[,\]]/.test(runtime)).toBe(false);
+  });
+
+  it('docker-compose healthcheck uses the absolute node path (runs in the distroless image)', () => {
+    const compose = readFileSync(join(repoRoot, 'docker-compose.yml'), 'utf8');
+    expect(compose).toContain(NODE);
+    // A bare `- node` list entry would exec `node` and mark the container unhealthy.
+    expect(/^\s*-\s*node\s*$/m.test(compose)).toBe(false);
+  });
+
+  it('self-update upgrader entrypoint uses the absolute node path (runs in the NEW distroless image)', () => {
+    const orch = readFileSync(join(srcRoot, 'services/self-update/orchestrator.ts'), 'utf8');
+    expect(orch).toContain(`'${NODE}'`);
+    // The bare-`node` default that bricked the upgrader must be gone.
+    expect(/\[\s*'node'\s*,/.test(orch)).toBe(false);
+  });
+});
+
+/**
  * Scope-leak invariant.
  *
  * Application-level RLS is enforced by passing a `Scope` argument into

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,10 @@ services:
 
     healthcheck:
       test:
+        # Absolute path: the image is distroless (node at /nodejs/bin/node, no
+        # bare `node` on PATH) — a bare `node` here marks the container unhealthy.
         - CMD
-        - node
+        - /nodejs/bin/node
         - -e
         - "fetch('http://127.0.0.1:8787/healthz',{headers:{Authorization:'Bearer '+process.env.REMBRIC_ADMIN_TOKEN}}).then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
       interval: 30s


### PR DESCRIPTION
## Incident

Updating to v0.21.14 (the first distroless release) fails in the dashboard with:

```
error during container init: exec: "node": executable file not found in $PATH
```

Production stays UP on the old version — the self-update fails while launching the *upgrader* container, before the main container is touched.

## Root cause

The runtime image moved to distroless (`gcr.io/distroless/nodejs22`) in #156, which ships node at `/nodejs/bin/node` with **no bare `node` on PATH**. Two call sites still used bare `node`:

1. **`orchestrator.ts`** — the self-update launches the upgrader with `Entrypoint: ['node', …]` → `exec: "node": not found` against the new image. **This is the reported error.**
2. **`docker-compose.yml` healthcheck** — uses `node` → container marked unhealthy under distroless.

Not caught earlier because the e2e starts the *main* container (correct entrypoint) and curls `/healthz`; it never exercises the self-update orchestrator nor Docker's healthcheck.

## Fix

- Both call sites → `/nodejs/bin/node`.
- New **`distroless runtime node-path` invariant test** pinning all three call sites (Dockerfile ENTRYPOINT + HEALTHCHECK, compose healthcheck, upgrader entrypoint) so a future bare `node` fails in CI, not in a release.

## Operator note (migration)

Crossing the bookworm→distroless boundary via the dashboard self-update is **not possible** — the OLD server (0.21.13/0.21.14) launches the upgrader with bare `node`. A **one-time manual update** to this fixed version is required; after that, self-update works again.

61 tests green · typecheck · lint.