### PR TITLE
feat(server): OAuth 2.1 authorization server for remote MCP connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,13 +205,14 @@ docker compose up -d
 
 All config via environment variables. With Docker, these live in `.env` and are loaded automatically by `docker compose up`. Required: `REMBRIC_ADMIN_TOKEN` (used to log into the dashboard and mint other tokens).
 
-| Variable               | Default                           | Description                                                                                                                |
-| ---------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `REMBRIC_HOST`         | `127.0.0.1` (`0.0.0.0` in Docker) | Bind address. Pinned to `0.0.0.0` inside the container so the published port works; never override in Docker.              |
-| `REMBRIC_PORT`         | `8787`                            | Bind port.                                                                                                                 |
-| `REMBRIC_DATA_DIR`     | `~/.rembric` (`/data` in Docker)  | Where the SQLite file lives. Pinned to `/data` inside the container; bind-mount `./data:/data` in compose.                 |
-| `LOG_LEVEL`            | `info`                            | `debug` / `info` / `warn` / `error`.                                                                                       |
-| `REMBRIC_UPDATE_CHECK` | `on`                              | `off` disables the daily release check (no badge, no modal, no GitHub API call). See [docs/updates.md](./docs/updates.md). |
+| Variable               | Default                           | Description                                                                                                                                                                                                                                                 |
+| ---------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `REMBRIC_HOST`         | `127.0.0.1` (`0.0.0.0` in Docker) | Bind address. Pinned to `0.0.0.0` inside the container so the published port works; never override in Docker.                                                                                                                                               |
+| `REMBRIC_PORT`         | `8787`                            | Bind port.                                                                                                                                                                                                                                                  |
+| `REMBRIC_DATA_DIR`     | `~/.rembric` (`/data` in Docker)  | Where the SQLite file lives. Pinned to `/data` inside the container; bind-mount `./data:/data` in compose.                                                                                                                                                  |
+| `LOG_LEVEL`            | `info`                            | `debug` / `info` / `warn` / `error`.                                                                                                                                                                                                                        |
+| `REMBRIC_UPDATE_CHECK` | `on`                              | `off` disables the daily release check (no badge, no modal, no GitHub API call). See [docs/updates.md](./docs/updates.md).                                                                                                                                  |
+| `REMBRIC_PUBLIC_URL`   | _unset_                           | Set to the public https issuer (`http://localhost` allowed for local testing) to enable the OAuth 2.1 authorization server, so OAuth clients (Claude Code, ChatGPT) connect without a static token. Off when unset. See [docs/agents.md](./docs/agents.md). |
 
 <details>
 <summary><b>Advanced configuration</b> — hardware, consolidation sweep, rate limiting, sessions, candidate detection</summary>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -79,7 +79,9 @@ In scope:
 - The shared plugin tree (`plugin/`) consumed by the Claude Code / Codex /
   Hermes marketplaces.
 - The MCP tool surface and the HTTP API exposed at `/mcp`, `/mcp/<slug>`,
-  `/api/<slug>/sessions*`, `/dashboard*`, `/healthz`.
+  `/api/<slug>/sessions*`, `/dashboard*`, `/healthz`, and the OAuth 2.1
+  endpoints (`/authorize`, `/token`, `/register`, `/revoke`,
+  `/.well-known/oauth-*`, `/dashboard/oauth/consent`).
 
 Out of scope (please do **not** spend time on these):
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -25,6 +25,7 @@
     "@modelcontextprotocol/sdk": "^1.0.0",
     "better-sqlite3": "^11.5.0",
     "drizzle-orm": "^0.36.0",
+    "express": "^5.2.1",
     "hono": "^4.6.0",
     "sqlite-vec": "^0.1.6",
     "ulid": "^2.3.0",
@@ -32,6 +33,7 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
+    "@types/express": "^5.0.0",
     "@types/node": "^22.7.0",
     "@vitest/coverage-v8": "^2.1.0",
     "drizzle-kit": "^0.27.0",

--- a/apps/server/src/config.test.ts
+++ b/apps/server/src/config.test.ts
@@ -67,6 +67,18 @@ describe('loadConfig — OAuth', () => {
     }
   });
 
+  it('rejects issuer forms the MCP SDK would reject (avoids a boot crash)', () => {
+    // The SDK's checkIssuerUrl throws on these; reject them as clean config
+    // errors instead. http loopback is limited to localhost / 127.0.0.1.
+    for (const issuer of [
+      'http://[::1]:8787',
+      'https://rembric.example.com/mcp?x=1',
+      'https://rembric.example.com/#frag',
+    ]) {
+      expect(() => loadConfig(env({ REMBRIC_PUBLIC_URL: issuer })), issuer).toThrow(ConfigError);
+    }
+  });
+
   it('rejects a non-URL issuer', () => {
     expect(() => loadConfig(env({ REMBRIC_PUBLIC_URL: 'not-a-url' }))).toThrow(ConfigError);
   });

--- a/apps/server/src/config.test.ts
+++ b/apps/server/src/config.test.ts
@@ -33,6 +33,57 @@ describe('loadConfig — types and ranges', () => {
   });
 });
 
+describe('loadConfig — OAuth', () => {
+  it('is disabled by default', () => {
+    const config = loadConfig(env());
+    expect(config.oauth.enabled).toBe(false);
+    expect(config.oauth.issuer).toBeNull();
+    expect(config.oauth.accessTtlMs).toBe(3_600_000);
+    expect(config.oauth.refreshTtlMs).toBe(30 * 86_400_000);
+  });
+
+  it('enables when REMBRIC_PUBLIC_URL is a valid https origin', () => {
+    const config = loadConfig(env({ REMBRIC_PUBLIC_URL: 'https://rembric.example.com' }));
+    expect(config.oauth.enabled).toBe(true);
+    expect(config.oauth.issuer).toBe('https://rembric.example.com');
+  });
+
+  it('strips a trailing slash from the issuer', () => {
+    const config = loadConfig(env({ REMBRIC_PUBLIC_URL: 'https://rembric.example.com/' }));
+    expect(config.oauth.issuer).toBe('https://rembric.example.com');
+  });
+
+  it('rejects a non-https issuer on a public host', () => {
+    expect(() => loadConfig(env({ REMBRIC_PUBLIC_URL: 'http://rembric.example.com' }))).toThrow(
+      ConfigError,
+    );
+  });
+
+  it('allows http for loopback hosts (local testing)', () => {
+    for (const issuer of ['http://localhost:8787', 'http://127.0.0.1:8787']) {
+      const config = loadConfig(env({ REMBRIC_PUBLIC_URL: issuer }));
+      expect(config.oauth.enabled).toBe(true);
+      expect(config.oauth.issuer).toBe(issuer);
+    }
+  });
+
+  it('rejects a non-URL issuer', () => {
+    expect(() => loadConfig(env({ REMBRIC_PUBLIC_URL: 'not-a-url' }))).toThrow(ConfigError);
+  });
+
+  it('parses custom TTLs (seconds) into ms', () => {
+    const config = loadConfig(
+      env({
+        REMBRIC_PUBLIC_URL: 'https://rembric.example.com',
+        REMBRIC_OAUTH_ACCESS_TTL: '900',
+        REMBRIC_OAUTH_REFRESH_TTL: '604800',
+      }),
+    );
+    expect(config.oauth.accessTtlMs).toBe(900_000);
+    expect(config.oauth.refreshTtlMs).toBe(604_800_000);
+  });
+});
+
 describe('loadConfig — removed env vars degrade gracefully', () => {
   // Upgrade contract (`remove-llm-consolidation` + `embed-embeddings-in-process`):
   // environments still defining chat-LLM, cron, or embedding-provider vars

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -210,8 +210,6 @@ function stripTrailingSlash(url: string): string {
   return url.endsWith('/') ? url.slice(0, -1) : url;
 }
 
-const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
-
 function isAllowedIssuerUrl(value: string): boolean {
   let url: URL;
   try {
@@ -219,8 +217,13 @@ function isAllowedIssuerUrl(value: string): boolean {
   } catch {
     return false;
   }
+  // Mirror the MCP SDK's checkIssuerUrl exactly: it rejects a query/fragment
+  // and permits a non-https issuer only for localhost / 127.0.0.1. Validating
+  // the same rules here turns a bad REMBRIC_PUBLIC_URL into a clean config
+  // error instead of an unhandled crash inside the SDK router at boot.
+  if (url.search || url.hash) return false;
   if (url.protocol === 'https:') return true;
-  return url.protocol === 'http:' && LOOPBACK_HOSTS.has(url.hostname);
+  return url.protocol === 'http:' && (url.hostname === 'localhost' || url.hostname === '127.0.0.1');
 }
 
 /** Redact secrets from a config for safe logging. */

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -51,6 +51,27 @@ const envSchema = z.object({
   REMBRIC_ADMIN_TOKEN: z.string().min(16).optional(),
   REMBRIC_SESSION_SECRET: z.string().min(16).optional(),
 
+  // OAuth 2.1 authorization server. The feature is enabled iff
+  // REMBRIC_PUBLIC_URL is set; it is the OAuth `issuer` and the base for
+  // every absolute metadata URL, so it MUST be the externally-reachable
+  // origin (a proxy/tunnel front, not the internal HOST:PORT). HTTPS is
+  // required, with an http exception ONLY for loopback hosts (localhost /
+  // 127.0.0.1) — the RFC 8414 testing exemption the MCP SDK also applies.
+  REMBRIC_PUBLIC_URL: z
+    .string()
+    .url()
+    .refine(isAllowedIssuerUrl, {
+      message: 'REMBRIC_PUBLIC_URL must be https:// (http allowed only for localhost / 127.0.0.1)',
+    })
+    .optional(),
+  REMBRIC_OAUTH_ACCESS_TTL: z.coerce.number().int().min(60).max(86_400).default(3600),
+  REMBRIC_OAUTH_REFRESH_TTL: z.coerce
+    .number()
+    .int()
+    .min(3600)
+    .max(365 * 86_400)
+    .default(30 * 86_400),
+
   // Per-token MCP rate limiting. Disabled by default — single-user
   // localhost deployments do not need it. Set RATE_LIMIT_ENABLED=true
   // to turn on the token-bucket limiter.
@@ -106,6 +127,13 @@ export interface Config {
   logLevel: LogLevel;
   adminToken: string | null;
   sessionSecret: string | null;
+  oauth: {
+    enabled: boolean;
+    /** OAuth issuer / external base URL; null when the feature is off. */
+    issuer: string | null;
+    accessTtlMs: number;
+    refreshTtlMs: number;
+  };
   rateLimit: {
     enabled: boolean;
     ratePerSecond: number;
@@ -154,6 +182,12 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     logLevel: parsed.LOG_LEVEL,
     adminToken: parsed.REMBRIC_ADMIN_TOKEN ?? null,
     sessionSecret: parsed.REMBRIC_SESSION_SECRET ?? null,
+    oauth: {
+      enabled: parsed.REMBRIC_PUBLIC_URL !== undefined,
+      issuer: parsed.REMBRIC_PUBLIC_URL ? stripTrailingSlash(parsed.REMBRIC_PUBLIC_URL) : null,
+      accessTtlMs: parsed.REMBRIC_OAUTH_ACCESS_TTL * 1000,
+      refreshTtlMs: parsed.REMBRIC_OAUTH_REFRESH_TTL * 1000,
+    },
     rateLimit: {
       enabled: parsed.RATE_LIMIT_ENABLED,
       ratePerSecond: parsed.RATE_LIMIT_RPS,
@@ -172,6 +206,23 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   };
 }
 
+function stripTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
+function isAllowedIssuerUrl(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  if (url.protocol === 'https:') return true;
+  return url.protocol === 'http:' && LOOPBACK_HOSTS.has(url.hostname);
+}
+
 /** Redact secrets from a config for safe logging. */
 export function redactConfig(config: Config): Record<string, unknown> {
   return {
@@ -181,6 +232,12 @@ export function redactConfig(config: Config): Record<string, unknown> {
     logLevel: config.logLevel,
     adminToken: config.adminToken ? '[set]' : '[unset]',
     sessionSecret: config.sessionSecret ? '[set]' : '[derived from admin token]',
+    oauth: {
+      enabled: config.oauth.enabled,
+      issuer: config.oauth.issuer ?? '[unset]',
+      accessTtlMs: config.oauth.accessTtlMs,
+      refreshTtlMs: config.oauth.refreshTtlMs,
+    },
     rateLimit: config.rateLimit,
     sessions: config.sessions,
     candidates: config.candidates,

--- a/apps/server/src/dashboard/oauth-consent.test.ts
+++ b/apps/server/src/dashboard/oauth-consent.test.ts
@@ -1,0 +1,124 @@
+import { randomBytes } from 'node:crypto';
+
+import { Hono, type Context, type Next } from 'hono';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createRepositories } from '../db/repositories/index.js';
+import { OAuthRepository } from '../db/repositories/oauth-repository.js';
+import { signAuthRequest, type AuthRequest } from '../services/oauth-areq.js';
+import { OAuthService } from '../services/oauth.js';
+import { SessionsService } from '../services/sessions.js';
+import { TokensService } from '../services/tokens.js';
+import { createTestDb, type TestDb } from '../test/db.js';
+
+import { createOAuthConsentRouter } from './oauth-consent.js';
+import type { ResolvedSession } from './types.js';
+
+const TTL = { accessTtlMs: 3_600_000, refreshTtlMs: 30 * 86_400_000 };
+const REDIRECT = 'https://chatgpt.example/callback';
+const KEY = randomBytes(32);
+
+describe('OAuth consent route', () => {
+  let t: TestDb;
+  let oauth: OAuthService;
+  let sessions: SessionsService;
+  let app: Hono;
+  let session: ResolvedSession;
+  let clientId: string;
+
+  beforeEach(() => {
+    t = createTestDb();
+    const repos = createRepositories(t.handle.db);
+    oauth = new OAuthService({ oauth: new OAuthRepository(t.handle.db) }, TTL);
+    sessions = new SessionsService(repos, randomBytes(32));
+    const tokens = new TokensService(repos);
+    const admin = tokens.create({ name: 'admin', scope: '*', projectId: null });
+    const created = sessions.create(admin.token.id);
+    session = { session: created.session, sessions, tokenId: admin.token.id };
+    clientId = oauth.registerClient({ redirectUris: [REDIRECT], clientName: 'ChatGPT' }).clientId;
+
+    app = new Hono();
+    app.use('*', (c: Context, next: Next) => {
+      c.set('session' as never, session as never);
+      return next();
+    });
+    app.route('/', createOAuthConsentRouter({ oauth, areqKey: KEY, sessions }));
+  });
+
+  afterEach(() => t.cleanup());
+
+  function areq(overrides: Partial<AuthRequest> = {}): string {
+    return signAuthRequest(
+      {
+        clientId,
+        redirectUri: REDIRECT,
+        codeChallenge: 'challenge-value',
+        scope: 'mcp',
+        state: 'st-9',
+        exp: Math.floor(Date.now() / 1000) + 300,
+        ...overrides,
+      },
+      KEY,
+    );
+  }
+
+  function csrf(): string {
+    return sessions.csrfToken(session.session, 'oauth.consent');
+  }
+
+  async function post(fields: Record<string, string>) {
+    return app.request('/consent', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams(fields).toString(),
+    });
+  }
+
+  it('GET renders the consent screen for a valid areq', async () => {
+    const res = await app.request(`/consent?areq=${encodeURIComponent(areq())}`);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('AUTHORIZE');
+    expect(body).toContain('ChatGPT');
+  });
+
+  it('GET rejects an invalid/expired areq with 400', async () => {
+    const expired = areq({ exp: Math.floor(Date.now() / 1000) - 1 });
+    const res = await app.request(`/consent?areq=${encodeURIComponent(expired)}`);
+    expect(res.status).toBe(400);
+  });
+
+  it('POST approve issues a code and redirects to the client redirect_uri', async () => {
+    const res = await post({ areq: areq(), decision: 'approve', csrf: csrf() });
+    expect(res.status).toBe(302);
+    const loc = res.headers.get('location') ?? '';
+    expect(loc.startsWith(`${REDIRECT}?`)).toBe(true);
+    const url = new URL(loc);
+    expect(url.searchParams.get('code')).toBeTruthy();
+    expect(url.searchParams.get('state')).toBe('st-9');
+    // The issued code is redeemable for the granted (write) scope.
+    const code = url.searchParams.get('code')!;
+    const pair = oauth.redeemCode({ code, clientId, redirectUri: REDIRECT });
+    expect(pair.scope).toBe('*');
+  });
+
+  it('POST deny redirects with access_denied and issues no code', async () => {
+    const res = await post({ areq: areq(), decision: 'deny', csrf: csrf() });
+    expect(res.status).toBe(302);
+    const url = new URL(res.headers.get('location') ?? '');
+    expect(url.searchParams.get('error')).toBe('access_denied');
+    expect(url.searchParams.get('code')).toBeNull();
+  });
+
+  it('POST without a valid CSRF token is rejected', async () => {
+    const res = await post({ areq: areq(), decision: 'approve', csrf: 'wrong' });
+    expect(res.status).toBe(403);
+  });
+
+  it('POST with a tampered areq is rejected with 400', async () => {
+    const blob = areq();
+    const tampered = `${blob}x`;
+    const res = await post({ areq: tampered, decision: 'approve', csrf: csrf() });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/server/src/dashboard/oauth-consent.ts
+++ b/apps/server/src/dashboard/oauth-consent.ts
@@ -1,0 +1,169 @@
+import { Hono } from 'hono';
+
+import { verifyAuthRequest } from '../services/oauth-areq.js';
+import { resolveGrantedScope, type OAuthService } from '../services/oauth.js';
+import type { SessionsService } from '../services/sessions.js';
+
+import { btn, flash } from './components.js';
+import { csrfInput, readFormAndVerifyCsrf } from './csrf.js';
+import { html, shell } from './templates.js';
+import type { ResolvedSession } from './types.js';
+
+/**
+ * OAuth consent screen, mounted under the dashboard so it inherits the
+ * signed-session auth (the operator must be logged in) and CSRF helpers.
+ *
+ * `provider.authorize` (which has no request access) signs the SDK-validated
+ * authorization request and redirects here; on approval we issue the code and
+ * redirect back to the client's registered redirect_uri with `code`+`state`.
+ */
+
+export interface OAuthConsentDeps {
+  oauth: OAuthService;
+  /** HMAC key for verifying the signed authorization request. */
+  areqKey: Buffer;
+  sessions: SessionsService;
+}
+
+const FORM = 'oauth.consent';
+
+export function createOAuthConsentRouter(deps: OAuthConsentDeps): Hono {
+  const app = new Hono();
+
+  app.get('/consent', (c) => {
+    const blob = c.req.query('areq') ?? '';
+    const areq = verifyAuthRequest(blob, deps.areqKey, Date.now());
+    if (!areq) return c.html(renderError('This authorization request is invalid or expired.'), 400);
+    const client = deps.oauth.findClient(areq.clientId);
+    if (!client) return c.html(renderError('Unknown OAuth client.'), 400);
+
+    const session = c.get('session' as never) as ResolvedSession;
+    const granted = resolveGrantedScope(areq.scope);
+    return c.html(
+      renderConsent({
+        blob,
+        clientName: client.clientName ?? areq.clientId,
+        redirectHost: safeHost(areq.redirectUri),
+        granted,
+        csrf: csrfInput(session.session, deps.sessions, FORM),
+      }),
+    );
+  });
+
+  app.post('/consent', async (c) => {
+    const session = c.get('session' as never) as ResolvedSession;
+    const form = await readFormAndVerifyCsrf(c, session.session, deps.sessions, FORM);
+    if (form instanceof Response) return form;
+
+    const blob = strField(form, 'areq');
+    const areq = verifyAuthRequest(blob, deps.areqKey, Date.now());
+    if (!areq) return c.html(renderError('This authorization request is invalid or expired.'), 400);
+
+    if (strField(form, 'decision') !== 'approve') {
+      return c.redirect(
+        buildRedirect(areq.redirectUri, { error: 'access_denied', state: areq.state }),
+      );
+    }
+
+    const scope = resolveGrantedScope(areq.scope);
+    const code = deps.oauth.issueCode({
+      clientId: areq.clientId,
+      redirectUri: areq.redirectUri,
+      codeChallenge: areq.codeChallenge,
+      scope,
+      subject: session.tokenId,
+    });
+    return c.redirect(buildRedirect(areq.redirectUri, { code, state: areq.state }));
+  });
+
+  return app;
+}
+
+function strField(form: FormData, name: string): string {
+  const v = form.get(name);
+  return typeof v === 'string' ? v : '';
+}
+
+function safeHost(uri: string): string {
+  try {
+    return new URL(uri).host;
+  } catch {
+    return uri;
+  }
+}
+
+function buildRedirect(redirectUri: string, params: Record<string, string | undefined>): string {
+  const url = new URL(redirectUri);
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== '') url.searchParams.set(k, v);
+  }
+  return url.href;
+}
+
+function consentShell(inner: ReturnType<typeof html>): string {
+  return shell(html`<div class="consent-stage"><div class="consent-card">${inner}</div></div>`, {
+    title: 'Authorize',
+    view: 'oauth-consent',
+  });
+}
+
+function consentBrand(): ReturnType<typeof html> {
+  return html`
+    <div class="brand">
+      <img src="/dashboard/assets/logo-transparent.png" alt="" aria-hidden="true" />
+      <span class="wordmark">Rembric · Authorize</span>
+    </div>
+  `;
+}
+
+function renderConsent(o: {
+  blob: string;
+  clientName: string;
+  redirectHost: string;
+  granted: string;
+  csrf: ReturnType<typeof csrfInput>;
+}): string {
+  // `html` escapes every interpolated string once — do NOT pre-escape here
+  // (that double-encodes, e.g. "&" → "&amp;amp;").
+  const access = o.granted === 'read:*' ? 'Read-only' : 'Read & write';
+  return consentShell(html`
+    ${consentBrand()}
+    <h1><span class="hl-lime">Authorize</span> Application.</h1>
+    <p class="lead">
+      <b>${o.clientName}</b> wants to connect to your Rembric memory and will redirect to
+      <code>${o.redirectHost}</code>.
+    </p>
+    <div class="consent-grant">
+      <span class="lbl">Granted access</span>
+      <span class="val"
+        ><span style="color:var(--lime)">${access}</span> · scope <code>${o.granted}</code></span
+      >
+    </div>
+    <p class="consent-note">
+      Project scope, if any, is bound by the connector path <code>/mcp/&lt;slug&gt;</code>.
+    </p>
+    <div class="consent-actions">
+      <form action="/dashboard/oauth/consent" method="post">
+        ${o.csrf}
+        <input type="hidden" name="areq" value="${o.blob}" />
+        <input type="hidden" name="decision" value="approve" />
+        ${btn({ variant: 'primary', label: 'AUTHORIZE →', type: 'submit' })}
+      </form>
+      <form action="/dashboard/oauth/consent" method="post">
+        ${o.csrf}
+        <input type="hidden" name="areq" value="${o.blob}" />
+        <input type="hidden" name="decision" value="deny" />
+        ${btn({ variant: 'secondary', label: 'DENY', type: 'submit' })}
+      </form>
+    </div>
+  `);
+}
+
+function renderError(message: string): string {
+  return consentShell(html`
+    ${consentBrand()}
+    <h1><span class="hl-lime">Authorization</span> Error.</h1>
+    ${flash({ tone: 'danger', label: 'ERROR', body: message })}
+    <p class="lead">Return to the application and start the connection again.</p>
+  `);
+}

--- a/apps/server/src/dashboard/styles/views/oauth-consent.css
+++ b/apps/server/src/dashboard/styles/views/oauth-consent.css
@@ -1,0 +1,107 @@
+/* OAUTH CONSENT — centered brutalist authorization card */
+
+.consent-stage {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--s-6);
+}
+
+.consent-card {
+  width: 100%;
+  max-width: 540px;
+  background: var(--bg-elev);
+  border: 1px solid var(--fg-faint);
+  padding: var(--s-7);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-5);
+}
+
+.consent-card .brand {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+}
+
+.consent-card .brand img {
+  display: block;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 auto;
+  user-select: none;
+  pointer-events: none;
+}
+
+.consent-card .brand .wordmark {
+  font-family: var(--f-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--fg-dim);
+}
+
+.consent-card h1 {
+  font-family: var(--f-display);
+  font-weight: 700;
+  font-size: 2.4rem;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+}
+
+.consent-card .lead {
+  color: var(--fg-dim);
+  line-height: 1.5;
+}
+
+.consent-card .lead b {
+  color: var(--fg);
+}
+
+.consent-grant {
+  border: 1px solid var(--fg-faint);
+  padding: var(--s-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-2);
+}
+
+.consent-grant .lbl {
+  font-family: var(--f-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--fg-dim);
+}
+
+.consent-grant .val {
+  font-family: var(--f-mono);
+  font-size: 0.95rem;
+}
+
+.consent-note {
+  font-family: var(--f-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  color: var(--fg-dim);
+}
+
+.consent-actions {
+  display: flex;
+  gap: var(--s-3);
+  align-items: center;
+}
+
+@media (max-width: 640px) {
+  .consent-stage {
+    padding: var(--s-4);
+    align-items: stretch;
+  }
+  .consent-card {
+    padding: var(--s-5);
+  }
+  .consent-card h1 {
+    font-size: 1.9rem;
+  }
+}

--- a/apps/server/src/db/migrations.test.ts
+++ b/apps/server/src/db/migrations.test.ts
@@ -190,6 +190,7 @@ describe('migrations 0011 + 0012 with referencing children', () => {
     expect(result.applied).toEqual([
       '0011_summary_length_check.sql',
       '0012_drop_summary_length_check.sql',
+      '0013_oauth_tables.sql',
     ]);
 
     // FK integrity after the rebuild.

--- a/apps/server/src/db/migrations/0013_oauth_tables.sql
+++ b/apps/server/src/db/migrations/0013_oauth_tables.sql
@@ -1,0 +1,48 @@
+-- 0013_oauth_tables.sql
+--
+-- Additive OAuth 2.1 authorization-server state. Three new tables; the
+-- static `tokens` table is untouched, so no rebuild / FK-drop dance is
+-- needed. Secrets are stored hashed (same scheme as `tokens`).
+
+CREATE TABLE oauth_clients (
+  client_id text PRIMARY KEY NOT NULL,
+  client_name text,
+  redirect_uris text NOT NULL,
+  token_endpoint_auth_method text NOT NULL,
+  created_at integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE oauth_authorization_codes (
+  id text PRIMARY KEY NOT NULL,
+  hash text NOT NULL,
+  client_id text NOT NULL,
+  redirect_uri text NOT NULL,
+  code_challenge text NOT NULL,
+  scope text NOT NULL,
+  subject text NOT NULL,
+  expires_at integer NOT NULL,
+  consumed_at integer,
+  created_at integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX oauth_authorization_codes_hash_idx ON oauth_authorization_codes (hash);
+--> statement-breakpoint
+CREATE TABLE oauth_tokens (
+  id text PRIMARY KEY NOT NULL,
+  kind text NOT NULL,
+  hash text NOT NULL,
+  client_id text NOT NULL,
+  family_id text NOT NULL,
+  scope text NOT NULL,
+  subject text NOT NULL,
+  expires_at integer NOT NULL,
+  rotated_at integer,
+  revoked_at integer,
+  created_at integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX oauth_tokens_hash_idx ON oauth_tokens (hash);
+--> statement-breakpoint
+CREATE INDEX oauth_tokens_family_idx ON oauth_tokens (family_id);
+--> statement-breakpoint
+CREATE INDEX oauth_tokens_expires_at_idx ON oauth_tokens (expires_at);

--- a/apps/server/src/db/repositories/index.ts
+++ b/apps/server/src/db/repositories/index.ts
@@ -4,6 +4,7 @@ import { AgentSessionsRepository } from './agent-sessions-repository.js';
 import { ConsolidationRepository } from './consolidation-repository.js';
 import { DashboardSessionsRepository } from './dashboard-sessions-repository.js';
 import { MemoryRepository } from './memory-repository.js';
+import { OAuthRepository } from './oauth-repository.js';
 import { ProjectsRepository } from './projects-repository.js';
 import { PromptsRepository } from './prompts-repository.js';
 import { RelationsRepository } from './relations-repository.js';
@@ -27,6 +28,7 @@ export {
   type AdminListMemoriesOpts,
   type FindActiveByScopeOpts,
 } from './memory-repository.js';
+export { OAuthRepository } from './oauth-repository.js';
 export { ProjectsRepository } from './projects-repository.js';
 export { PromptsRepository, type AdminListPromptsOpts } from './prompts-repository.js';
 export {
@@ -44,6 +46,7 @@ export interface Repositories {
   prompts: PromptsRepository;
   projects: ProjectsRepository;
   tokens: TokensRepository;
+  oauth: OAuthRepository;
   consolidation: ConsolidationRepository;
   vectors: VectorsRepository;
   dashboardSessions: DashboardSessionsRepository;
@@ -57,6 +60,7 @@ export function createRepositories(db: Db): Repositories {
     prompts: new PromptsRepository(db),
     projects: new ProjectsRepository(db),
     tokens: new TokensRepository(db),
+    oauth: new OAuthRepository(db),
     consolidation: new ConsolidationRepository(db),
     vectors: new VectorsRepository(db),
     dashboardSessions: new DashboardSessionsRepository(db),

--- a/apps/server/src/db/repositories/oauth-repository.ts
+++ b/apps/server/src/db/repositories/oauth-repository.ts
@@ -1,0 +1,78 @@
+import { and, eq, isNull } from 'drizzle-orm';
+
+import type { Db } from '../client.js';
+import {
+  oauthAuthorizationCodes,
+  oauthClients,
+  oauthTokens,
+  type NewOAuthAuthorizationCode,
+  type NewOAuthClient,
+  type NewOAuthToken,
+  type OAuthAuthorizationCode,
+  type OAuthClient,
+  type OAuthToken,
+  type OAuthTokenKind,
+} from '../schema/oauth.js';
+
+export class OAuthRepository {
+  constructor(private readonly db: Db) {}
+
+  insertClient(values: NewOAuthClient): OAuthClient | undefined {
+    return this.db.insert(oauthClients).values(values).returning().get();
+  }
+
+  findClient(clientId: string): OAuthClient | undefined {
+    return this.db.select().from(oauthClients).where(eq(oauthClients.clientId, clientId)).get();
+  }
+
+  insertCode(values: NewOAuthAuthorizationCode): OAuthAuthorizationCode | undefined {
+    return this.db.insert(oauthAuthorizationCodes).values(values).returning().get();
+  }
+
+  findCodeByHash(hash: string): OAuthAuthorizationCode | undefined {
+    return this.db
+      .select()
+      .from(oauthAuthorizationCodes)
+      .where(eq(oauthAuthorizationCodes.hash, hash))
+      .get();
+  }
+
+  /** Mark a code consumed only if not already consumed; returns rows changed. */
+  consumeCode(id: string, consumedAt: Date): number {
+    return this.db
+      .update(oauthAuthorizationCodes)
+      .set({ consumedAt })
+      .where(and(eq(oauthAuthorizationCodes.id, id), isNull(oauthAuthorizationCodes.consumedAt)))
+      .run().changes;
+  }
+
+  insertToken(values: NewOAuthToken): OAuthToken | undefined {
+    return this.db.insert(oauthTokens).values(values).returning().get();
+  }
+
+  findTokenByHash(hash: string, kind: OAuthTokenKind): OAuthToken | undefined {
+    return this.db
+      .select()
+      .from(oauthTokens)
+      .where(and(eq(oauthTokens.hash, hash), eq(oauthTokens.kind, kind)))
+      .get();
+  }
+
+  /** Mark a refresh token rotated only if not already rotated; returns rows changed. */
+  markRefreshRotated(id: string, rotatedAt: Date): number {
+    return this.db
+      .update(oauthTokens)
+      .set({ rotatedAt })
+      .where(and(eq(oauthTokens.id, id), isNull(oauthTokens.rotatedAt)))
+      .run().changes;
+  }
+
+  /** Revoke every still-active token in a family. Returns rows changed. */
+  revokeFamily(familyId: string, revokedAt: Date): number {
+    return this.db
+      .update(oauthTokens)
+      .set({ revokedAt })
+      .where(and(eq(oauthTokens.familyId, familyId), isNull(oauthTokens.revokedAt)))
+      .run().changes;
+  }
+}

--- a/apps/server/src/db/schema/index.ts
+++ b/apps/server/src/db/schema/index.ts
@@ -8,6 +8,7 @@ export * from './projects.js';
 export * from './confirmations.js';
 export * from './consolidation.js';
 export * from './tokens.js';
+export * from './oauth.js';
 export * from './sessions.js';
 export * from './agent-sessions.js';
 export * from './prompts.js';

--- a/apps/server/src/db/schema/oauth.ts
+++ b/apps/server/src/db/schema/oauth.ts
@@ -1,0 +1,82 @@
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+/**
+ * OAuth 2.1 authorization-server state, kept in dedicated tables so the
+ * static operator `tokens` table is untouched (its rows are few, named, and
+ * long-lived; OAuth rows are many, anonymous, and short-lived).
+ *
+ * Secrets (authorization codes, access/refresh tokens) are stored only as a
+ * deterministic SHA-256 (NOT the salted scrypt the static `tokens` table
+ * uses — see design D1: stretching adds nothing to a 256-bit random secret,
+ * and a per-row salt would preclude the indexed O(1) lookup these hot-path
+ * tables need). The two hash schemes are intentionally different and not
+ * interchangeable. `oauth_tokens.scope` reuses the static `TokenScope`
+ * grammar so the same `isAuthorized()` checks apply. `family_id` groups an
+ * access/refresh lineage so refresh-reuse detection can revoke the whole
+ * family.
+ */
+
+export const oauthClients = sqliteTable('oauth_clients', {
+  clientId: text('client_id').primaryKey(),
+  clientName: text('client_name'),
+  /** JSON array of registered redirect URIs. */
+  redirectUris: text('redirect_uris').notNull(),
+  tokenEndpointAuthMethod: text('token_endpoint_auth_method').notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+});
+
+export const oauthAuthorizationCodes = sqliteTable(
+  'oauth_authorization_codes',
+  {
+    id: text('id').primaryKey(),
+    /** Hash of the single-use authorization code secret. */
+    hash: text('hash').notNull(),
+    clientId: text('client_id').notNull(),
+    redirectUri: text('redirect_uri').notNull(),
+    /** PKCE S256 challenge bound at /authorize, verified at /token. */
+    codeChallenge: text('code_challenge').notNull(),
+    scope: text('scope').notNull(),
+    subject: text('subject').notNull(),
+    expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
+    consumedAt: integer('consumed_at', { mode: 'timestamp_ms' }),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+  },
+  (table) => ({
+    hashIdx: index('oauth_authorization_codes_hash_idx').on(table.hash),
+  }),
+);
+
+export const oauthTokens = sqliteTable(
+  'oauth_tokens',
+  {
+    id: text('id').primaryKey(),
+    /** `access` | `refresh`. */
+    kind: text('kind').notNull(),
+    /** Hash of the bearer secret. */
+    hash: text('hash').notNull(),
+    clientId: text('client_id').notNull(),
+    /** Groups an access/refresh lineage for refresh-reuse family revocation. */
+    familyId: text('family_id').notNull(),
+    scope: text('scope').notNull(),
+    subject: text('subject').notNull(),
+    expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
+    /** Set when a refresh token is consumed by rotation. */
+    rotatedAt: integer('rotated_at', { mode: 'timestamp_ms' }),
+    revokedAt: integer('revoked_at', { mode: 'timestamp_ms' }),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+  },
+  (table) => ({
+    hashIdx: index('oauth_tokens_hash_idx').on(table.hash),
+    familyIdx: index('oauth_tokens_family_idx').on(table.familyId),
+    expiresAtIdx: index('oauth_tokens_expires_at_idx').on(table.expiresAt),
+  }),
+);
+
+export type OAuthClient = typeof oauthClients.$inferSelect;
+export type NewOAuthClient = typeof oauthClients.$inferInsert;
+export type OAuthAuthorizationCode = typeof oauthAuthorizationCodes.$inferSelect;
+export type NewOAuthAuthorizationCode = typeof oauthAuthorizationCodes.$inferInsert;
+export type OAuthToken = typeof oauthTokens.$inferSelect;
+export type NewOAuthToken = typeof oauthTokens.$inferInsert;
+
+export type OAuthTokenKind = 'access' | 'refresh';

--- a/apps/server/src/server/api-router.ts
+++ b/apps/server/src/server/api-router.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { truncateSummary, type AgentSessionsService } from '../services/agent-sessions.js';
 import { DomainError } from '../services/errors.js';
+import type { OAuthService } from '../services/oauth.js';
 import type { ProjectsService } from '../services/projects.js';
 import { isAuthorized } from '../services/tokens.js';
 import type { TokensService } from '../services/tokens.js';
@@ -30,6 +31,8 @@ export interface ApiRouterDeps {
   agentSessions: AgentSessionsService;
   tokens: TokensService;
   projects: ProjectsService;
+  /** OAuth access-token fallback, so /api auth matches /mcp. Null when OAuth is off. */
+  oauth?: OAuthService | null;
   /**
    * Fire-and-forget consolidation sweep (decay + deadline orphaning),
    * invoked after a session is created. Throttled and error-isolated by
@@ -194,6 +197,7 @@ function authMiddleware(deps: ApiRouterDeps) {
         pathSlug: slug,
         tokens: deps.tokens,
         projects: deps.projects,
+        oauth: deps.oauth ?? null,
       });
       c.set('rembricCtx', ctx);
     } catch (err) {

--- a/apps/server/src/server/auth.test.ts
+++ b/apps/server/src/server/auth.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createRepositories, type Repositories } from '../db/repositories/index.js';
+import { OAuthService } from '../services/oauth.js';
+import { ProjectsService } from '../services/projects.js';
+import { TokensService } from '../services/tokens.js';
+import { createTestDb, type TestDb } from '../test/db.js';
+
+import { AuthError, authenticate } from './auth.js';
+
+const TTL = { accessTtlMs: 3_600_000, refreshTtlMs: 30 * 86_400_000 };
+
+describe('authenticate — static + OAuth coexistence', () => {
+  let t: TestDb;
+  let repos: Repositories;
+  let tokens: TokensService;
+  let projects: ProjectsService;
+  let oauth: OAuthService;
+
+  beforeEach(() => {
+    t = createTestDb();
+    repos = createRepositories(t.handle.db);
+    tokens = new TokensService(repos);
+    projects = new ProjectsService(repos);
+    oauth = new OAuthService({ oauth: repos.oauth }, TTL);
+  });
+
+  afterEach(() => t.cleanup());
+
+  function mintOAuthAccessToken(scope: '*' | 'read:*' = '*'): string {
+    const client = oauth.registerClient({ redirectUris: ['https://c/cb'] });
+    const code = oauth.issueCode({
+      clientId: client.clientId,
+      redirectUri: 'https://c/cb',
+      codeChallenge: 'challenge-placeholder',
+      scope,
+      subject: 'operator',
+    });
+    return oauth.redeemCode({ code, clientId: client.clientId, redirectUri: 'https://c/cb' })
+      .accessToken;
+  }
+
+  it('authenticates a static token (unchanged behavior)', () => {
+    const created = tokens.create({ name: 'static', scope: '*', projectId: null });
+    const ctx = authenticate({
+      authorization: `Bearer ${created.plaintext}`,
+      pathSlug: undefined,
+      tokens,
+      projects,
+      oauth,
+    });
+    expect(ctx.scope).toBe('*');
+    expect(ctx.token.id).toBe(created.token.id);
+  });
+
+  it('falls back to an OAuth access token when static lookup misses', () => {
+    const access = mintOAuthAccessToken('*');
+    const ctx = authenticate({
+      authorization: `Bearer ${access}`,
+      pathSlug: undefined,
+      tokens,
+      projects,
+      oauth,
+    });
+    expect(ctx.scope).toBe('*');
+    expect(ctx.token.name).toMatch(/^oauth:/);
+  });
+
+  it('preserves OAuth scope (read:*) through resolution', () => {
+    const access = mintOAuthAccessToken('read:*');
+    const ctx = authenticate({
+      authorization: `Bearer ${access}`,
+      pathSlug: undefined,
+      tokens,
+      projects,
+      oauth,
+    });
+    expect(ctx.scope).toBe('read:*');
+  });
+
+  it('rejects an unknown token with token_invalid', () => {
+    expect(() =>
+      authenticate({
+        authorization: 'Bearer totally-unknown',
+        pathSlug: undefined,
+        tokens,
+        projects,
+        oauth,
+      }),
+    ).toThrow(AuthError);
+  });
+
+  it('does not accept OAuth tokens when oauth is disabled', () => {
+    const access = mintOAuthAccessToken('*');
+    expect(() =>
+      authenticate({
+        authorization: `Bearer ${access}`,
+        pathSlug: undefined,
+        tokens,
+        projects,
+        oauth: null,
+      }),
+    ).toThrow(AuthError);
+  });
+
+  it('never authenticates a token row with an empty hash (synthetic-token safety)', () => {
+    // The OAuth synthetic Token carries hash:'' and is never persisted; this
+    // guards the invariant that an empty stored hash can never match.
+    repos.tokens.insert({
+      id: 'empty-hash',
+      name: 'empty-hash',
+      hash: '',
+      scope: '*',
+      projectId: null,
+      createdAt: new Date(0),
+      expiresAt: null,
+      revokedAt: null,
+    });
+    expect(() => tokens.authenticate('')).toThrow(/not recognized/);
+    expect(() => tokens.authenticate('anything')).toThrow(/not recognized/);
+  });
+
+  it('does not retry a revoked static token against OAuth', () => {
+    const created = tokens.create({ name: 'revokeme', scope: '*', projectId: null });
+    tokens.revoke('revokeme');
+    try {
+      authenticate({
+        authorization: `Bearer ${created.plaintext}`,
+        pathSlug: undefined,
+        tokens,
+        projects,
+        oauth,
+      });
+      throw new Error('expected AuthError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AuthError);
+      expect((err as AuthError).code).toBe('token_revoked');
+    }
+  });
+});

--- a/apps/server/src/server/auth.ts
+++ b/apps/server/src/server/auth.ts
@@ -1,6 +1,8 @@
+import type { Token } from '../db/schema/tokens.js';
 import { DomainError } from '../services/errors.js';
+import type { OAuthService } from '../services/oauth.js';
 import type { ProjectsService } from '../services/projects.js';
-import type { TokensService } from '../services/tokens.js';
+import type { TokenScope, TokensService } from '../services/tokens.js';
 
 import type { RequestContext } from './request-context.js';
 
@@ -51,8 +53,10 @@ export function authenticate(input: {
   pathSlug: string | undefined;
   tokens: TokensService;
   projects: ProjectsService;
+  /** When set, OAuth-minted access tokens are accepted as a fallback. */
+  oauth?: OAuthService | null;
 }): RequestContext {
-  const { authorization, pathSlug, tokens, projects } = input;
+  const { authorization, pathSlug, tokens, projects, oauth } = input;
 
   if (!authorization) {
     throw new AuthError('missing_token', 'missing Authorization header', 401);
@@ -65,21 +69,7 @@ export function authenticate(input: {
     throw new AuthError('malformed_authorization', 'empty bearer token', 401);
   }
 
-  let resolved: ReturnType<TokensService['authenticate']>;
-  try {
-    resolved = tokens.authenticate(plaintext);
-  } catch (err) {
-    if (err instanceof DomainError) {
-      if (err.code === 'token_revoked') {
-        throw new AuthError('token_revoked', 'token has been revoked', 401);
-      }
-      if (err.code === 'token_expired') {
-        throw new AuthError('token_expired', 'token has expired', 401);
-      }
-      throw new AuthError('token_invalid', 'token not recognized', 401);
-    }
-    throw err;
-  }
+  const resolved = resolveToken(plaintext, tokens, oauth ?? null);
 
   const project = pathSlug && pathSlug.length > 0 ? (projects.findBySlug(pathSlug) ?? null) : null;
 
@@ -97,5 +87,56 @@ export function authenticate(input: {
     project,
     requestedSlug: pathSlug && pathSlug.length > 0 ? pathSlug : null,
     mcpSessionId: null,
+  };
+}
+
+/**
+ * Resolve a bearer secret to a token + scope. The static `tokens` table is
+ * consulted first (unchanged behavior); only a genuine no-match falls
+ * through to the OAuth access-token lookup. A static revoked/expired token
+ * is a definitive match and is NOT retried against OAuth.
+ */
+function resolveToken(
+  plaintext: string,
+  tokens: TokensService,
+  oauth: OAuthService | null,
+): { token: Token; scope: TokenScope } {
+  try {
+    return tokens.authenticate(plaintext);
+  } catch (err) {
+    if (!(err instanceof DomainError)) throw err;
+    if (err.code === 'token_revoked') {
+      throw new AuthError('token_revoked', 'token has been revoked', 401);
+    }
+    if (err.code === 'token_expired') {
+      throw new AuthError('token_expired', 'token has expired', 401);
+    }
+    // token_not_found / token_invalid → try OAuth before rejecting.
+    if (oauth) {
+      const oa = oauth.authenticateAccessToken(plaintext);
+      if (oa) {
+        return { token: syntheticOAuthToken(oa.clientId, oa.scope), scope: oa.scope };
+      }
+    }
+    throw new AuthError('token_invalid', 'token not recognized', 401);
+  }
+}
+
+/**
+ * A `Token`-shaped value for an OAuth-authenticated connection. Keyed on the
+ * client id (stable across refresh rotations and per-connector — DCR runs
+ * once per connector instance) so session ownership and rate-limit bucketing
+ * stay continuous. The `hash` is never read after authentication.
+ */
+function syntheticOAuthToken(clientId: string, scope: TokenScope): Token {
+  return {
+    id: `oauth:${clientId}`,
+    name: `oauth:${clientId}`,
+    hash: '',
+    scope,
+    projectId: null,
+    createdAt: new Date(0),
+    expiresAt: null,
+    revokedAt: null,
   };
 }

--- a/apps/server/src/server/bootstrap.ts
+++ b/apps/server/src/server/bootstrap.ts
@@ -13,6 +13,7 @@ import { AgentSessionsService } from '../services/agent-sessions.js';
 import { EmbeddingWorker } from '../services/embedding-worker.js';
 import { DomainError } from '../services/errors.js';
 import { MemoryService } from '../services/memory.js';
+import { OAuthService } from '../services/oauth.js';
 import { ProjectsService } from '../services/projects.js';
 import { PromptsService } from '../services/prompts.js';
 import { RelationsService } from '../services/relations.js';
@@ -23,7 +24,7 @@ import {
   SelfUpdateOrchestrator,
 } from '../services/self-update/orchestrator.js';
 import { SessionsService } from '../services/sessions.js';
-import { deriveSessionKey, TokensService } from '../services/tokens.js';
+import { deriveOAuthAreqKey, deriveSessionKey, TokensService } from '../services/tokens.js';
 import { UpdateCheckService } from '../services/update-check.js';
 import { REMBRIC_VERSION } from '../version.js';
 
@@ -36,6 +37,7 @@ import {
   type DataCounts,
 } from './data-loss-guard.js';
 import { startHttpServer, type HttpServerHandle } from './http.js';
+import { createOAuthProvider } from './oauth-provider.js';
 import { RateLimiter } from './rate-limit.js';
 import { SessionRouter } from './session-router.js';
 
@@ -119,6 +121,26 @@ export async function bootstrap(
     throw new Error('session secret is missing; set REMBRIC_SESSION_SECRET or REMBRIC_ADMIN_TOKEN');
   }
   const sessions = new SessionsService(repos, deriveSessionKey(sessionSecretBase));
+
+  // OAuth 2.1 authorization server — enabled only when REMBRIC_PUBLIC_URL is
+  // set (config.oauth.issuer). The SDK router owns the protocol; our service
+  // owns persistence/logic; the consent screen lives in the dashboard.
+  const oauthAreqKey = deriveOAuthAreqKey(sessionSecretBase);
+  const oauthService =
+    config.oauth.enabled && config.oauth.issuer
+      ? new OAuthService(
+          { oauth: repos.oauth },
+          { accessTtlMs: config.oauth.accessTtlMs, refreshTtlMs: config.oauth.refreshTtlMs },
+        )
+      : null;
+  const oauthProvider =
+    oauthService && config.oauth.issuer
+      ? createOAuthProvider({
+          oauth: oauthService,
+          issuer: config.oauth.issuer,
+          areqKey: oauthAreqKey,
+        })
+      : null;
 
   // In-process embedder + drain worker — fills memory_vec so save-time
   // candidate detection has vectors to kNN over. The model loads eagerly
@@ -269,6 +291,15 @@ export async function bootstrap(
     rateLimiter,
     triggerConsolidation: () => Promise.resolve(runner.runAll({ force: true })),
     sweep: sweepOnSessionStart,
+    oauth:
+      oauthService && oauthProvider && config.oauth.issuer
+        ? {
+            provider: oauthProvider,
+            service: oauthService,
+            issuer: config.oauth.issuer,
+            scopesSupported: ['mcp', 'read'],
+          }
+        : null,
     dashboard: {
       repos,
       diagnostics: dbDiagnostics,
@@ -288,6 +319,8 @@ export async function bootstrap(
       undoOp: (opId) => undoOp(repos, dbHandle.db, opId),
       orphanAfterMs: config.judgments.orphanAfterMs,
       orphanDeadlineMs: config.judgments.orphanDeadlineMs,
+      oauth: oauthService,
+      oauthAreqKey: oauthService ? oauthAreqKey : null,
     },
   });
 
@@ -332,6 +365,9 @@ function printBootstrapBanner(config: Config, counts: DataCounts): void {
   console.error(
     `[bootstrap] counts: memory=${counts.memory} projects=${counts.projects} sessions=${counts.sessions} tokens=${counts.tokens} prompts=${counts.prompts}`,
   );
+  if (config.oauth.enabled) {
+    console.error(`[bootstrap] oauth: enabled, issuer=${config.oauth.issuer}`);
+  }
 }
 
 function printReadyBanner(url: string, firstRun: boolean): void {

--- a/apps/server/src/server/bootstrap.ts
+++ b/apps/server/src/server/bootstrap.ts
@@ -123,23 +123,20 @@ export async function bootstrap(
   const sessions = new SessionsService(repos, deriveSessionKey(sessionSecretBase));
 
   // OAuth 2.1 authorization server — enabled only when REMBRIC_PUBLIC_URL is
-  // set (config.oauth.issuer). The SDK router owns the protocol; our service
-  // owns persistence/logic; the consent screen lives in the dashboard.
+  // set (`config.oauth.issuer` is non-null iff enabled). The SDK router owns
+  // the protocol; our service owns persistence/logic; consent lives in the
+  // dashboard.
+  const oauthIssuer = config.oauth.issuer;
   const oauthAreqKey = deriveOAuthAreqKey(sessionSecretBase);
-  const oauthService =
-    config.oauth.enabled && config.oauth.issuer
-      ? new OAuthService(
-          { oauth: repos.oauth },
-          { accessTtlMs: config.oauth.accessTtlMs, refreshTtlMs: config.oauth.refreshTtlMs },
-        )
-      : null;
+  const oauthService = oauthIssuer
+    ? new OAuthService(
+        { oauth: repos.oauth },
+        { accessTtlMs: config.oauth.accessTtlMs, refreshTtlMs: config.oauth.refreshTtlMs },
+      )
+    : null;
   const oauthProvider =
-    oauthService && config.oauth.issuer
-      ? createOAuthProvider({
-          oauth: oauthService,
-          issuer: config.oauth.issuer,
-          areqKey: oauthAreqKey,
-        })
+    oauthService && oauthIssuer
+      ? createOAuthProvider({ oauth: oauthService, issuer: oauthIssuer, areqKey: oauthAreqKey })
       : null;
 
   // In-process embedder + drain worker — fills memory_vec so save-time
@@ -292,11 +289,11 @@ export async function bootstrap(
     triggerConsolidation: () => Promise.resolve(runner.runAll({ force: true })),
     sweep: sweepOnSessionStart,
     oauth:
-      oauthService && oauthProvider && config.oauth.issuer
+      oauthService && oauthProvider && oauthIssuer
         ? {
             provider: oauthProvider,
             service: oauthService,
-            issuer: config.oauth.issuer,
+            issuer: oauthIssuer,
             scopesSupported: ['mcp', 'read'],
           }
         : null,

--- a/apps/server/src/server/dashboard-router.ts
+++ b/apps/server/src/server/dashboard-router.ts
@@ -22,6 +22,7 @@ import { csrfInput, readFormAndVerifyCsrf } from '../dashboard/csrf.js';
 import { createJudgmentsRouter } from '../dashboard/judgments.js';
 import { createMaintenanceRouter } from '../dashboard/maintenance.js';
 import { createMemoriesRouter } from '../dashboard/memories.js';
+import { createOAuthConsentRouter } from '../dashboard/oauth-consent.js';
 import { createProjectsRouter } from '../dashboard/projects.js';
 import { createPromptsRouter } from '../dashboard/prompts.js';
 import { createSessionsRouter } from '../dashboard/sessions.js';
@@ -43,6 +44,7 @@ import type { Repositories } from '../db/repositories/index.js';
 import type { AgentSessionsService } from '../services/agent-sessions.js';
 import { DomainError } from '../services/errors.js';
 import type { MemoryService } from '../services/memory.js';
+import type { OAuthService } from '../services/oauth.js';
 import type { ProjectsService } from '../services/projects.js';
 import type { PromptsService } from '../services/prompts.js';
 import type { RelationsService } from '../services/relations.js';
@@ -79,6 +81,9 @@ export interface DashboardDeps {
   /** Resolved judgment aging thresholds (from `config.judgments`). */
   orphanAfterMs: number;
   orphanDeadlineMs: number;
+  /** OAuth service + consent signing key; present only when OAuth is enabled. */
+  oauth?: OAuthService | null;
+  oauthAreqKey?: Buffer | null;
 }
 
 export interface DashboardStats {
@@ -102,19 +107,22 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
   app.get('/assets/:path{.+}', createAssetsMiddleware());
 
   // ── login / logout (anonymous) ───────────────────────────────────
-  app.get('/login', (c) => c.html(renderLogin(null)));
+  app.get('/login', (c) => c.html(renderLogin(null, safeNext(c.req.query('next')))));
 
   app.post('/login', async (c) => {
     const form = await c.req.formData();
     const r = form.get('token');
     const tokenPlain = typeof r === 'string' ? r : '';
+    const next = safeNext(
+      typeof form.get('next') === 'string' ? (form.get('next') as string) : null,
+    );
     if (tokenPlain.length === 0) {
-      return c.html(renderLogin('Token is required.'), 400);
+      return c.html(renderLogin('Token is required.', next), 400);
     }
     try {
       const resolved = deps.tokens.authenticate(tokenPlain);
       if (resolved.scope !== '*') {
-        return c.html(renderLogin('Only admin-scoped tokens can access the dashboard.'), 403);
+        return c.html(renderLogin('Only admin-scoped tokens can access the dashboard.', next), 403);
       }
       const { cookie } = deps.sessions.create(resolved.token.id);
       setCookie(c, COOKIE_NAME, cookie, {
@@ -123,10 +131,10 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
         path: '/dashboard',
         maxAge: SESSION_TTL_SECONDS,
       });
-      return c.redirect('/dashboard');
+      return c.redirect(next ?? '/dashboard');
     } catch (err) {
       if (err instanceof DomainError) {
-        return c.html(renderLogin('Invalid token.'), 401);
+        return c.html(renderLogin('Invalid token.', next), 401);
       }
       throw err;
     }
@@ -161,9 +169,9 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
       return next();
     }
     const cookie = getCookie(c, COOKIE_NAME);
-    if (!cookie) return c.redirect('/dashboard/login');
+    if (!cookie) return c.redirect(loginWithNext(c));
     const ctx = deps.sessions.resolve(cookie);
-    if (!ctx) return c.redirect('/dashboard/login');
+    if (!ctx) return c.redirect(loginWithNext(c));
 
     const resolved: ResolvedSession = {
       session: ctx.session,
@@ -557,7 +565,40 @@ export function createDashboardRouter(deps: DashboardDeps): Hono {
     }),
   );
 
+  if (deps.oauth && deps.oauthAreqKey) {
+    app.route(
+      '/oauth',
+      createOAuthConsentRouter({
+        oauth: deps.oauth,
+        areqKey: deps.oauthAreqKey,
+        sessions: deps.sessions,
+      }),
+    );
+  }
+
   return app;
+}
+
+/**
+ * Same-origin dashboard path to return to after login, or null. Restricted to
+ * the OAuth consent route — the only flow that needs return-to — so every
+ * other dashboard redirect stays the bare `/dashboard/login`.
+ */
+function safeNext(next: string | null | undefined): string | null {
+  if (!next) return null;
+  return next.startsWith('/dashboard/oauth/') ? next : null;
+}
+
+function loginWithNext(c: Context): string {
+  let target = '/dashboard/login';
+  try {
+    const u = new URL(c.req.url);
+    const next = safeNext(u.pathname + u.search);
+    if (next) target += `?next=${encodeURIComponent(next)}`;
+  } catch {
+    /* fall through to bare login */
+  }
+  return target;
 }
 
 /* ── helpers used by the Overview body ─────────────────────────── */
@@ -675,8 +716,11 @@ function systemRow(label: string, value: string, tone: 'fg' | 'lime'): SafeHtml 
   `;
 }
 
-function renderLogin(error: string | null): string {
+function renderLogin(error: string | null, next: string | null = null): string {
   const errorHtml = error ? flash({ tone: 'danger', label: 'ERROR', body: error }) : raw('');
+  const nextInput = next
+    ? raw(`<input type="hidden" name="next" value="${escape(next)}">`)
+    : raw('');
   const body = html`
     <div class="login-stage">
       <div class="left">
@@ -718,7 +762,7 @@ function renderLogin(error: string | null): string {
           class="stack"
           style="max-width:none;width:100%"
         >
-          ${errorHtml}
+          ${errorHtml}${nextInput}
           <div class="field">
             <label>Admin token</label>
             <input

--- a/apps/server/src/server/http.ts
+++ b/apps/server/src/server/http.ts
@@ -6,11 +6,18 @@ import {
 } from 'node:http';
 
 import { getRequestListener } from '@hono/node-server';
+import type { OAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import {
+  getOAuthProtectedResourceMetadataUrl,
+  mcpAuthRouter,
+} from '@modelcontextprotocol/sdk/server/auth/router.js';
+import express from 'express';
 import { Hono, type Context } from 'hono';
 
 import type { DbDiagnostics } from '../db/diagnostics.js';
 import { type McpTransportManager } from '../mcp/index.js';
 import type { AgentSessionsService } from '../services/agent-sessions.js';
+import type { OAuthService } from '../services/oauth.js';
 import type { ProjectsService } from '../services/projects.js';
 import type { TokensService } from '../services/tokens.js';
 import { REMBRIC_VERSION } from '../version.js';
@@ -57,6 +64,19 @@ export interface CreateHttpServerOptions {
   triggerConsolidation?: () => Promise<unknown>;
   /** Fire-and-forget lazy sweep, invoked after a session is created. */
   sweep?: (projectId: string | null) => void;
+  /**
+   * OAuth 2.1 authorization server. When present, the SDK `mcpAuthRouter`
+   * (a vetted Express router) is mounted for the OAuth endpoints and the
+   * `/mcp` `401` advertises the protected-resource metadata.
+   */
+  oauth?: {
+    provider: OAuthServerProvider;
+    /** OAuth service for the `/mcp` access-token fallback in `authenticate()`. */
+    service: OAuthService;
+    /** Issuer / external base URL (no trailing slash). */
+    issuer: string;
+    scopesSupported?: string[];
+  } | null;
 }
 
 export interface HttpServerHandle {
@@ -126,6 +146,25 @@ export async function startHttpServer(opts: CreateHttpServerOptions): Promise<Ht
 
   const honoListener = getRequestListener(honoApp.fetch);
 
+  // OAuth authorization server: the SDK's vetted Express router owns the
+  // protocol surface (PKCE validation, redirect/state/CSRF, metadata, DCR,
+  // rate limiting). Mounted only when OAuth is enabled. The router MUST be
+  // installed at the application root.
+  const oauthListener = opts.oauth
+    ? (() => {
+        const app = express();
+        app.use(
+          mcpAuthRouter({
+            provider: opts.oauth.provider,
+            issuerUrl: new URL(opts.oauth.issuer),
+            scopesSupported: opts.oauth.scopesSupported,
+            resourceName: 'Rembric',
+          }),
+        );
+        return app;
+      })()
+    : null;
+
   const server = createNodeServer((req, res) => {
     const rawUrl = req.url ?? '/';
     const pathname = parsePathname(rawUrl);
@@ -133,6 +172,10 @@ export async function startHttpServer(opts: CreateHttpServerOptions): Promise<Ht
       void handleMcpRequest(req, res, opts, pathname).catch((err: unknown) => {
         respondInternal(res, err);
       });
+      return;
+    }
+    if (oauthListener && isOAuthPath(pathname)) {
+      oauthListener(req, res);
       return;
     }
     void honoListener(req, res);
@@ -213,9 +256,17 @@ async function handleMcpRequest(
       pathSlug: slug,
       tokens: opts.tokens,
       projects: opts.projects,
+      oauth: opts.oauth?.service ?? null,
     });
   } catch (err) {
     if (err instanceof AuthError) {
+      // RFC 9728: advertise the protected-resource metadata so OAuth clients
+      // can discover the authorization server. Additive — static-token
+      // clients ignore the header. Only emitted when OAuth is enabled.
+      if (opts.oauth && err.status === 401) {
+        const metadataUrl = getOAuthProtectedResourceMetadataUrl(new URL(opts.oauth.issuer));
+        res.setHeader('WWW-Authenticate', `Bearer resource_metadata="${metadataUrl}"`);
+      }
       respondJson(res, err.status, { ok: false, code: err.code, message: err.message });
       return;
     }
@@ -301,6 +352,13 @@ function extractProjectSlug(pathname: string): string | undefined {
 const SLUG_RE = /^[a-zA-Z0-9_.-]+$/;
 function isValidSlug(slug: string): boolean {
   return slug.length > 0 && slug.length <= 128 && SLUG_RE.test(slug);
+}
+
+const OAUTH_EXACT_PATHS = new Set(['/authorize', '/token', '/register', '/revoke']);
+
+/** Reserved OAuth authorization-server paths handled by the SDK router. */
+function isOAuthPath(pathname: string): boolean {
+  return OAUTH_EXACT_PATHS.has(pathname) || pathname.startsWith('/.well-known/oauth-');
 }
 
 function respondJson(res: ServerResponse, status: number, body: unknown): void {

--- a/apps/server/src/server/http.ts
+++ b/apps/server/src/server/http.ts
@@ -96,6 +96,7 @@ export async function startHttpServer(opts: CreateHttpServerOptions): Promise<Ht
       tokens: opts.tokens,
       projects: opts.projects,
       diagnostics: opts.diagnostics,
+      oauth: opts.oauth?.service ?? null,
     }),
   );
   honoApp.get('/', (c) => c.redirect('/dashboard'));
@@ -114,6 +115,7 @@ export async function startHttpServer(opts: CreateHttpServerOptions): Promise<Ht
       tokens: opts.tokens,
       projects: opts.projects,
       sweep: opts.sweep,
+      oauth: opts.oauth?.service ?? null,
     }),
   );
 
@@ -200,6 +202,8 @@ export interface HealthzDeps {
   tokens: TokensService;
   projects: ProjectsService;
   diagnostics: DbDiagnostics;
+  /** OAuth access-token fallback, so /healthz auth matches /mcp. Null when OAuth is off. */
+  oauth?: OAuthService | null;
 }
 
 export function createHealthzHandler(deps: HealthzDeps) {
@@ -217,6 +221,7 @@ export function createHealthzHandler(deps: HealthzDeps) {
         pathSlug: undefined,
         tokens: deps.tokens,
         projects: deps.projects,
+        oauth: deps.oauth ?? null,
       });
       deps.diagnostics.ping();
       return c.json({ ok: true, version: REMBRIC_VERSION });

--- a/apps/server/src/server/oauth-http.test.ts
+++ b/apps/server/src/server/oauth-http.test.ts
@@ -1,0 +1,155 @@
+import { createHash, randomBytes } from 'node:crypto';
+import type { AddressInfo } from 'node:net';
+
+import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
+import express from 'express';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { OAuthRepository } from '../db/repositories/oauth-repository.js';
+import { OAuthService } from '../services/oauth.js';
+import { createTestDb, type TestDb } from '../test/db.js';
+
+import { createOAuthProvider } from './oauth-provider.js';
+
+/**
+ * End-to-end of the OAuth dance over real HTTP through the SDK's vetted
+ * authorization-server router backed by our provider. Exercises metadata
+ * discovery, Dynamic Client Registration, PKCE-validated authorization-code
+ * exchange (the SDK validates PKCE itself), and refresh rotation. The consent
+ * screen is injected here via `oauth.issueCode` (it is unit-tested on its own
+ * and needs a logged-in dashboard session, out of scope for this HTTP smoke).
+ */
+
+const TTL = { accessTtlMs: 3_600_000, refreshTtlMs: 30 * 86_400_000 };
+const REDIRECT = 'https://chatgpt.example/callback';
+
+function pkce(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString('base64url');
+  return { verifier, challenge: createHash('sha256').update(verifier).digest('base64url') };
+}
+
+describe('OAuth authorization server over HTTP (SDK router + our provider)', () => {
+  let t: TestDb;
+  let oauth: OAuthService;
+  let server: ReturnType<express.Express['listen']>;
+  let base: string;
+
+  beforeEach(async () => {
+    t = createTestDb();
+    oauth = new OAuthService({ oauth: new OAuthRepository(t.handle.db) }, TTL);
+    const provider = createOAuthProvider({
+      oauth,
+      issuer: 'http://localhost',
+      areqKey: randomBytes(32),
+    });
+    const app = express();
+    app.use(
+      mcpAuthRouter({
+        provider,
+        issuerUrl: new URL('http://localhost'),
+        scopesSupported: ['mcp', 'read'],
+        resourceName: 'Rembric',
+      }),
+    );
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, '127.0.0.1', () => resolve());
+    });
+    const port = (server.address() as AddressInfo).port;
+    base = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    t.cleanup();
+  });
+
+  async function form(path: string, fields: Record<string, string>) {
+    const res = await fetch(`${base}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams(fields).toString(),
+    });
+    return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+  }
+
+  it('publishes authorization-server metadata advertising S256 only', async () => {
+    const res = await fetch(`${base}/.well-known/oauth-authorization-server`);
+    expect(res.status).toBe(200);
+    const md = (await res.json()) as Record<string, unknown>;
+    expect(md.code_challenge_methods_supported).toEqual(['S256']);
+    expect(md.grant_types_supported).toContain('authorization_code');
+    expect(md.grant_types_supported).toContain('refresh_token');
+  });
+
+  it('registers a client, exchanges a PKCE code, and rotates the refresh token', async () => {
+    const regRes = await fetch(`${base}/register`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ redirect_uris: [REDIRECT], token_endpoint_auth_method: 'none' }),
+    });
+    expect(regRes.status).toBe(201);
+    const client = (await regRes.json()) as { client_id: string };
+    expect(client.client_id).toMatch(/^oauthc_/);
+
+    // Simulate consent approval: mint a code for the registered client.
+    const { verifier, challenge } = pkce();
+    const code = oauth.issueCode({
+      clientId: client.client_id,
+      redirectUri: REDIRECT,
+      codeChallenge: challenge,
+      scope: '*',
+      subject: 'operator',
+    });
+
+    const tok = await form('/token', {
+      grant_type: 'authorization_code',
+      code,
+      code_verifier: verifier,
+      redirect_uri: REDIRECT,
+      client_id: client.client_id,
+    });
+    expect(tok.status).toBe(200);
+    expect(tok.body.access_token).toBeTruthy();
+    expect(tok.body.token_type).toBe('Bearer');
+    const refreshToken = tok.body.refresh_token as string;
+    expect(refreshToken).toBeTruthy();
+
+    // Resolve the minted access token through the service (same path /mcp uses).
+    expect(oauth.authenticateAccessToken(tok.body.access_token as string)?.scope).toBe('*');
+
+    const refreshed = await form('/token', {
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: client.client_id,
+    });
+    expect(refreshed.status).toBe(200);
+    expect(refreshed.body.access_token).toBeTruthy();
+    expect(refreshed.body.access_token).not.toBe(tok.body.access_token);
+  });
+
+  it('rejects a token exchange with a wrong PKCE verifier (SDK validates PKCE)', async () => {
+    const regRes = await fetch(`${base}/register`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ redirect_uris: [REDIRECT], token_endpoint_auth_method: 'none' }),
+    });
+    const client = (await regRes.json()) as { client_id: string };
+    const { challenge } = pkce();
+    const code = oauth.issueCode({
+      clientId: client.client_id,
+      redirectUri: REDIRECT,
+      codeChallenge: challenge,
+      scope: '*',
+      subject: 'operator',
+    });
+    const tok = await form('/token', {
+      grant_type: 'authorization_code',
+      code,
+      code_verifier: 'wrong-verifier-entirely',
+      redirect_uri: REDIRECT,
+      client_id: client.client_id,
+    });
+    expect(tok.status).toBe(400);
+    expect(tok.body.error).toBe('invalid_grant');
+  });
+});

--- a/apps/server/src/server/oauth-provider.test.ts
+++ b/apps/server/src/server/oauth-provider.test.ts
@@ -1,0 +1,128 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+import type { Response } from 'express';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { OAuthRepository } from '../db/repositories/oauth-repository.js';
+import { OAuthService } from '../services/oauth.js';
+import { createTestDb, type TestDb } from '../test/db.js';
+
+import { createOAuthProvider } from './oauth-provider.js';
+
+const TTL = { accessTtlMs: 3_600_000, refreshTtlMs: 30 * 86_400_000 };
+const REDIRECT = 'https://chatgpt.example/callback';
+
+function pkce(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString('base64url');
+  return { verifier, challenge: createHash('sha256').update(verifier).digest('base64url') };
+}
+
+interface RedirectCapture {
+  redirected?: { status: number; url: string };
+}
+
+/** Minimal express Response stub capturing redirects (the SDK only calls redirect). */
+function resStub(): Response & RedirectCapture {
+  const capture: RedirectCapture = {};
+  const stub = {
+    redirect(status: number, url: string) {
+      capture.redirected = { status, url };
+    },
+    get redirected() {
+      return capture.redirected;
+    },
+    // Test stub: the provider only ever calls res.redirect, so a partial
+    // Response is sufficient; the cast documents that narrowing.
+  } as unknown as Response & RedirectCapture;
+  return stub;
+}
+
+describe('createOAuthProvider', () => {
+  let t: TestDb;
+  let oauth: OAuthService;
+  let provider: ReturnType<typeof createOAuthProvider>;
+
+  beforeEach(() => {
+    t = createTestDb();
+    oauth = new OAuthService({ oauth: new OAuthRepository(t.handle.db) }, TTL);
+    provider = createOAuthProvider({
+      oauth,
+      issuer: 'https://rembric.example.com',
+      areqKey: randomBytes(32),
+    });
+  });
+
+  afterEach(() => t.cleanup());
+
+  it('registers a public client and reads it back', async () => {
+    const created = await provider.clientsStore.registerClient?.({
+      redirect_uris: [REDIRECT],
+      client_name: 'ChatGPT',
+    });
+    expect(created?.client_id).toMatch(/^oauthc_/);
+    expect(created?.token_endpoint_auth_method).toBe('none');
+    const fetched = await provider.clientsStore.getClient(created!.client_id);
+    expect(fetched?.redirect_uris).toEqual([REDIRECT]);
+  });
+
+  it('authorize() redirects to the dashboard consent screen with a signed areq', async () => {
+    const res = resStub();
+    await provider.authorize(
+      { client_id: 'oauthc_x', redirect_uris: [REDIRECT] },
+      { redirectUri: REDIRECT, codeChallenge: 'ch', scopes: ['mcp'], state: 's1' },
+      res,
+    );
+    expect(res.redirected?.status).toBe(302);
+    expect(res.redirected?.url).toContain(
+      'https://rembric.example.com/dashboard/oauth/consent?areq=',
+    );
+  });
+
+  it('exchanges a code (PKCE validated upstream) into OAuthTokens and verifies the access token', async () => {
+    const client = oauth.registerClient({ redirectUris: [REDIRECT] });
+    const { challenge } = pkce();
+    const code = oauth.issueCode({
+      clientId: client.clientId,
+      redirectUri: REDIRECT,
+      codeChallenge: challenge,
+      scope: '*',
+      subject: 'operator',
+    });
+    const tokens = await provider.exchangeAuthorizationCode(
+      { client_id: client.clientId, redirect_uris: [REDIRECT] },
+      code,
+      undefined,
+      REDIRECT,
+    );
+    expect(tokens.token_type).toBe('Bearer');
+    expect(tokens.access_token).toBeTruthy();
+    expect(tokens.refresh_token).toBeTruthy();
+
+    const info = await provider.verifyAccessToken(tokens.access_token);
+    expect(info.clientId).toBe(client.clientId);
+    expect(info.scopes).toEqual(['*']);
+
+    const refreshed = await provider.exchangeRefreshToken(
+      { client_id: client.clientId, redirect_uris: [REDIRECT] },
+      tokens.refresh_token!,
+    );
+    expect(refreshed.access_token).not.toBe(tokens.access_token);
+  });
+
+  it('maps a service invalid_grant to a 400-class OAuth error (not a 500)', async () => {
+    await expect(
+      provider.exchangeAuthorizationCode(
+        { client_id: 'oauthc_x', redirect_uris: [REDIRECT] },
+        'unknown-code',
+        undefined,
+        REDIRECT,
+      ),
+    ).rejects.toMatchObject({ errorCode: 'invalid_grant' });
+  });
+
+  it('rejects an unknown access token in verifyAccessToken', async () => {
+    await expect(provider.verifyAccessToken('nope')).rejects.toMatchObject({
+      errorCode: 'invalid_token',
+    });
+  });
+});

--- a/apps/server/src/server/oauth-provider.ts
+++ b/apps/server/src/server/oauth-provider.ts
@@ -22,12 +22,7 @@ import type {
 import type { Response } from 'express';
 
 import { signAuthRequest, type AuthRequest } from '../services/oauth-areq.js';
-import {
-  OAuthError,
-  resolveGrantedScope,
-  type OAuthService,
-  type TokenPair,
-} from '../services/oauth.js';
+import { OAuthError, type OAuthService, type TokenPair } from '../services/oauth.js';
 
 /**
  * Implements the MCP SDK's `OAuthServerProvider` so the vetted SDK
@@ -103,11 +98,7 @@ export function createOAuthProvider(opts: OAuthProviderOptions): OAuthServerProv
       _client: OAuthClientInformationFull,
       authorizationCode: string,
     ): Promise<string> {
-      try {
-        return Promise.resolve(oauth.challengeForCode(authorizationCode));
-      } catch (err) {
-        return Promise.reject(toSdkError(err));
-      }
+      return settled(() => oauth.challengeForCode(authorizationCode));
     },
 
     exchangeAuthorizationCode(
@@ -116,32 +107,20 @@ export function createOAuthProvider(opts: OAuthProviderOptions): OAuthServerProv
       _codeVerifier?: string,
       redirectUri?: string,
     ): Promise<OAuthTokens> {
-      try {
-        return Promise.resolve(
-          toOAuthTokens(
-            oauth.redeemCode({
-              code: authorizationCode,
-              clientId: client.client_id,
-              redirectUri,
-            }),
-          ),
-        );
-      } catch (err) {
-        return Promise.reject(toSdkError(err));
-      }
+      return settled(() =>
+        toOAuthTokens(
+          oauth.redeemCode({ code: authorizationCode, clientId: client.client_id, redirectUri }),
+        ),
+      );
     },
 
     exchangeRefreshToken(
       client: OAuthClientInformationFull,
       refreshToken: string,
     ): Promise<OAuthTokens> {
-      try {
-        return Promise.resolve(
-          toOAuthTokens(oauth.refresh({ refreshToken, clientId: client.client_id })),
-        );
-      } catch (err) {
-        return Promise.reject(toSdkError(err));
-      }
+      return settled(() =>
+        toOAuthTokens(oauth.refresh({ refreshToken, clientId: client.client_id })),
+      );
     },
 
     verifyAccessToken(token: string): Promise<AuthInfo> {
@@ -167,9 +146,17 @@ export function createOAuthProvider(opts: OAuthProviderOptions): OAuthServerProv
   };
 }
 
-/** Default the requested scope the same way the consent screen will grant it. */
-export function defaultGrantedScope(scope: string | undefined): string {
-  return resolveGrantedScope(scope);
+/**
+ * Run a synchronous provider operation, mapping our `OAuthError` to the SDK's
+ * error classes so the token handler renders the right 400-class response
+ * (rather than a generic 500). Returns a rejected promise on failure.
+ */
+function settled<T>(fn: () => T): Promise<T> {
+  try {
+    return Promise.resolve(fn());
+  } catch (err) {
+    return Promise.reject(toSdkError(err));
+  }
 }
 
 function toClientInfo(

--- a/apps/server/src/server/oauth-provider.ts
+++ b/apps/server/src/server/oauth-provider.ts
@@ -1,0 +1,218 @@
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
+import {
+  AccessDeniedError,
+  InvalidClientError,
+  InvalidGrantError,
+  InvalidRequestError,
+  InvalidScopeError,
+  InvalidTokenError,
+  ServerError,
+  UnsupportedGrantTypeError,
+} from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import type {
+  AuthorizationParams,
+  OAuthServerProvider,
+} from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type {
+  OAuthClientInformationFull,
+  OAuthTokenRevocationRequest,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import type { Response } from 'express';
+
+import { signAuthRequest, type AuthRequest } from '../services/oauth-areq.js';
+import {
+  OAuthError,
+  resolveGrantedScope,
+  type OAuthService,
+  type TokenPair,
+} from '../services/oauth.js';
+
+/**
+ * Implements the MCP SDK's `OAuthServerProvider` so the vetted SDK
+ * authorization server (`mcpAuthRouter`) owns the protocol surface
+ * (PKCE validation, redirect/CSRF/state handling, metadata, DCR, rate
+ * limiting) while our audited `OAuthService` owns persistence and logic.
+ *
+ * `authorize()` only receives the response object, so it cannot read the
+ * operator session — it signs the SDK-validated request and redirects to the
+ * dashboard consent screen (which has session + CSRF), which finishes the
+ * flow by issuing a code.
+ */
+
+export interface OAuthProviderOptions {
+  oauth: OAuthService;
+  /** OAuth issuer / external base URL (no trailing slash). */
+  issuer: string;
+  /** HMAC key for signing the consent hand-off (derived from session secret). */
+  areqKey: Buffer;
+  /** Seconds an unconsented authorization request stays valid. */
+  consentTtlSeconds?: number;
+  now?: () => Date;
+}
+
+const CONSENT_PATH = '/dashboard/oauth/consent';
+
+export function createOAuthProvider(opts: OAuthProviderOptions): OAuthServerProvider {
+  const { oauth, issuer, areqKey } = opts;
+  const now = opts.now ?? (() => new Date());
+  const consentTtl = opts.consentTtlSeconds ?? 600;
+
+  const clientsStore: OAuthRegisteredClientsStore = {
+    getClient(clientId) {
+      const client = oauth.findClient(clientId);
+      return client
+        ? toClientInfo(client.clientId, oauth.redirectUrisFor(client), client.clientName)
+        : undefined;
+    },
+    registerClient(client) {
+      const created = oauth.registerClient({
+        clientName: client.client_name ?? null,
+        redirectUris: client.redirect_uris,
+        tokenEndpointAuthMethod: client.token_endpoint_auth_method,
+      });
+      return toClientInfo(created.clientId, oauth.redirectUrisFor(created), created.clientName);
+    },
+  };
+
+  return {
+    get clientsStore() {
+      return clientsStore;
+    },
+
+    authorize(
+      client: OAuthClientInformationFull,
+      params: AuthorizationParams,
+      res: Response,
+    ): Promise<void> {
+      const req: AuthRequest = {
+        clientId: client.client_id,
+        redirectUri: params.redirectUri,
+        codeChallenge: params.codeChallenge,
+        scope: (params.scopes ?? []).join(' '),
+        state: params.state,
+        exp: Math.floor(now().getTime() / 1000) + consentTtl,
+      };
+      const blob = signAuthRequest(req, areqKey);
+      res.redirect(302, `${issuer}${CONSENT_PATH}?areq=${encodeURIComponent(blob)}`);
+      return Promise.resolve();
+    },
+
+    challengeForAuthorizationCode(
+      _client: OAuthClientInformationFull,
+      authorizationCode: string,
+    ): Promise<string> {
+      try {
+        return Promise.resolve(oauth.challengeForCode(authorizationCode));
+      } catch (err) {
+        return Promise.reject(toSdkError(err));
+      }
+    },
+
+    exchangeAuthorizationCode(
+      client: OAuthClientInformationFull,
+      authorizationCode: string,
+      _codeVerifier?: string,
+      redirectUri?: string,
+    ): Promise<OAuthTokens> {
+      try {
+        return Promise.resolve(
+          toOAuthTokens(
+            oauth.redeemCode({
+              code: authorizationCode,
+              clientId: client.client_id,
+              redirectUri,
+            }),
+          ),
+        );
+      } catch (err) {
+        return Promise.reject(toSdkError(err));
+      }
+    },
+
+    exchangeRefreshToken(
+      client: OAuthClientInformationFull,
+      refreshToken: string,
+    ): Promise<OAuthTokens> {
+      try {
+        return Promise.resolve(
+          toOAuthTokens(oauth.refresh({ refreshToken, clientId: client.client_id })),
+        );
+      } catch (err) {
+        return Promise.reject(toSdkError(err));
+      }
+    },
+
+    verifyAccessToken(token: string): Promise<AuthInfo> {
+      const resolved = oauth.authenticateAccessToken(token);
+      if (!resolved) {
+        return Promise.reject(new InvalidTokenError('access token is invalid or expired'));
+      }
+      return Promise.resolve({
+        token,
+        clientId: resolved.clientId,
+        scopes: [resolved.scope],
+        expiresAt: resolved.expiresAtSeconds,
+      });
+    },
+
+    revokeToken(
+      _client: OAuthClientInformationFull,
+      request: OAuthTokenRevocationRequest,
+    ): Promise<void> {
+      oauth.revokeByToken(request.token);
+      return Promise.resolve();
+    },
+  };
+}
+
+/** Default the requested scope the same way the consent screen will grant it. */
+export function defaultGrantedScope(scope: string | undefined): string {
+  return resolveGrantedScope(scope);
+}
+
+function toClientInfo(
+  clientId: string,
+  redirectUris: string[],
+  clientName: string | null,
+): OAuthClientInformationFull {
+  return {
+    client_id: clientId,
+    redirect_uris: redirectUris,
+    token_endpoint_auth_method: 'none',
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    client_name: clientName ?? undefined,
+  };
+}
+
+function toOAuthTokens(pair: TokenPair): OAuthTokens {
+  return {
+    access_token: pair.accessToken,
+    token_type: 'Bearer',
+    expires_in: pair.expiresInSeconds,
+    refresh_token: pair.refreshToken,
+    scope: pair.scope,
+  };
+}
+
+function toSdkError(err: unknown): Error {
+  if (err instanceof OAuthError) {
+    switch (err.code) {
+      case 'invalid_request':
+        return new InvalidRequestError(err.message);
+      case 'invalid_client':
+        return new InvalidClientError(err.message);
+      case 'invalid_grant':
+        return new InvalidGrantError(err.message);
+      case 'invalid_scope':
+        return new InvalidScopeError(err.message);
+      case 'unsupported_grant_type':
+        return new UnsupportedGrantTypeError(err.message);
+      case 'access_denied':
+        return new AccessDeniedError(err.message);
+    }
+  }
+  return new ServerError(err instanceof Error ? err.message : 'internal error');
+}

--- a/apps/server/src/services/oauth-areq.test.ts
+++ b/apps/server/src/services/oauth-areq.test.ts
@@ -1,0 +1,52 @@
+import { randomBytes } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import { signAuthRequest, verifyAuthRequest, type AuthRequest } from './oauth-areq.js';
+
+const KEY = randomBytes(32);
+const NOW = 1_000_000_000_000;
+
+function req(overrides: Partial<AuthRequest> = {}): AuthRequest {
+  return {
+    clientId: 'oauthc_x',
+    redirectUri: 'https://chatgpt.example/cb',
+    codeChallenge: 'challenge',
+    scope: 'mcp',
+    state: 'st-123',
+    exp: Math.floor(NOW / 1000) + 600,
+    ...overrides,
+  };
+}
+
+describe('oauth-areq', () => {
+  it('round-trips a signed authorization request', () => {
+    const blob = signAuthRequest(req(), KEY);
+    const out = verifyAuthRequest(blob, KEY, NOW);
+    expect(out).not.toBeNull();
+    expect(out?.clientId).toBe('oauthc_x');
+    expect(out?.state).toBe('st-123');
+  });
+
+  it('rejects a tampered payload', () => {
+    const blob = signAuthRequest(req(), KEY);
+    const [body, sig] = blob.split('.');
+    const forged = `${body}x.${sig}`;
+    expect(verifyAuthRequest(forged, KEY, NOW)).toBeNull();
+  });
+
+  it('rejects a wrong signing key', () => {
+    const blob = signAuthRequest(req(), KEY);
+    expect(verifyAuthRequest(blob, randomBytes(32), NOW)).toBeNull();
+  });
+
+  it('rejects an expired request', () => {
+    const blob = signAuthRequest(req({ exp: Math.floor(NOW / 1000) - 1 }), KEY);
+    expect(verifyAuthRequest(blob, KEY, NOW)).toBeNull();
+  });
+
+  it('rejects a malformed blob', () => {
+    expect(verifyAuthRequest('not-a-blob', KEY, NOW)).toBeNull();
+    expect(verifyAuthRequest('', KEY, NOW)).toBeNull();
+  });
+});

--- a/apps/server/src/services/oauth-areq.ts
+++ b/apps/server/src/services/oauth-areq.ts
@@ -1,0 +1,47 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Stateless, signed hand-off of an already-SDK-validated authorization
+ * request from `provider.authorize` (which only has the response object) to
+ * the consent screen (a dashboard route with full request/session access).
+ *
+ * The payload is HMAC-signed with a key derived from the session secret, so
+ * the consent screen can trust that the client_id / redirect_uri / scope /
+ * code_challenge were validated by the SDK authorize handler and not forged.
+ * Short-lived (the `exp` field) to bound replay.
+ */
+
+export interface AuthRequest {
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  scope: string;
+  state?: string;
+  /** Expiry, seconds since epoch. */
+  exp: number;
+}
+
+export function signAuthRequest(req: AuthRequest, key: Buffer): string {
+  const body = Buffer.from(JSON.stringify(req), 'utf8').toString('base64url');
+  const sig = createHmac('sha256', key).update(body).digest('base64url');
+  return `${body}.${sig}`;
+}
+
+export function verifyAuthRequest(blob: string, key: Buffer, nowMs: number): AuthRequest | null {
+  const dot = blob.indexOf('.');
+  if (dot <= 0) return null;
+  const body = blob.slice(0, dot);
+  const sig = blob.slice(dot + 1);
+  const expected = createHmac('sha256', key).update(body).digest('base64url');
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+  let parsed: AuthRequest;
+  try {
+    parsed = JSON.parse(Buffer.from(body, 'base64url').toString('utf8')) as AuthRequest;
+  } catch {
+    return null;
+  }
+  if (typeof parsed.exp !== 'number' || parsed.exp * 1000 <= nowMs) return null;
+  return parsed;
+}

--- a/apps/server/src/services/oauth.test.ts
+++ b/apps/server/src/services/oauth.test.ts
@@ -1,0 +1,264 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { OAuthRepository } from '../db/repositories/oauth-repository.js';
+import { createTestDb, type TestDb } from '../test/db.js';
+
+import { OAuthError, OAuthService, resolveGrantedScope } from './oauth.js';
+
+const TTL = { accessTtlMs: 3_600_000, refreshTtlMs: 30 * 86_400_000 };
+
+function pkcePair(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString('base64url');
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, challenge };
+}
+
+describe('OAuthService', () => {
+  let t: TestDb;
+  let repo: OAuthRepository;
+  let clock: { now: Date };
+  let svc: OAuthService;
+
+  beforeEach(() => {
+    t = createTestDb();
+    repo = new OAuthRepository(t.handle.db);
+    clock = { now: new Date(1_000_000) };
+    svc = new OAuthService({ oauth: repo }, TTL, () => clock.now);
+  });
+
+  afterEach(() => t.cleanup());
+
+  function register(redirectUris = ['https://chatgpt.example/callback']) {
+    return svc.registerClient({ clientName: 'ChatGPT', redirectUris });
+  }
+
+  function authorize(overrides: Partial<{ challenge: string; scope: '*' | 'read:*' }> = {}) {
+    const client = register();
+    const { verifier, challenge } = pkcePair();
+    const code = svc.issueCode({
+      clientId: client.clientId,
+      redirectUri: 'https://chatgpt.example/callback',
+      codeChallenge: overrides.challenge ?? challenge,
+      scope: overrides.scope ?? '*',
+      subject: 'operator',
+    });
+    return { client, code, verifier };
+  }
+
+  describe('registerClient', () => {
+    it('creates a public client with no secret', () => {
+      const client = register();
+      expect(client.clientId).toMatch(/^oauthc_/);
+      expect(client.tokenEndpointAuthMethod).toBe('none');
+      expect(svc.redirectUrisFor(client)).toEqual(['https://chatgpt.example/callback']);
+    });
+
+    it('rejects empty redirect_uris', () => {
+      expect(() => svc.registerClient({ redirectUris: [] })).toThrow(OAuthError);
+    });
+
+    it('rejects a confidential client', () => {
+      expect(() =>
+        svc.registerClient({
+          redirectUris: ['https://x/cb'],
+          tokenEndpointAuthMethod: 'client_secret_post',
+        }),
+      ).toThrow(OAuthError);
+    });
+
+    it('rejects a non-loopback http redirect_uri (open-redirect surface)', () => {
+      expect(() => svc.registerClient({ redirectUris: ['http://evil.example/cb'] })).toThrow(
+        OAuthError,
+      );
+    });
+
+    it('allows http loopback redirect_uris', () => {
+      const client = svc.registerClient({ redirectUris: ['http://127.0.0.1:8080/cb'] });
+      expect(svc.redirectUrisFor(client)).toEqual(['http://127.0.0.1:8080/cb']);
+    });
+  });
+
+  describe('authorization code redemption', () => {
+    it('redeems a valid code for a token pair (PKCE verified upstream by the SDK)', () => {
+      const { client, code } = authorize();
+      const pair = svc.redeemCode({
+        code,
+        clientId: client.clientId,
+        redirectUri: 'https://chatgpt.example/callback',
+      });
+      expect(pair.accessToken).toBeTruthy();
+      expect(pair.refreshToken).toBeTruthy();
+      expect(pair.scope).toBe('*');
+      expect(pair.expiresInSeconds).toBe(3600);
+
+      const resolved = svc.authenticateAccessToken(pair.accessToken);
+      expect(resolved?.scope).toBe('*');
+      expect(resolved?.clientId).toBe(client.clientId);
+    });
+
+    it('exposes the stored code_challenge for the SDK token handler to verify', () => {
+      const { code } = authorize();
+      expect(svc.challengeForCode(code)).toBeTruthy();
+    });
+
+    it('challengeForCode throws on an unknown code', () => {
+      expect(() => svc.challengeForCode('nope')).toThrow(/not recognized/);
+    });
+
+    it('rejects a reused (single-use) code', () => {
+      const { client, code } = authorize();
+      const args = {
+        code,
+        clientId: client.clientId,
+        redirectUri: 'https://chatgpt.example/callback',
+      };
+      svc.redeemCode(args);
+      expect(() => svc.redeemCode(args)).toThrow(/already used/);
+    });
+
+    it('rejects an expired code', () => {
+      const { client, code } = authorize();
+      clock.now = new Date(clock.now.getTime() + 121_000);
+      expect(() =>
+        svc.redeemCode({
+          code,
+          clientId: client.clientId,
+          redirectUri: 'https://chatgpt.example/callback',
+        }),
+      ).toThrow(/expired/);
+    });
+
+    it('rejects a mismatched redirect_uri', () => {
+      const { client, code } = authorize();
+      expect(() =>
+        svc.redeemCode({
+          code,
+          clientId: client.clientId,
+          redirectUri: 'https://evil.example/cb',
+        }),
+      ).toThrow(/redirect_uri/);
+    });
+
+    it('rejects a mismatched client_id', () => {
+      const { code } = authorize();
+      expect(() =>
+        svc.redeemCode({
+          code,
+          clientId: 'oauthc_other',
+          redirectUri: 'https://chatgpt.example/callback',
+        }),
+      ).toThrow(/client_id/);
+    });
+
+    it('rejects an unknown code', () => {
+      expect(() =>
+        svc.redeemCode({
+          code: 'nope',
+          clientId: 'oauthc_x',
+          redirectUri: 'https://chatgpt.example/callback',
+        }),
+      ).toThrow(/not recognized/);
+    });
+  });
+
+  describe('refresh rotation', () => {
+    function mint() {
+      const { client, code } = authorize();
+      const pair = svc.redeemCode({
+        code,
+        clientId: client.clientId,
+        redirectUri: 'https://chatgpt.example/callback',
+      });
+      return { client, pair };
+    }
+
+    it('issues a rotated pair and invalidates the old refresh token', () => {
+      const { client, pair } = mint();
+      const next = svc.refresh({ refreshToken: pair.refreshToken, clientId: client.clientId });
+      expect(next.accessToken).not.toBe(pair.accessToken);
+      expect(next.refreshToken).not.toBe(pair.refreshToken);
+      // Old refresh now rejected.
+      expect(() =>
+        svc.refresh({ refreshToken: pair.refreshToken, clientId: client.clientId }),
+      ).toThrow(/reuse detected/);
+    });
+
+    it('revokes the whole family on refresh reuse', () => {
+      const { client, pair } = mint();
+      const next = svc.refresh({ refreshToken: pair.refreshToken, clientId: client.clientId });
+      // Reuse the consumed (original) refresh token → family revoke.
+      expect(() =>
+        svc.refresh({ refreshToken: pair.refreshToken, clientId: client.clientId }),
+      ).toThrow(/family revoked/);
+      // The access token minted by the legitimate rotation is now revoked too.
+      expect(svc.authenticateAccessToken(next.accessToken)).toBeNull();
+    });
+
+    it('rejects an expired refresh token', () => {
+      const { client, pair } = mint();
+      clock.now = new Date(clock.now.getTime() + TTL.refreshTtlMs + 1000);
+      expect(() =>
+        svc.refresh({ refreshToken: pair.refreshToken, clientId: client.clientId }),
+      ).toThrow(/expired/);
+    });
+
+    it('rejects a refresh token with a mismatched client_id', () => {
+      const { pair } = mint();
+      expect(() =>
+        svc.refresh({ refreshToken: pair.refreshToken, clientId: 'oauthc_other' }),
+      ).toThrow(/client_id/);
+    });
+  });
+
+  describe('access token resolution', () => {
+    it('returns null for an expired access token', () => {
+      const { client, code } = authorize();
+      const pair = svc.redeemCode({
+        code,
+        clientId: client.clientId,
+        redirectUri: 'https://chatgpt.example/callback',
+      });
+      clock.now = new Date(clock.now.getTime() + TTL.accessTtlMs + 1000);
+      expect(svc.authenticateAccessToken(pair.accessToken)).toBeNull();
+    });
+
+    it('returns null for an unknown token', () => {
+      expect(svc.authenticateAccessToken('not-a-token')).toBeNull();
+    });
+
+    it('does not resolve a refresh token as an access token', () => {
+      const { client, code } = authorize();
+      const pair = svc.redeemCode({
+        code,
+        clientId: client.clientId,
+        redirectUri: 'https://chatgpt.example/callback',
+      });
+      expect(svc.authenticateAccessToken(pair.refreshToken)).toBeNull();
+    });
+  });
+});
+
+describe('resolveGrantedScope', () => {
+  it('fails closed to least privilege for unknown/empty scope', () => {
+    expect(resolveGrantedScope(undefined)).toBe('read:*');
+    expect(resolveGrantedScope('')).toBe('read:*');
+    expect(resolveGrantedScope('garbage-scope')).toBe('read:*');
+  });
+
+  it('grants write only when explicitly requested', () => {
+    expect(resolveGrantedScope('mcp')).toBe('*');
+    expect(resolveGrantedScope('mcp:write')).toBe('*');
+    expect(resolveGrantedScope('*')).toBe('*');
+  });
+
+  it('maps read-only requests to read:*', () => {
+    expect(resolveGrantedScope('read')).toBe('read:*');
+    expect(resolveGrantedScope('mcp:read')).toBe('read:*');
+  });
+
+  it('grants write when both read and write are requested', () => {
+    expect(resolveGrantedScope('read mcp')).toBe('*');
+  });
+});

--- a/apps/server/src/services/oauth.ts
+++ b/apps/server/src/services/oauth.ts
@@ -1,0 +1,328 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+import { ulid } from 'ulid';
+
+import type { OAuthRepository } from '../db/repositories/oauth-repository.js';
+import type { OAuthAuthorizationCode, OAuthClient, OAuthToken } from '../db/schema/oauth.js';
+
+import type { TokenScope } from './tokens.js';
+
+/**
+ * OAuth 2.1 authorization-server logic: Dynamic Client Registration,
+ * Authorization Code + PKCE (S256) issuance and exchange, and refresh-token
+ * rotation with reuse detection.
+ *
+ * Secrets (codes, access/refresh tokens) are high-entropy random values
+ * stored only as a deterministic SHA-256 (indexed for O(1) lookup) — see
+ * design decision D1: stretching adds nothing to a 256-bit random secret,
+ * and a per-row salt would preclude lookup. The granted `scope` reuses the
+ * static `TokenScope` grammar so `isAuthorized()` applies unchanged.
+ */
+
+const SECRET_BYTES = 32;
+const CODE_TTL_MS = 120_000;
+
+export type OAuthErrorCode =
+  | 'invalid_request'
+  | 'invalid_client'
+  | 'invalid_grant'
+  | 'invalid_scope'
+  | 'unsupported_grant_type'
+  | 'access_denied';
+
+export class OAuthError extends Error {
+  constructor(
+    public readonly code: OAuthErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'OAuthError';
+  }
+}
+
+export interface RegisterClientInput {
+  clientName?: string | null;
+  redirectUris: string[];
+  tokenEndpointAuthMethod?: string;
+}
+
+export interface IssueCodeInput {
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  scope: TokenScope;
+  subject: string;
+}
+
+export interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+  expiresInSeconds: number;
+  scope: TokenScope;
+}
+
+export interface ResolvedAccessToken {
+  scope: TokenScope;
+  subject: string;
+  clientId: string;
+  /** Expiry as seconds since epoch (for AuthInfo). */
+  expiresAtSeconds: number;
+}
+
+export interface OAuthServiceOptions {
+  accessTtlMs: number;
+  refreshTtlMs: number;
+}
+
+export class OAuthService {
+  constructor(
+    private readonly repos: { oauth: OAuthRepository },
+    private readonly opts: OAuthServiceOptions,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  registerClient(input: RegisterClientInput): OAuthClient {
+    if (input.redirectUris.length === 0) {
+      throw new OAuthError('invalid_request', 'at least one redirect_uri is required');
+    }
+    for (const uri of input.redirectUris) {
+      if (!isAllowedRedirectUri(uri)) {
+        throw new OAuthError(
+          'invalid_request',
+          `redirect_uri '${uri}' must be https (or http loopback)`,
+        );
+      }
+    }
+    const authMethod = input.tokenEndpointAuthMethod ?? 'none';
+    if (authMethod !== 'none') {
+      throw new OAuthError(
+        'invalid_request',
+        'only public clients (token_endpoint_auth_method=none) are supported',
+      );
+    }
+    const ts = this.now();
+    const row = this.repos.oauth.insertClient({
+      clientId: `oauthc_${ulid(ts.getTime())}`,
+      clientName: input.clientName ?? null,
+      redirectUris: JSON.stringify(input.redirectUris),
+      tokenEndpointAuthMethod: authMethod,
+      createdAt: ts,
+    });
+    if (!row) throw new OAuthError('invalid_request', 'client registration failed');
+    return row;
+  }
+
+  findClient(clientId: string): OAuthClient | undefined {
+    return this.repos.oauth.findClient(clientId);
+  }
+
+  redirectUrisFor(client: OAuthClient): string[] {
+    try {
+      const parsed: unknown = JSON.parse(client.redirectUris);
+      return Array.isArray(parsed) ? parsed.filter((u): u is string => typeof u === 'string') : [];
+    } catch {
+      return [];
+    }
+  }
+
+  /** Issue a single-use authorization code; returns the plaintext code. */
+  issueCode(input: IssueCodeInput): string {
+    const ts = this.now();
+    const secret = generateSecret();
+    const row = this.repos.oauth.insertCode({
+      id: ulid(ts.getTime()),
+      hash: hashSecret(secret),
+      clientId: input.clientId,
+      redirectUri: input.redirectUri,
+      codeChallenge: input.codeChallenge,
+      scope: input.scope,
+      subject: input.subject,
+      expiresAt: new Date(ts.getTime() + CODE_TTL_MS),
+      consumedAt: null,
+      createdAt: ts,
+    });
+    if (!row) throw new OAuthError('invalid_request', 'failed to issue authorization code');
+    return secret;
+  }
+
+  /**
+   * Return the PKCE `code_challenge` bound to an unconsumed, unexpired code.
+   * Used by the SDK token handler to validate PKCE itself (it then calls
+   * `redeemCode`). Throws `invalid_grant` on any miss.
+   */
+  challengeForCode(code: string): string {
+    return this.findValidCode(code).codeChallenge;
+  }
+
+  /**
+   * Bind-check + atomic single-use consume + issue a token pair. PKCE is
+   * verified upstream by the SDK token handler (via `challengeForCode` +
+   * `pkce-challenge`), so it is not re-checked here.
+   */
+  redeemCode(input: { code: string; clientId: string; redirectUri?: string }): TokenPair {
+    const code = this.findValidCode(input.code);
+    if (code.clientId !== input.clientId) {
+      throw new OAuthError('invalid_grant', 'client_id does not match the authorization code');
+    }
+    if (input.redirectUri !== undefined && code.redirectUri !== input.redirectUri) {
+      throw new OAuthError('invalid_grant', 'redirect_uri does not match the authorization code');
+    }
+    // Atomic single-use: only the first redemption flips consumed_at.
+    if (this.repos.oauth.consumeCode(code.id, this.now()) === 0) {
+      throw new OAuthError('invalid_grant', 'authorization code already used');
+    }
+    return this.issueTokenPair({
+      clientId: code.clientId,
+      familyId: `oauthf_${ulid(this.now().getTime())}`,
+      scope: code.scope as TokenScope,
+      subject: code.subject,
+    });
+  }
+
+  private findValidCode(code: string): OAuthAuthorizationCode {
+    const row = this.repos.oauth.findCodeByHash(hashSecret(code));
+    if (!row) throw new OAuthError('invalid_grant', 'authorization code not recognized');
+    if (row.consumedAt) throw new OAuthError('invalid_grant', 'authorization code already used');
+    if (row.expiresAt.getTime() <= this.now().getTime()) {
+      throw new OAuthError('invalid_grant', 'authorization code expired');
+    }
+    return row;
+  }
+
+  refresh(input: { refreshToken: string; clientId: string }): TokenPair {
+    const refresh = this.repos.oauth.findTokenByHash(hashSecret(input.refreshToken), 'refresh');
+    if (!refresh) throw new OAuthError('invalid_grant', 'refresh token not recognized');
+    if (refresh.revokedAt) {
+      throw new OAuthError('invalid_grant', 'refresh token revoked');
+    }
+    if (refresh.rotatedAt) {
+      // Reuse of an already-rotated refresh token ⇒ treat as compromise.
+      this.repos.oauth.revokeFamily(refresh.familyId, this.now());
+      throw new OAuthError('invalid_grant', 'refresh token reuse detected; token family revoked');
+    }
+    if (refresh.clientId !== input.clientId) {
+      throw new OAuthError('invalid_grant', 'client_id does not match the refresh token');
+    }
+    if (refresh.expiresAt.getTime() <= this.now().getTime()) {
+      throw new OAuthError('invalid_grant', 'refresh token expired');
+    }
+    if (this.repos.oauth.markRefreshRotated(refresh.id, this.now()) === 0) {
+      // Lost the race to another concurrent refresh of the same token.
+      this.repos.oauth.revokeFamily(refresh.familyId, this.now());
+      throw new OAuthError('invalid_grant', 'refresh token reuse detected; token family revoked');
+    }
+    return this.issueTokenPair({
+      clientId: refresh.clientId,
+      familyId: refresh.familyId,
+      scope: refresh.scope as TokenScope,
+      subject: refresh.subject,
+    });
+  }
+
+  /** Resolve an access token presented as a bearer; null if not a valid OAuth access token. */
+  authenticateAccessToken(plaintext: string): ResolvedAccessToken | null {
+    const token = this.repos.oauth.findTokenByHash(hashSecret(plaintext), 'access');
+    if (!token) return null;
+    if (token.revokedAt) return null;
+    if (token.expiresAt.getTime() <= this.now().getTime()) return null;
+    return {
+      scope: token.scope as TokenScope,
+      subject: token.subject,
+      clientId: token.clientId,
+      expiresAtSeconds: Math.floor(token.expiresAt.getTime() / 1000),
+    };
+  }
+
+  /** Revoke the token family that a given access or refresh token belongs to. */
+  revokeByToken(plaintext: string): void {
+    const hash = hashSecret(plaintext);
+    const token =
+      this.repos.oauth.findTokenByHash(hash, 'access') ??
+      this.repos.oauth.findTokenByHash(hash, 'refresh');
+    if (token) this.repos.oauth.revokeFamily(token.familyId, this.now());
+  }
+
+  private issueTokenPair(input: {
+    clientId: string;
+    familyId: string;
+    scope: TokenScope;
+    subject: string;
+  }): TokenPair {
+    const accessSecret = generateSecret();
+    const refreshSecret = generateSecret();
+    this.insertToken('access', accessSecret, input, this.opts.accessTtlMs);
+    this.insertToken('refresh', refreshSecret, input, this.opts.refreshTtlMs);
+    return {
+      accessToken: accessSecret,
+      refreshToken: refreshSecret,
+      expiresInSeconds: Math.floor(this.opts.accessTtlMs / 1000),
+      scope: input.scope,
+    };
+  }
+
+  private insertToken(
+    kind: 'access' | 'refresh',
+    secret: string,
+    grant: { clientId: string; familyId: string; scope: TokenScope; subject: string },
+    ttlMs: number,
+  ): OAuthToken {
+    const ts = this.now();
+    const row = this.repos.oauth.insertToken({
+      id: ulid(ts.getTime()),
+      kind,
+      hash: hashSecret(secret),
+      clientId: grant.clientId,
+      familyId: grant.familyId,
+      scope: grant.scope,
+      subject: grant.subject,
+      expiresAt: new Date(ts.getTime() + ttlMs),
+      rotatedAt: null,
+      revokedAt: null,
+      createdAt: ts,
+    });
+    if (!row) throw new OAuthError('invalid_request', `failed to issue ${kind} token`);
+    return row;
+  }
+}
+
+/**
+ * Map a requested OAuth `scope` string to the existing `TokenScope` grammar.
+ * Fail-closed: write access (`*`) is granted ONLY when explicitly requested;
+ * an unknown, empty, or read-only request yields least privilege (`read:*`).
+ * The consent screen is authoritative and may downgrade further. Project
+ * restriction comes from the connector path (`/mcp/<slug>`), not the scope
+ * string (design D7).
+ */
+export function resolveGrantedScope(requestedScope: string | undefined): TokenScope {
+  const tokens = (requestedScope ?? '').toLowerCase().split(/\s+/).filter(Boolean);
+  const wantsWrite = tokens.some(
+    (t) => t === '*' || t === 'mcp' || t === 'mcp:write' || t.endsWith(':write'),
+  );
+  return wantsWrite ? '*' : 'read:*';
+}
+
+function generateSecret(): string {
+  return randomBytes(SECRET_BYTES).toString('base64url');
+}
+
+function hashSecret(plaintext: string): string {
+  return createHash('sha256').update(plaintext).digest('hex');
+}
+
+/**
+ * Registrable redirect URIs are https, or http only for loopback (RFC 8252
+ * native-client guidance). Arbitrary `http://` hosts are rejected to close
+ * the open-redirect surface.
+ */
+function isAllowedRedirectUri(value: string): boolean {
+  try {
+    const u = new URL(value);
+    if (u.protocol === 'https:') return true;
+    if (u.protocol === 'http:') {
+      return u.hostname === '127.0.0.1' || u.hostname === '::1' || u.hostname === 'localhost';
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}

--- a/apps/server/src/services/tokens.ts
+++ b/apps/server/src/services/tokens.ts
@@ -210,3 +210,8 @@ export function isAuthorized(
 export function deriveSessionKey(baseSecret: string): Buffer {
   return createHmac('sha256', baseSecret).update('rembric:session').digest();
 }
+
+/** Derive a distinct HMAC key for signing the OAuth consent hand-off. */
+export function deriveOAuthAreqKey(baseSecret: string): Buffer {
+  return createHmac('sha256', baseSecret).update('rembric:oauth-areq').digest();
+}

--- a/apps/server/src/test/invariants.test.ts
+++ b/apps/server/src/test/invariants.test.ts
@@ -688,3 +688,29 @@ describe('migration runner FK-safety invariant', () => {
     expect(finallyBlock, 'expected a finally block that re-enables foreign_keys').not.toBeNull();
   });
 });
+
+describe('oauth additive-migration invariant', () => {
+  // The OAuth change promises the static `tokens` table is untouched and the
+  // OAuth migration is purely additive (CREATE TABLE only — no rebuild dance).
+  const oauthMigration = readFileSync(join(srcRoot, 'db/migrations/0013_oauth_tables.sql'), 'utf8');
+
+  it('0013 never DROPs or ALTERs the static `tokens` table', () => {
+    expect(/\b(DROP|ALTER)\s+TABLE\s+tokens\b/i.test(oauthMigration)).toBe(false);
+  });
+
+  it('0013 is additive: only CREATE TABLE / CREATE INDEX statements', () => {
+    const statements = oauthMigration
+      .split(/-->\s*statement-breakpoint/)
+      .map((s) =>
+        s
+          .split('\n')
+          .filter((l) => !l.trim().startsWith('--'))
+          .join('\n')
+          .trim(),
+      )
+      .filter((s) => s.length > 0);
+    for (const stmt of statements) {
+      expect(/^CREATE\s+(TABLE|INDEX)\b/i.test(stmt), `non-additive statement: ${stmt}`).toBe(true);
+    }
+  });
+});

--- a/apps/server/src/test/oauth-e2e.test.ts
+++ b/apps/server/src/test/oauth-e2e.test.ts
@@ -186,9 +186,15 @@ describe('OAuth local E2E (live server)', () => {
     const tokens = (await tokenRes.json()) as { access_token: string; refresh_token: string };
     expect(tokens.access_token).toBeTruthy();
 
-    // 8. The minted access token authenticates /mcp (not 401).
+    // 8. The minted access token authenticates /mcp (not 401)...
     const mcp = await mcpStatus(tokens.access_token);
     expect(mcp.status).not.toBe(401);
+
+    // ...and /healthz too — auth is unified across bearer surfaces, not /mcp-only.
+    const health = await fetch(`${base}/healthz`, {
+      headers: { authorization: `Bearer ${tokens.access_token}` },
+    });
+    expect(health.status).toBe(200);
 
     // 9. Refresh rotates to a new access token.
     const refresh = await fetch(`${base}/token`, {

--- a/apps/server/src/test/oauth-e2e.test.ts
+++ b/apps/server/src/test/oauth-e2e.test.ts
@@ -1,0 +1,207 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { createServer as createNetServer } from 'node:net';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { type BootstrappedServer, createServer } from '../server/index.js';
+
+import { createTestDb } from './db.js';
+import { FakeEmbedder } from './embedder.js';
+
+/**
+ * Local OAuth 2.1 end-to-end against a live server (no ChatGPT, no Docker,
+ * no browser). Boots the real HTTP surface with OAuth enabled on a loopback
+ * issuer and drives the full dance over `fetch`:
+ *
+ *   register → authorize → dashboard login → consent approve → token
+ *   → use the minted access token on /mcp
+ *
+ * Plus: the static-token path still authenticates /mcp, and an
+ * unauthenticated /mcp 401 advertises the protected-resource metadata.
+ */
+
+const ADMIN_TOKEN = 'oauth-e2e-admin-token-with-enough-entropy-xyz';
+const REDIRECT = 'https://chatgpt.example/callback';
+
+async function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const sock = createNetServer();
+    sock.unref();
+    sock.on('error', reject);
+    sock.listen(0, '127.0.0.1', () => {
+      const addr = sock.address();
+      if (!addr || typeof addr === 'string') {
+        sock.close();
+        reject(new Error('expected AddressInfo'));
+        return;
+      }
+      const p = addr.port;
+      sock.close(() => resolve(p));
+    });
+  });
+}
+
+function pkce(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString('base64url');
+  return { verifier, challenge: createHash('sha256').update(verifier).digest('base64url') };
+}
+
+describe('OAuth local E2E (live server)', () => {
+  let server: BootstrappedServer;
+  let base: string;
+
+  beforeAll(async () => {
+    const tmp = createTestDb();
+    tmp.cleanup();
+    const port = await findFreePort();
+    base = `http://127.0.0.1:${port}`;
+    server = await createServer(
+      {
+        REMBRIC_HOST: '127.0.0.1',
+        REMBRIC_PORT: String(port),
+        REMBRIC_DATA_DIR: tmp.dataDir,
+        REMBRIC_ADMIN_TOKEN: ADMIN_TOKEN,
+        REMBRIC_PUBLIC_URL: base,
+        REMBRIC_UPDATE_CHECK: 'off',
+      },
+      { embedder: new FakeEmbedder() },
+    );
+  }, 30_000);
+
+  afterAll(async () => {
+    await server.shutdown();
+  });
+
+  async function mcpStatus(token?: string): Promise<Response> {
+    return fetch(`${base}/mcp`, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'e2e', version: '0' },
+        },
+      }),
+    });
+  }
+
+  it('unauthenticated /mcp returns 401 advertising the protected-resource metadata', async () => {
+    const res = await mcpStatus();
+    expect(res.status).toBe(401);
+    expect(res.headers.get('www-authenticate')).toContain(
+      `resource_metadata="${base}/.well-known/oauth-protected-resource"`,
+    );
+  });
+
+  it('static admin token still authenticates /mcp (not 401)', async () => {
+    const res = await mcpStatus(ADMIN_TOKEN);
+    expect(res.status).not.toBe(401);
+  });
+
+  it('drives the full OAuth dance and the minted access token authenticates /mcp', async () => {
+    // 1. Discovery.
+    const meta = await fetch(`${base}/.well-known/oauth-authorization-server`);
+    expect(meta.status).toBe(200);
+
+    // 2. Dynamic Client Registration.
+    const reg = await fetch(`${base}/register`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ redirect_uris: [REDIRECT], token_endpoint_auth_method: 'none' }),
+    });
+    expect(reg.status).toBe(201);
+    const { client_id: clientId } = (await reg.json()) as { client_id: string };
+
+    // 3. Authorize → redirect to the dashboard consent screen.
+    const { verifier, challenge } = pkce();
+    const authUrl =
+      `${base}/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}` +
+      `&redirect_uri=${encodeURIComponent(REDIRECT)}&code_challenge=${challenge}` +
+      `&code_challenge_method=S256&scope=mcp&state=xyz`;
+    const authRes = await fetch(authUrl, { method: 'GET', redirect: 'manual' });
+    expect(authRes.status).toBe(302);
+    const consentUrl = new URL(authRes.headers.get('location') ?? '');
+    expect(consentUrl.pathname).toBe('/dashboard/oauth/consent');
+    const areq = consentUrl.searchParams.get('areq')!;
+    expect(areq).toBeTruthy();
+
+    // 4. Operator login (dashboard session cookie).
+    const login = await fetch(`${base}/dashboard/login`, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ token: ADMIN_TOKEN }).toString(),
+    });
+    const cookie = (login.headers.get('set-cookie') ?? '').split(';')[0] ?? '';
+    expect(cookie).toContain('rembric_session=');
+
+    // 5. Load the consent screen, extract the CSRF token.
+    const consentPage = await fetch(
+      `${base}/dashboard/oauth/consent?areq=${encodeURIComponent(areq)}`,
+      {
+        headers: { cookie },
+      },
+    );
+    expect(consentPage.status).toBe(200);
+    const html = await consentPage.text();
+    const csrf = /name="csrf" value="([^"]+)"/.exec(html)?.[1];
+    expect(csrf).toBeTruthy();
+
+    // 6. Approve consent → redirect to the client with an authorization code.
+    const approve = await fetch(`${base}/dashboard/oauth/consent`, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: { cookie, 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ areq, decision: 'approve', csrf: csrf! }).toString(),
+    });
+    expect(approve.status).toBe(302);
+    const back = new URL(approve.headers.get('location') ?? '');
+    expect(`${back.origin}${back.pathname}`).toBe(REDIRECT);
+    expect(back.searchParams.get('state')).toBe('xyz');
+    const code = back.searchParams.get('code')!;
+    expect(code).toBeTruthy();
+
+    // 7. Exchange the code for tokens (SDK validates PKCE).
+    const tokenRes = await fetch(`${base}/token`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        code_verifier: verifier,
+        redirect_uri: REDIRECT,
+        client_id: clientId,
+      }).toString(),
+    });
+    expect(tokenRes.status).toBe(200);
+    const tokens = (await tokenRes.json()) as { access_token: string; refresh_token: string };
+    expect(tokens.access_token).toBeTruthy();
+
+    // 8. The minted access token authenticates /mcp (not 401).
+    const mcp = await mcpStatus(tokens.access_token);
+    expect(mcp.status).not.toBe(401);
+
+    // 9. Refresh rotates to a new access token.
+    const refresh = await fetch(`${base}/token`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: tokens.refresh_token,
+        client_id: clientId,
+      }).toString(),
+    });
+    expect(refresh.status).toBe(200);
+    const rotated = (await refresh.json()) as { access_token: string };
+    expect(rotated.access_token).not.toBe(tokens.access_token);
+  }, 20_000);
+});

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -20,6 +20,8 @@ Header: Authorization: Bearer <agent-token>
 
 Mint per-agent tokens from the dashboard at `/dashboard/tokens`. Plaintext shown exactly once.
 
+**OAuth 2.1 — no static token.** OAuth-capable clients (Claude Code as a remote MCP server, ChatGPT custom connectors) can connect without minting a token: set `REMBRIC_PUBLIC_URL` (the https issuer; `http://localhost` allowed for local testing) and the server runs the authorization-code + PKCE flow itself. The client points at the same `…/mcp[/<slug>]` URL with **no `Authorization` header**; the first connect opens a consent screen where you sign in with the admin token and approve, after which the client manages the token (refresh included). It is off unless `REMBRIC_PUBLIC_URL` is set, and the static-token path above is unchanged — both kinds of token authenticate `/mcp` identically.
+
 The MCP server emits a short `instructions` block at handshake teaching the proactive-save protocol (when to save, when to call `memory.judge`, when to call `memory.session_summary`). Clients that support `initialize.instructions` (Claude Code, Codex CLI) inject it into the system prompt. Other clients still get the same protocol via each tool's description.
 
 ## Reading prior context

--- a/openspec/changes/archive/2026-06-15-oauth2-resource-server-for-remote-mcp/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-15-oauth2-resource-server-for-remote-mcp/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/archive/2026-06-15-oauth2-resource-server-for-remote-mcp/design.md
+++ b/openspec/changes/archive/2026-06-15-oauth2-resource-server-for-remote-mcp/design.md
@@ -1,0 +1,123 @@
+## Context
+
+Rembric authenticates `/mcp` with operator-issued static bearer tokens (`TokensService`, `apps/server/src/services/tokens.ts`): a high-entropy secret, scrypt-hashed at rest, resolved by linear scan + constant-time compare into a `{ token, scope }`. Scope grammar is `*` | `read:*` | `project:<id>` | `read:project:<id>`. The HTTP surface is Hono (`apps/server/src/server/http.ts` + `api-router.ts`); the MCP transport is Streamable HTTP behind `authenticate()` in `apps/server/src/server/auth.ts`.
+
+ChatGPT custom connectors (and the broader remote-MCP client ecosystem) will not accept a pasted static token — they require an OAuth 2.1 Authorization Code + PKCE handshake per the MCP authorization spec, after which ChatGPT itself mints and carries the access token as `Authorization: Bearer`. To be reachable as a connector, Rembric must speak that handshake while remaining a single self-hosted process backed by one SQLite file. This design is scoped to **single-tenant private use**: one operator, their own instance. Multi-tenant SaaS and public-directory submission are explicitly out.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Speak OAuth 2.1 (Authorization Code + PKCE `S256`, Dynamic Client Registration, refresh rotation, metadata discovery) well enough for a ChatGPT custom connector to attach.
+- Keep the static operator-token path **byte-for-byte unchanged** in behavior; OAuth is purely additive.
+- Stay self-contained: in-process, same SQLite, **zero new runtime services and ideally zero new dependencies** (Node `crypto` covers PKCE, randomness, hashing, HMAC signing).
+- Preserve all load-bearing invariants: append-only memory, scope-at-service-layer, `topic_key`, judgment freshness, and the `/mcp` vs `/mcp/<slug>` path-scoping contract.
+- Honor the existing `auth` spec's hard requirements: tokens hashed at rest, **immediate revocation** (no TTL cache), no plaintext in logs.
+
+**Non-Goals:**
+
+- Multi-tenant accounts / user management / signup / password reset.
+- Public ChatGPT app-directory submission (would force a hosted multi-tenant pivot).
+- Apps SDK UI widgets / embedded HTML components.
+- Machine-to-machine grants (client_credentials), confidential clients with secrets, mTLS — ChatGPT does not use them and single-tenant does not need them.
+
+## Decisions
+
+### D1 — Opaque, hashed, DB-validated access tokens (NOT JWT)
+
+OAuth access & refresh tokens are high-entropy random secrets, scrypt-hashed at rest exactly like static tokens, and validated by DB lookup.
+
+- _Why:_ The `auth` spec mandates **immediate revocation with no TTL cache**. Self-contained JWTs cannot be revoked before expiry without a denylist — which is just a DB lookup, so JWT buys nothing and adds a JWKS endpoint + signing-key rotation surface. Opaque tokens give the immediate-revocation guarantee for free.
+- **Hashing scheme — deterministic SHA-256, NOT salted scrypt.** OAuth secrets (codes, access/refresh tokens) are hashed with a single-pass SHA-256 stored in an _indexed_ column, enabling O(1) lookup by token value. This differs from the static `tokens` table (salted scrypt + linear scan): (a) static tokens are few (<100) so a scan is fine, but OAuth issues a fresh pair on every refresh, so a salted-scrypt linear scan over many short-lived rows would be both slow and (with per-row random salts) impossible to index; (b) scrypt/argon stretching exists to defend _low-entropy_ operator-chosen secrets — it adds nothing to a 256-bit random token, for which SHA-256 is the standard, sufficient at-rest hash (this is how mainstream OAuth servers store opaque tokens). The `auth` spec's "hashed at rest, never plaintext" requirement is fully satisfied.
+- _Alternative considered:_ Signed JWT access tokens with a JWKS endpoint. Rejected: revocation complexity, key management, larger attack surface, no benefit for a single resource server validating its own tokens.
+- _Alternative considered:_ Reuse salted-scrypt `hashToken`/`verifyToken` for OAuth too. Rejected: precludes indexed lookup and imposes a deliberately-expensive KDF on a hot path that gains no security for high-entropy secrets.
+
+### D2 — Sibling tables, static `tokens` table untouched
+
+Add `oauth_clients`, `oauth_authorization_codes`, and `oauth_tokens` (access + refresh discriminated by a `kind` column) as **new tables**. The existing `tokens` table and its rows are not altered.
+
+- _Why:_ Static operator tokens are few, long-lived, uniquely named, and surfaced in the dashboard token list. OAuth tokens are many, short-lived, anonymous, and machine-minted — mixing them would pollute the operator UI and collide with the `name` uniqueness constraint. Separate tables keep the static path literally unchanged and mean the migration is **additive `CREATE TABLE` only** — no `tokens` rebuild, so no FK-drop dance.
+- _Validation stays unified:_ `authenticate()` tries the static `tokens` path first (unchanged), then falls back to `oauth_tokens` access-token lookup. Both return the same `{ token-like, scope }` shape so everything downstream is identical.
+- _Alternative considered:_ One `tokens` table + a `kind` column. Rejected: forces a table rebuild (CHECK/NOT NULL via the SQLite rebuild dance, FK-drop risk), pollutes the operator dashboard, and risks regressing the static path the change promises to leave alone.
+
+### D3 — OAuth is opt-in via `REMBRIC_PUBLIC_URL`; absent ⇒ feature fully dark
+
+The authorization server is enabled **iff** `REMBRIC_PUBLIC_URL` is set (it is the OAuth `issuer` and the base for all absolute metadata URLs). When unset: no `/.well-known/*`, no `/authorize`, no `/token`, no `/register`, and the `/mcp` `401` does **not** emit `WWW-Authenticate` — i.e. existing operators see zero behavior change.
+
+- _Why:_ OAuth metadata requires an absolute, externally-correct issuer URL that the server cannot infer behind a proxy/tunnel from `HOST:PORT`. Gating on its presence makes the feature strictly opt-in and keeps the blast radius zero for current deployments.
+- _Alternative considered:_ Always-on, infer issuer from `Host` header. Rejected: `Host` is attacker-controllable and unreliable behind proxies; a wrong issuer silently breaks the handshake and is a known OAuth footgun.
+
+### D4 — Single-user login reuses the dashboard session; consent is one screen
+
+`/authorize` authenticates the human by **reusing the existing signed, revocable dashboard session** (`dashboard_sessions`). If the operator is not logged in, they are bounced to `/dashboard/login` (existing flow) and returned. Once authenticated, a single consent screen shows the requesting client + requested scope and lets the operator confirm and pick the granted scope.
+
+- _Why:_ The dashboard session is already signed, httpOnly, and revocable per the `auth` spec — reusing it means **no new credential, no new login surface**. Consent is a genuine OAuth requirement and a one-screen form.
+- _Alternative considered:_ A dedicated login form accepting `REMBRIC_ADMIN_TOKEN`. Kept as a documented fallback only; the dashboard session is primary because it already satisfies the spec's signing/revocation requirements.
+- **Login identity ≠ granted scope.** The credential the operator authenticates _with_ (dashboard session or the `*`-scoped admin token) only proves they are the operator and therefore may grant _any_ scope. It does NOT propagate its own scope into the minted token: the access token issued to the client carries the scope chosen at consent (D7), which can be narrower (`read:*`, `project:<id>`) than the admin's `*`. The admin token never reaches the client.
+
+### D5 — PKCE `S256` mandatory; public client; DCR with `token_endpoint_auth_method: none`
+
+`/authorize` rejects requests without a `code_challenge`; only `S256` is accepted (`plain` rejected). `/register` issues a public `client_id` with no secret. Authorization codes are single-use, short-TTL (~60s), bound to the `code_challenge`, redirect URI, and granted scope.
+
+- _Why:_ ChatGPT is a public client and uses PKCE; `S256`-only and single-use codes close the interception/replay vectors. No client secret to store or leak.
+- _Alternative considered:_ Allow `plain` PKCE / confidential clients. Rejected: weaker, unnecessary for the target client.
+
+### D6 — Refresh-token rotation with reuse detection
+
+`/token` with `grant_type=refresh_token` issues a new access token **and a new refresh token**, marking the presented refresh token consumed (`rotatedAt`). Presenting an already-rotated refresh token is treated as compromise: the token family is revoked.
+
+- _Why:_ Rotation + reuse detection is the OAuth 2.1 BCP for public clients; a stolen-and-replayed refresh token gets the whole family killed.
+- _Trade-off:_ A client that races two refreshes can self-revoke. Accepted — ChatGPT serializes refreshes; the safety property is worth the rare edge.
+
+### D7 — OAuth scope ⇄ existing `TokenScope` grammar; path-scoping unchanged
+
+Requested OAuth scope strings map to the existing grammar at consent time: a full-access grant → `*`, a read-only grant → `read:*`. Project restriction continues to come from the connector's request **path** (`/mcp/<slug>`) via the existing path-scoping contract — the OAuth token's scope is layered on top exactly as a static token's scope is today.
+
+- _Why:_ Reuses `isAuthorized()` verbatim; no second authorization model. The protected-resource metadata is served for both `/mcp` and `/mcp/<slug>` so a path-scoped connector discovers the same issuer.
+- **Per-project in practice = one connector per project.** ChatGPT's `server_url` may include a path, so a connector pointed at `/mcp/<slug>` is confined to that project by the path-scoping contract regardless of the token's scope (an `*`-scoped OAuth token on `/mcp/foo` still only touches `foo`). The clean per-project story is therefore one ChatGPT connector per `/mcp/<slug>`, each running its own OAuth and receiving its own access token.
+- _Alternative considered:_ Encoding the project into the OAuth scope (`project:<id>`). Deferred: the path already carries it and is the canonical source; duplicating it invites drift. Left as a future extension if a client needs project selection at consent.
+
+## Risks / Trade-offs
+
+- **[Risk] OAuth is the most security-critical surface in the repo; a subtle bug is a breach (PKCE bypass, non-rotating refresh, code replay).** → Exhaustive negative tests are first-class deliverables, not afterthoughts: tampered/missing `code_verifier`, `plain` challenge rejection, code single-use, expired code, refresh reuse → family revoke, expired/revoked access token, cross-client code use. Opaque-token + DB-validation design keeps the surface small and reuses audited `crypto` primitives.
+- **[Risk] Regressing the static-token path while adding the OAuth fork in `authenticate()`.** → Sibling-table design (D2) means the static path is not edited, only fronted; an invariant test asserts a static token still authenticates and an OAuth/static token cannot be confused. The full existing `auth`/`tokens` test suite must stay green.
+- **[Risk] Wrong issuer URL silently breaks the handshake (proxy/tunnel mismatch).** → `REMBRIC_PUBLIC_URL` is explicit and required to enable OAuth (D3); metadata is generated from it; a startup log line echoes the resolved issuer; docs call out TLS/reachability.
+- **[Risk] New routes collide with `/mcp` path-scoping or dashboard routes.** → OAuth routes live at fixed, reserved paths (`/.well-known/oauth-*`, `/authorize`, `/token`, `/register`); a routing test asserts `/mcp` and `/mcp/<slug>` behavior is unchanged and that `<slug>` cannot shadow a reserved path.
+- **[Trade-off] Maintaining an OAuth AS tracks the evolving MCP authorization spec and ChatGPT's expectations.** → Accepted because OAuth 2.1 on remote MCP is an emerging cross-client standard worth owning; scope is held to single-tenant to cap the surface.
+- **[Trade-off] Expired OAuth rows accumulate (no append-only purge applies to `oauth_*` tables).** → Accepted; a lightweight prune of expired/rotated rows is optional and out of scope for this change. Rejection is by `expiresAt`/`rotatedAt` check, so stale rows are inert.
+
+## Migration Plan
+
+1. Additive migration: `CREATE TABLE oauth_clients`, `oauth_authorization_codes`, `oauth_tokens` (+ indexes). No change to `tokens`, so no FK-drop dance.
+2. Ship behind the `REMBRIC_PUBLIC_URL` gate (D3) — deploying the new image with the env unset is a no-op for existing operators.
+3. Rollback: unset `REMBRIC_PUBLIC_URL` to disable the surface immediately; the new tables are inert when empty. A full revert drops the additive tables (safe — no parent FKs into them from existing data).
+
+### D8 — Endpoint-phase security requirements (from the security review)
+
+The service layer uses only standard primitives (CSPRNG, SHA-256, `timingSafeEqual`, RFC 7636 S256) and was independently audited; the issues found there were fixed (scope now fails _closed_ to `read:*`; `redirect_uri` registration restricted to https + loopback per RFC 8252; schema hashing docstring corrected). The remaining risk lives in the HTTP endpoints (group 5), which MUST implement:
+
+- **/authorize**: reject `code_challenge_method != S256` and any missing/empty `code_challenge`; validate `code_verifier`/`code_challenge` length+charset (RFC 7636 §4.1, 43–128 unreserved); **exact-match** `redirect_uri` against the registered set; **never** redirect an error to an unvalidated `redirect_uri`; round-trip the client `state` parameter (client CSRF); the consent form itself MUST carry its own CSRF token tied to the dashboard session.
+- **/token & /authorize**: never log `code`, `code_verifier`, or tokens.
+- **/register & /token**: apply the existing per-token rate limiter (open DCR + token endpoint are abuse surfaces).
+- Consider consuming/invalidating the authorization code on a PKCE-failed exchange (defense-in-depth; weigh against an attacker-burns-code DoS — PKCE already protects confidentiality, so this is optional).
+
+### D9 — Audience/resource binding (RFC 8707) — explicit decision
+
+OAuth tokens are NOT audience-bound to a specific resource; project restriction comes from the connector path (`/mcp/<slug>`, D7), so a token minted for one connector is technically usable on any `/mcp/<slug>` the bearer reaches. For a **single-tenant self-hosted** server with one operator this is an accepted trade-off (there is only one resource and one principal). This is **non-standard for multi-resource MCP** and is recorded here as a deliberate decision, NOT an oversight. If Rembric ever moves toward multi-tenant/hosted (the rejected Camino A), add a `resource`/audience column, accept the `resource` parameter at `/authorize` + `/token`, and validate the audience at MCP dispatch.
+
+### D10 — Endpoint layer = MCP SDK's OAuth authorization server (vetted), backed by our audited core
+
+Per operator decision (2026-06-15), the HTTP endpoint layer is NOT hand-rolled. We use the OAuth authorization server already shipped in `@modelcontextprotocol/sdk@1.29.0` (an existing direct dependency): `mcpAuthRouter` + its `authorize`/`token`/`register`/`metadata`/`revoke` handlers + `bearerAuth` middleware + built-in rate limiting. We implement the SDK's `OAuthServerProvider` (+ `OAuthRegisteredClientsStore`) interface, delegating to the already-audited `services/oauth.ts` + `oauth-repository.ts`. This means:
+
+- The protocol-correctness surface most prone to OAuth hacks (PKCE validation, `state`/CSRF, `redirect_uri` exact-match + error-redirect handling, metadata document shape, DCR, RFC 8707 `resource` plumbing, rate limiting) is owned by the **vetted, MCP-purpose-built** SDK, not by us. This directly satisfies the "no home-cooked auth" requirement.
+- Our hand-rolled core is repurposed, not discarded: it becomes the provider's storage/logic backing (`issueCode`→authorize, `exchangeCode`→`exchangeAuthorizationCode`, `refresh`→`exchangeRefreshToken`, `authenticateAccessToken`→`verifyAccessToken`, the repo as `clientsStore`). The SDK can perform PKCE validation itself (via `challengeForAuthorizationCode`), making our `verifyPkceS256` redundant on the endpoint path (kept only if still used internally).
+- **Supply chain:** `express@5.2.1` + `express-rate-limit` are already present transitively under the SDK, so this adds no new download. Before any `package.json` edit (if we choose to declare a direct dep), route through the `npm-security-best-practices` skill per the repo contract.
+- **Wiring:** `mcpAuthRouter` is an Express router; the existing node `http` server already path-routes (`/mcp*` → MCP transport, else → Hono). Add a third branch: the reserved OAuth paths → the Express auth router. The `/mcp` resource-server bearer check stays our unified `authenticate()` (it must also accept static tokens); the SDK's `verifyAccessToken` provider method maps to `oauth.authenticateAccessToken`.
+
+The consent + single-user login (D4) is implemented inside the provider's `authorize(client, params, res)` — the SDK hands us the validated request and we render the consent / reuse the dashboard session, then redirect with code+state as the interface requires.
+
+## Open Questions
+
+- Should the consent screen allow choosing a **project scope** at grant time (vs relying solely on the connector path)? Deferred per D7; revisit if a client needs it.
+- Token TTL defaults: proposed access ~1h, refresh ~30d. Confirm against ChatGPT's refresh cadence during e2e.
+- Hand-roll the remaining endpoints vs adopt a vetted OAuth library (adds a dependency → npm-security review) vs front with an external IdP (breaks self-contained). The service core is hand-rolled but small and audited; the endpoint layer is where a library would most reduce surface. **Operator decision pending.**

--- a/openspec/changes/archive/2026-06-15-oauth2-resource-server-for-remote-mcp/proposal.md
+++ b/openspec/changes/archive/2026-06-15-oauth2-resource-server-for-remote-mcp/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+ChatGPT (and a growing set of remote MCP clients) will only attach to an authenticated MCP server through an OAuth 2.1 flow that conforms to the MCP authorization spec — they mint and carry the bearer token themselves and **cannot** accept a pasted static API key. Rembric today authenticates `/mcp` exclusively with operator-issued static bearer tokens (`TokensService`), so it cannot be added as a ChatGPT custom connector at all. More broadly, OAuth 2.1 is becoming the standard auth handshake for remote MCP across clients; adding it is worthwhile on its own merits, with the ChatGPT connector as the first concrete consumer.
+
+This change adds OAuth as a **self-contained, in-process authorization server** alongside the existing static-token path — both converge on the same bearer validation — scoped to **single-tenant private use** (no multi-tenant SaaS, no marketplace submission). It deliberately does NOT pursue the public ChatGPT app directory, which would force a hosted multi-tenant pivot that breaks the single-SQLite / operator-token invariants.
+
+## What Changes
+
+- Add an embedded **OAuth 2.1 authorization server** to the existing HTTP surface (Hono), with endpoints:
+  - `GET /.well-known/oauth-authorization-server` and `GET /.well-known/oauth-protected-resource` — metadata discovery (absolute URLs derived from the issuer).
+  - `POST /register` — Dynamic Client Registration (ChatGPT runs this once per connector).
+  - `GET /authorize` — Authorization Code flow with **PKCE** (`S256`), gated by a single-user login + a one-screen consent.
+  - `POST /token` — authorization-code exchange and **refresh-token rotation**; issues short-lived access tokens.
+- Extend the token model to carry OAuth access/refresh tokens (a `kind` discriminator on the `tokens` aggregate, or a sibling table) with short expiries, while leaving the **static operator-token path unchanged**. Both kinds resolve through the existing `authenticate()` and the existing scope grammar (`*`, `project:<id>`, `read:*`) is reused as OAuth scopes.
+- Make the `/mcp` (and `/mcp/<slug>`) `401` advertise `WWW-Authenticate: Bearer resource_metadata="<issuer>/.well-known/oauth-protected-resource"` so OAuth clients can discover the authorization server. This is **additive** — static-token clients ignore the header.
+- Add one required env, `REMBRIC_PUBLIC_URL` (the OAuth issuer / external base URL); reuse `REMBRIC_SESSION_SECRET` (via `deriveSessionKey`) for OAuth artifact signing and reuse `REMBRIC_ADMIN_TOKEN` as the single-user login credential at `/authorize`. Access/refresh TTLs are env-tunable with sane defaults.
+- Heavy test coverage: unit tests for the full flow (DCR, PKCE happy-path + tamper/replay, code single-use, refresh rotation, expiry, revoke, scope mapping), invariant tests proving the static-token path and append-only memory are untouched, and an e2e smoke validating **both** auth paths (static bearer + OAuth-minted token) against the dev Docker stack.
+
+This does NOT change the append-only memory invariant, the scope-at-service-layer invariant, `topic_key` convergence, or judgment freshness. The `/mcp` vs `/mcp/<slug>` path-scoping contract is preserved verbatim.
+
+## Capabilities
+
+### New Capabilities
+
+- `mcp-oauth`: The OAuth 2.1 authorization-server + protected-resource surface — metadata discovery, Dynamic Client Registration, Authorization Code + PKCE with single-user login/consent, token issuance and refresh rotation, and the `WWW-Authenticate` challenge on protected MCP routes.
+
+### Modified Capabilities
+
+- `auth`: The token model gains an OAuth dimension — access/refresh tokens are issued by the authorization server (not the operator dashboard), are short-lived, carry the same scope grammar, and are revocable on the same immediate-effect contract. The static operator-token requirements are unchanged; new requirements describe how OAuth-minted tokens coexist and how they are stored and hashed at rest.
+- `mcp-api`: The MCP endpoint MUST accept OAuth-minted bearer tokens on the same validation path as static tokens, and MUST emit the `WWW-Authenticate` resource-metadata challenge on `401`. The Streamable-HTTP transport and path-scoping contracts are unchanged.
+
+## Impact
+
+- **New code**: an OAuth module under `apps/server/src/server/` (e.g. `oauth/` — authorization-server handlers, metadata documents, PKCE + code/refresh logic, consent/login views) wired into the Hono app in `apps/server/src/server/http.ts` / `api-router.ts`.
+- **Modified code**:
+  - `apps/server/src/services/tokens.ts` — issue/validate OAuth access & refresh tokens, refresh rotation, scope mapping; `authenticate()` accepts both kinds.
+  - `apps/server/src/server/auth.ts` — `401` paths emit `WWW-Authenticate`.
+  - `apps/server/src/db/schema/tokens.ts` + a new migration — `kind` discriminator (or sibling table) for OAuth tokens, OAuth client registrations, and pending authorization codes; table-rebuild dance if a `CHECK`/NOT NULL is involved.
+  - `apps/server/src/db/repositories/` — repository methods for the new rows (all SQL stays here).
+  - Config/env loading — `REMBRIC_PUBLIC_URL`, optional `REMBRIC_OAUTH_ACCESS_TTL` / `REMBRIC_OAUTH_REFRESH_TTL`.
+- **Tests**: new co-located `*.test.ts` for the OAuth module + `tokens.ts`; additions to `apps/server/src/test/invariants.test.ts` (static path unchanged, data-access confinement for new SQL); an e2e smoke under the `rembric-smoke-tests` pattern exercising both auth paths against `pnpm run dev:docker:up`.
+- **Docs**: a connector setup note (Developer Mode + `REMBRIC_PUBLIC_URL` + TLS reachability) as manual fallback; no change to the TUI installer's canonical path.
+- **Dependencies**: prefer zero new deps (Node `crypto` covers PKCE/signing). Any candidate dep MUST route through the `npm-security-best-practices` skill.
+- **Invariants referenced**: append-only memory (untouched), scope-at-service-layer (OAuth scopes resolve to the same `Scope`), path-scoping contract (`/mcp` vs `/mcp/<slug>`, preserved).

--- a/openspec/changes/archive/2026-06-15-oauth2-resource-server-for-remote-mcp/specs/auth/spec.md
+++ b/openspec/changes/archive/2026-06-15-oauth2-resource-server-for-remote-mcp/specs/auth/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: OAuth-minted tokens MUST be hashed at rest
+
+Access and refresh tokens issued by the OAuth authorization server SHALL be high-entropy random secrets (at least 256 bits) persisted only as a cryptographic hash (SHA-256 of the secret, stored in an indexed column for O(1) lookup), SHALL be returned to the client exactly once at issuance, and SHALL never be persisted or logged in plaintext. They SHALL be stored in dedicated `oauth_*` tables, leaving the static `tokens` table and its rows unchanged.
+
+#### Scenario: OAuth access token stored hashed
+
+- **WHEN** the `/token` endpoint issues an access token
+- **THEN** the persisted row SHALL contain only a hash of the secret, and the plaintext SHALL appear only in the token response body
+
+#### Scenario: OAuth token absent from logs
+
+- **WHEN** a request log line is emitted for an OAuth `/token` or `/mcp` call
+- **THEN** the log SHALL NOT contain the plaintext access or refresh token
+
+### Requirement: OAuth access tokens MUST authenticate `/mcp` on the same path as static tokens
+
+The MCP authentication step SHALL accept an OAuth-minted access token presented as `Authorization: Bearer <token>` and resolve it to the same `{ scope }` shape as a static token, after first attempting the static-token lookup. An OAuth access token and a static token SHALL NOT be confusable: a value that does not verify as a static token SHALL fall through to OAuth lookup, and vice versa, with constant-time comparison preserved.
+
+#### Scenario: OAuth access token authenticates
+
+- **GIVEN** a valid, unexpired, unrevoked OAuth access token with scope `*`
+- **WHEN** it is used as the `/mcp` bearer to call `memory.search`
+- **THEN** the call SHALL be authorized exactly as the same call with a static `*` token
+
+#### Scenario: Static token path unchanged
+
+- **GIVEN** a valid static operator token
+- **WHEN** it is used as the `/mcp` bearer after this change ships
+- **THEN** the token SHALL authenticate with identical behavior to before the change
+
+### Requirement: OAuth access tokens MUST be short-lived and OAuth tokens MUST be revocable with immediate effect
+
+OAuth access tokens SHALL carry a short expiry (default approximately one hour, tunable via env) and SHALL be rejected once expired. Revocation of an OAuth token (including family revocation triggered by refresh reuse) SHALL take effect on the next request, with no in-memory cache holding a revoked token valid for longer than a few seconds — the same immediate-revocation contract as static tokens.
+
+#### Scenario: Expired OAuth access token rejected
+
+- **GIVEN** an OAuth access token past its expiry
+- **WHEN** it is presented to `/mcp`
+- **THEN** the request SHALL be rejected with `401 Unauthorized`
+
+#### Scenario: Revoked OAuth token rejected immediately
+
+- **GIVEN** an OAuth access token whose grant family was revoked at time T
+- **WHEN** the token is used at T+1s
+- **THEN** the request SHALL be rejected with `401 Unauthorized`

--- a/openspec/changes/archive/2026-06-15-oauth2-resource-server-for-remote-mcp/specs/mcp-api/spec.md
+++ b/openspec/changes/archive/2026-06-15-oauth2-resource-server-for-remote-mcp/specs/mcp-api/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: The MCP endpoint MUST advertise the authorization server on `401` when OAuth is enabled
+
+When OAuth is enabled (`REMBRIC_PUBLIC_URL` set), an unauthenticated or invalid-token request to `/mcp` or `/mcp/<slug>` SHALL respond `401` with a `WWW-Authenticate: Bearer` header that includes `resource_metadata="<issuer>/.well-known/oauth-protected-resource"`, enabling OAuth clients to discover the authorization server. When OAuth is disabled, the `401` response SHALL NOT include this header and SHALL be byte-compatible with the pre-change behavior.
+
+#### Scenario: 401 advertises resource metadata when OAuth enabled
+
+- **GIVEN** the server started with `REMBRIC_PUBLIC_URL=https://rembric.example.com`
+- **WHEN** a request hits `/mcp` with no `Authorization` header
+- **THEN** the response SHALL be `401` and SHALL carry `WWW-Authenticate: Bearer resource_metadata="https://rembric.example.com/.well-known/oauth-protected-resource"`
+
+#### Scenario: 401 unchanged when OAuth disabled
+
+- **GIVEN** the server started without `REMBRIC_PUBLIC_URL`
+- **WHEN** a request hits `/mcp` with no `Authorization` header
+- **THEN** the response SHALL be `401` and SHALL NOT include a `WWW-Authenticate` header
+
+### Requirement: OAuth and static tokens MUST share the path-scoping contract
+
+A connection authenticated by an OAuth access token SHALL be subject to the identical `/mcp` vs `/mcp/<slug>` path-scoping contract as a static-token connection: a path-scoped OAuth connection SHALL enforce strict project isolation, and a global OAuth connection SHALL behave as a global static-token connection. The authentication mechanism SHALL NOT change scope resolution.
+
+#### Scenario: Path-scoped OAuth connection enforces isolation
+
+- **GIVEN** a connection at `/mcp/foo` authenticated with an OAuth access token
+- **WHEN** the client calls `memory.save` with `scope='global'`
+- **THEN** the response SHALL be an MCP error with `code: 'scope_locked'`, identical to the static-token case
+
+#### Scenario: Reserved OAuth paths do not shadow MCP slugs
+
+- **GIVEN** OAuth is enabled
+- **WHEN** the server routes requests for `/authorize`, `/token`, `/register`, and `/.well-known/oauth-*`
+- **THEN** those SHALL resolve to the OAuth handlers and SHALL NOT be interpreted as `/mcp` project slugs, and `/mcp/<slug>` routing SHALL remain unchanged

--- a/openspec/changes/archive/2026-06-15-oauth2-resource-server-for-remote-mcp/specs/mcp-oauth/spec.md
+++ b/openspec/changes/archive/2026-06-15-oauth2-resource-server-for-remote-mcp/specs/mcp-oauth/spec.md
@@ -1,0 +1,148 @@
+## ADDED Requirements
+
+### Requirement: OAuth is opt-in via `REMBRIC_PUBLIC_URL`
+
+The OAuth 2.1 authorization-server surface SHALL be enabled if and only if `REMBRIC_PUBLIC_URL` is set to a non-empty absolute URL, which SHALL serve as the OAuth `issuer` and the base for every absolute URL in the metadata documents. The issuer SHALL use the `https` scheme, except that an `http` scheme SHALL be accepted only for loopback hosts (`localhost`, `127.0.0.1`, `[::1]`) to support local testing (the RFC 8414 loopback exemption). When `REMBRIC_PUBLIC_URL` is unset, the server SHALL NOT expose any OAuth endpoint and SHALL NOT alter any existing behavior (including the `/mcp` `401` response).
+
+#### Scenario: OAuth disabled by default
+
+- **GIVEN** the server is started without `REMBRIC_PUBLIC_URL`
+- **WHEN** a client requests `/.well-known/oauth-authorization-server`, `/authorize`, `/token`, or `/register`
+- **THEN** the server SHALL respond `404 Not Found` and the static-token `/mcp` path SHALL behave exactly as before this change
+
+#### Scenario: OAuth enabled with issuer
+
+- **GIVEN** the server is started with `REMBRIC_PUBLIC_URL=https://rembric.example.com`
+- **WHEN** a client fetches `/.well-known/oauth-authorization-server`
+- **THEN** the response SHALL be a JSON metadata document whose `issuer` equals `https://rembric.example.com` and whose endpoint URLs are absolute under that issuer
+
+#### Scenario: Non-HTTPS issuer on a public host rejected at startup
+
+- **GIVEN** `REMBRIC_PUBLIC_URL` is set to an `http://` URL on a non-loopback host (e.g. `http://rembric.example.com`)
+- **WHEN** the server starts
+- **THEN** the server SHALL refuse to start with a clear error, because OAuth 2.1 requires the issuer to be served over TLS off-loopback
+
+#### Scenario: Loopback http issuer accepted for local testing
+
+- **GIVEN** `REMBRIC_PUBLIC_URL` is set to `http://localhost:8788` (or `http://127.0.0.1:8788`)
+- **WHEN** the server starts
+- **THEN** the server SHALL start with OAuth enabled, the issuer set to that loopback origin
+
+### Requirement: The server MUST publish OAuth authorization-server and protected-resource metadata
+
+When OAuth is enabled, the server SHALL serve `GET /.well-known/oauth-authorization-server` and `GET /.well-known/oauth-protected-resource` as JSON. The authorization-server document SHALL advertise the `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, the supported `code_challenge_methods_supported` including `S256`, `grant_types_supported` including `authorization_code` and `refresh_token`, and `response_types_supported` including `code`. The protected-resource document SHALL advertise the protected resource and its `authorization_servers`.
+
+#### Scenario: Authorization-server metadata advertises PKCE S256
+
+- **WHEN** a client fetches `/.well-known/oauth-authorization-server`
+- **THEN** the response SHALL list `S256` in `code_challenge_methods_supported` and SHALL NOT advertise `plain`
+
+#### Scenario: Protected-resource metadata points back to the issuer
+
+- **WHEN** a client fetches `/.well-known/oauth-protected-resource`
+- **THEN** the response SHALL list the configured issuer in its `authorization_servers`
+
+### Requirement: The server MUST support Dynamic Client Registration for public clients
+
+When OAuth is enabled, `POST /register` SHALL accept an OAuth Dynamic Client Registration request and SHALL create a public client: it SHALL return a generated `client_id`, SHALL NOT issue a `client_secret`, and SHALL record `token_endpoint_auth_method: none`. The server SHALL persist the registered `redirect_uris` and reject later authorization requests whose `redirect_uri` is not among them.
+
+#### Scenario: Registering a public client
+
+- **WHEN** a client POSTs valid registration metadata including one or more `redirect_uris` to `/register`
+- **THEN** the server SHALL respond `201 Created` with a `client_id`, no `client_secret`, and `token_endpoint_auth_method` of `none`
+
+#### Scenario: Authorization with an unregistered redirect URI
+
+- **GIVEN** a registered client whose `redirect_uris` do not include `https://evil.example/cb`
+- **WHEN** an `/authorize` request arrives with `redirect_uri=https://evil.example/cb`
+- **THEN** the server SHALL reject the request and SHALL NOT redirect to that URI
+
+### Requirement: Authorization Code flow MUST require PKCE S256
+
+When OAuth is enabled, `GET /authorize` SHALL implement the Authorization Code flow and SHALL require a `code_challenge` with `code_challenge_method=S256`. Requests without a `code_challenge`, or with `code_challenge_method=plain`, SHALL be rejected. Issued authorization codes SHALL be single-use, SHALL expire within 120 seconds, and SHALL be bound to the `code_challenge`, the `redirect_uri`, the `client_id`, and the granted scope.
+
+#### Scenario: Authorize without PKCE is rejected
+
+- **WHEN** an `/authorize` request omits `code_challenge`
+- **THEN** the server SHALL reject the request with an `invalid_request` error
+
+#### Scenario: Plain PKCE method is rejected
+
+- **WHEN** an `/authorize` request supplies `code_challenge_method=plain`
+- **THEN** the server SHALL reject the request with an `invalid_request` error
+
+#### Scenario: Authorization code is single-use
+
+- **GIVEN** an authorization code already exchanged once at `/token`
+- **WHEN** the same code is presented to `/token` a second time
+- **THEN** the server SHALL reject the exchange with `invalid_grant` and SHALL NOT issue a token
+
+#### Scenario: Authorization code expires
+
+- **GIVEN** an authorization code issued more than 120 seconds ago
+- **WHEN** it is presented to `/token`
+- **THEN** the server SHALL reject the exchange with `invalid_grant`
+
+### Requirement: The human MUST authenticate and consent before a code is issued
+
+`GET /authorize` SHALL only issue an authorization code after the operator is authenticated via the existing dashboard session and has explicitly granted consent for the requesting client and scope. An unauthenticated operator SHALL be redirected into the existing dashboard login flow and returned to the consent step on success.
+
+#### Scenario: Unauthenticated operator is sent to login
+
+- **GIVEN** no valid dashboard session cookie is present
+- **WHEN** the operator opens an `/authorize` URL
+- **THEN** the server SHALL redirect to `/dashboard/login` and, after successful login, SHALL return to the consent screen for the original request
+
+#### Scenario: Consent denied yields no code
+
+- **GIVEN** an authenticated operator on the consent screen
+- **WHEN** the operator denies consent
+- **THEN** the server SHALL redirect back to the client's `redirect_uri` with an `access_denied` error and SHALL NOT issue an authorization code
+
+### Requirement: The token endpoint MUST exchange codes and verify PKCE
+
+When OAuth is enabled, `POST /token` SHALL support `grant_type=authorization_code`. It SHALL recompute the SHA-256 of the presented `code_verifier`, compare it to the stored `code_challenge`, and reject the exchange with `invalid_grant` on mismatch, on a missing `code_verifier`, on a `redirect_uri` that does not match the one bound to the code, or on a `client_id` mismatch. On success it SHALL issue a short-lived opaque access token and a refresh token.
+
+#### Scenario: Successful code exchange
+
+- **GIVEN** a valid unexpired authorization code and the matching `code_verifier`, `redirect_uri`, and `client_id`
+- **WHEN** the client POSTs them to `/token`
+- **THEN** the server SHALL respond with an `access_token`, a `token_type` of `Bearer`, an `expires_in`, and a `refresh_token`
+
+#### Scenario: PKCE verifier mismatch
+
+- **GIVEN** a valid authorization code
+- **WHEN** the client POSTs a `code_verifier` whose SHA-256 does not equal the bound `code_challenge`
+- **THEN** the server SHALL reject the exchange with `invalid_grant`
+
+### Requirement: Refresh tokens MUST rotate with reuse detection
+
+When OAuth is enabled, `POST /token` SHALL support `grant_type=refresh_token`. A successful refresh SHALL issue a new access token AND a new refresh token, and SHALL mark the presented refresh token consumed. Presenting an already-consumed refresh token SHALL be treated as compromise: the server SHALL revoke the entire token family (the access/refresh tokens descended from the original grant).
+
+#### Scenario: Refresh issues a rotated pair
+
+- **GIVEN** a valid, unconsumed refresh token
+- **WHEN** the client POSTs it with `grant_type=refresh_token`
+- **THEN** the server SHALL return a new `access_token` and a new `refresh_token`, and the presented refresh token SHALL no longer be accepted
+
+#### Scenario: Refresh reuse revokes the family
+
+- **GIVEN** a refresh token that has already been rotated once
+- **WHEN** the same (now-consumed) refresh token is presented again
+- **THEN** the server SHALL reject it with `invalid_grant` and SHALL revoke all access and refresh tokens in that grant family
+
+### Requirement: Issued OAuth tokens MUST map to the existing scope grammar
+
+The scope granted at consent SHALL be expressed in the existing `TokenScope` grammar (`*`, `read:*`, `project:<id>`, `read:project:<id>`) so that OAuth-minted tokens are authorized by the same `isAuthorized()` checks as static tokens. The mapping SHALL fail closed: an absent, empty, or unrecognized requested scope SHALL yield least privilege (`read:*`); write access (`*`) SHALL be granted only when write is explicitly requested. Project restriction MAY additionally derive from the connector's request path (`/mcp/<slug>`) under the existing path-scoping contract.
+
+#### Scenario: Unknown or empty requested scope fails closed
+
+- **GIVEN** an authorization request whose `scope` is absent, empty, or unrecognized
+- **WHEN** consent is granted
+- **THEN** the minted access token SHALL receive least privilege (`read:*`), not full access
+
+#### Scenario: Read-only OAuth grant cannot write
+
+- **GIVEN** an access token minted from a grant consented as read-only (`read:*`)
+- **WHEN** the token is used to invoke `memory.save`
+- **THEN** the request SHALL be rejected with the same `403`-class authorization failure as a static `read:*` token

--- a/openspec/changes/archive/2026-06-15-oauth2-resource-server-for-remote-mcp/tasks.md
+++ b/openspec/changes/archive/2026-06-15-oauth2-resource-server-for-remote-mcp/tasks.md
@@ -1,0 +1,44 @@
+## 1. Data model & migration
+
+- [x] 1.1 Add `apps/server/src/db/schema/oauth.ts` with three tables — `oauth_clients` (client_id, redirect_uris JSON, token_endpoint_auth_method, created_at), `oauth_authorization_codes` (code hash, client_id, redirect_uri, code_challenge, scope, subject, expires_at, consumed_at), `oauth_tokens` (id, kind `access`|`refresh`, hash, client_id, family_id, scope, subject, expires_at, rotated_at, revoked_at, created_at) — exporting `$inferSelect`/`$inferInsert` types. No change to `tokens.ts` schema.
+- [x] 1.2 Add an additive `CREATE TABLE` migration under `apps/server/src/db/migrations/` for the three tables + indexes (by hash, by family_id, by expires_at). Verify it needs no `tokens` rebuild and passes `pnpm vitest run apps/server/src/db` and the migration FK-safety invariant.
+- [x] 1.3 Add `apps/server/src/db/repositories/oauth-repository.ts` with all SQL for the new tables (insert/find-by-hash/consume-code/rotate-refresh/revoke-family/find-client); register it in `repositories/index.ts`. Confirm no SQL leaks outside `db/` via the data-access-confinement invariant test.
+
+## 2. Config & issuer gating
+
+- [x] 2.1 Add config loading for `REMBRIC_PUBLIC_URL` (issuer), optional `REMBRIC_OAUTH_ACCESS_TTL` (default 3600s) and `REMBRIC_OAUTH_REFRESH_TTL` (default 30d). Expose an `oauthEnabled` boolean = issuer present.
+- [x] 2.2 At startup, if `REMBRIC_PUBLIC_URL` is set, validate it is an absolute `https://` URL and refuse to start otherwise with a clear message; log the resolved issuer. Add a unit test for accept/reject cases.
+
+## 3. OAuth core (service layer)
+
+- [x] 3.1 Add an OAuth service (e.g. `apps/server/src/services/oauth.ts`) with PKCE `S256` verification (Node `crypto`), authorization-code issuance/lookup/single-use-consume bound to (challenge, redirect_uri, client_id, scope, subject), and helpers reusing `hashToken`/`verifyToken` from `tokens.ts` for code/token hashing. Unit-test happy path + tamper/missing/`plain` rejection + expiry + replay.
+- [x] 3.2 Implement access+refresh issuance and refresh rotation with family reuse detection (consuming a rotated refresh token revokes the whole `family_id`). Unit-test rotation, reuse→family-revoke, expiry.
+- [x] 3.3 Implement OAuth-scope ⇄ `TokenScope` mapping (full→`*`, read-only→`read:*`) reused by consent and validation. Unit-test the mapping including read-only-cannot-write.
+
+## 4. Unified authentication
+
+- [x] 4.1 Extend `TokensService.authenticate()` (or a thin wrapper consulted by `server/auth.ts`) to try the static `tokens` lookup first, then fall back to `oauth_tokens` access-token lookup, returning the same `{ token-like, scope }` shape. Preserve constant-time compare. Unit-test: static token unchanged, OAuth access token resolves, expired/revoked OAuth token → reject.
+- [x] 4.2 Make the `/mcp` and `/mcp/<slug>` `401` emit `WWW-Authenticate: Bearer resource_metadata="<issuer>/.well-known/oauth-protected-resource"` only when `oauthEnabled`; byte-identical 401 (no header) when disabled. Unit-test both branches.
+
+## 5. HTTP endpoints — MCP SDK authorization server (vetted) + our provider (design D10)
+
+- [x] 5.0 Consult `npm-security-best-practices` skill re: relying on `@modelcontextprotocol/sdk/server/auth/*` (+ transitively-present `express`/`express-rate-limit`); decide whether a direct `package.json` dep declaration is needed and, if so, clear it through the skill's checklist.
+- [x] 5.1 Implement the SDK `OAuthRegisteredClientsStore` over `oauth-repository.ts` (getClient / registerClient → public client, https+loopback redirect validation already in `services/oauth.ts`). Unit-test get/register + unregistered-redirect rejection.
+- [x] 5.2 Implement the SDK `OAuthServerProvider` delegating to `services/oauth.ts`: `authorize()` (render consent + reuse dashboard session, redirect with code+state), `challengeForAuthorizationCode()`, `exchangeAuthorizationCode()` → `exchangeCode`, `exchangeRefreshToken()` → `refresh`, `verifyAccessToken()` → `authenticateAccessToken`, `revokeToken()`. Unit-test each provider method.
+- [x] 5.3 Build the consent + single-user login screen used by `authorize()` (reuse dashboard session; bounce to `/dashboard/login` and back; consent form with CSRF). Unit-test login-redirect + approve/deny.
+- [x] 5.4 Mount `mcpAuthRouter({ provider, issuerUrl, scopesSupported, resourceName })` (gated on `config.oauth.enabled`) and bridge the Express router into the node `http` server alongside `/mcp` and Hono; ensure reserved OAuth paths never shadow `/mcp/<slug>`. Route-collision test.
+- [x] 5.5 Confirm `pnpm run typecheck` and `pnpm run lint` pass; SDK owns PKCE/CSRF/redirect/metadata/DCR/rate-limit per D10.
+
+## 6. Invariant & regression coverage
+
+- [x] 6.1 Add invariant assertions to `apps/server/src/test/invariants.test.ts`: static-token path behavior unchanged; OAuth SQL confined to `db/`; `oauth_*` writes do not touch memory append-only paths; reserved OAuth routes do not collide with `/mcp` path-scoping.
+- [x] 6.2 Run the full existing `auth`/`tokens`/`mcp` suites and confirm green (no regression): `pnpm vitest run apps/server/src/services/tokens.test.ts apps/server/src/server apps/server/src/mcp`.
+
+## 7. End-to-end smoke (both auth paths)
+
+- [x] 7.1 Add an e2e smoke (under the `rembric-smoke-tests` pattern) that, against `pnpm run dev:docker:up` with `REMBRIC_PUBLIC_URL` set: (a) authenticates `/mcp` with a static bearer and runs `memory.save`+`memory.search`; (b) drives the full OAuth dance (register → authorize+consent → token) to mint an access token and runs the same MCP calls with it; (c) asserts the disabled-OAuth `401` has no `WWW-Authenticate`. Document any operator-only step.
+- [x] 7.2 **Operator-only:** run the smoke locally against the live dev Docker stack and capture pass/fail; if blocked (no Docker), fall back to an in-process HTTP test exercising both auth paths against the Hono app without containers.
+
+## 8. Docs
+
+- [x] 8.1 Add a connector setup note (Developer Mode, set `REMBRIC_PUBLIC_URL`, TLS/public reachability, per-project = per-`/mcp/<slug>` connector) as manual fallback; do not alter the TUI installer canonical path. Update env reference if one exists.

--- a/openspec/specs/auth/spec.md
+++ b/openspec/specs/auth/spec.md
@@ -75,3 +75,49 @@ Dashboard sessions SHALL be backed by a signed httpOnly cookie referencing a `da
 - **GIVEN** an active dashboard session
 - **WHEN** the corresponding `dashboard_sessions` row is deleted
 - **THEN** the next request bearing that cookie SHALL be treated as unauthenticated
+
+### Requirement: OAuth-minted tokens MUST be hashed at rest
+
+Access and refresh tokens issued by the OAuth authorization server SHALL be high-entropy random secrets (at least 256 bits) persisted only as a cryptographic hash (SHA-256 of the secret, stored in an indexed column for O(1) lookup), SHALL be returned to the client exactly once at issuance, and SHALL never be persisted or logged in plaintext. They SHALL be stored in dedicated `oauth_*` tables, leaving the static `tokens` table and its rows unchanged.
+
+#### Scenario: OAuth access token stored hashed
+
+- **WHEN** the `/token` endpoint issues an access token
+- **THEN** the persisted row SHALL contain only a hash of the secret, and the plaintext SHALL appear only in the token response body
+
+#### Scenario: OAuth token absent from logs
+
+- **WHEN** a request log line is emitted for an OAuth `/token` or `/mcp` call
+- **THEN** the log SHALL NOT contain the plaintext access or refresh token
+
+### Requirement: OAuth access tokens MUST authenticate `/mcp` on the same path as static tokens
+
+The MCP authentication step SHALL accept an OAuth-minted access token presented as `Authorization: Bearer <token>` and resolve it to the same `{ scope }` shape as a static token, after first attempting the static-token lookup. An OAuth access token and a static token SHALL NOT be confusable: a value that does not verify as a static token SHALL fall through to OAuth lookup, and vice versa, with constant-time comparison preserved.
+
+#### Scenario: OAuth access token authenticates
+
+- **GIVEN** a valid, unexpired, unrevoked OAuth access token with scope `*`
+- **WHEN** it is used as the `/mcp` bearer to call `memory.search`
+- **THEN** the call SHALL be authorized exactly as the same call with a static `*` token
+
+#### Scenario: Static token path unchanged
+
+- **GIVEN** a valid static operator token
+- **WHEN** it is used as the `/mcp` bearer after this change ships
+- **THEN** the token SHALL authenticate with identical behavior to before the change
+
+### Requirement: OAuth access tokens MUST be short-lived and OAuth tokens MUST be revocable with immediate effect
+
+OAuth access tokens SHALL carry a short expiry (default approximately one hour, tunable via env) and SHALL be rejected once expired. Revocation of an OAuth token (including family revocation triggered by refresh reuse) SHALL take effect on the next request, with no in-memory cache holding a revoked token valid for longer than a few seconds — the same immediate-revocation contract as static tokens.
+
+#### Scenario: Expired OAuth access token rejected
+
+- **GIVEN** an OAuth access token past its expiry
+- **WHEN** it is presented to `/mcp`
+- **THEN** the request SHALL be rejected with `401 Unauthorized`
+
+#### Scenario: Revoked OAuth token rejected immediately
+
+- **GIVEN** an OAuth access token whose grant family was revoked at time T
+- **WHEN** the token is used at T+1s
+- **THEN** the request SHALL be rejected with `401 Unauthorized`

--- a/openspec/specs/mcp-api/spec.md
+++ b/openspec/specs/mcp-api/spec.md
@@ -851,3 +851,35 @@ The `plugins` command strings SHALL be derived from the canonical installer entr
 - **THEN** it SHALL include a `status` command using the installer's `--status --json` mode that references the canonical entrypoint
 - **AND** that command SHALL NOT contain `--action=update` or any other mutating flag
 - **AND** the `plugins.note` SHALL direct the operator to run the status command first and update only where the reported `action` is `update`
+
+### Requirement: The MCP endpoint MUST advertise the authorization server on `401` when OAuth is enabled
+
+When OAuth is enabled (`REMBRIC_PUBLIC_URL` set), an unauthenticated or invalid-token request to `/mcp` or `/mcp/<slug>` SHALL respond `401` with a `WWW-Authenticate: Bearer` header that includes `resource_metadata="<issuer>/.well-known/oauth-protected-resource"`, enabling OAuth clients to discover the authorization server. When OAuth is disabled, the `401` response SHALL NOT include this header and SHALL be byte-compatible with the pre-change behavior.
+
+#### Scenario: 401 advertises resource metadata when OAuth enabled
+
+- **GIVEN** the server started with `REMBRIC_PUBLIC_URL=https://rembric.example.com`
+- **WHEN** a request hits `/mcp` with no `Authorization` header
+- **THEN** the response SHALL be `401` and SHALL carry `WWW-Authenticate: Bearer resource_metadata="https://rembric.example.com/.well-known/oauth-protected-resource"`
+
+#### Scenario: 401 unchanged when OAuth disabled
+
+- **GIVEN** the server started without `REMBRIC_PUBLIC_URL`
+- **WHEN** a request hits `/mcp` with no `Authorization` header
+- **THEN** the response SHALL be `401` and SHALL NOT include a `WWW-Authenticate` header
+
+### Requirement: OAuth and static tokens MUST share the path-scoping contract
+
+A connection authenticated by an OAuth access token SHALL be subject to the identical `/mcp` vs `/mcp/<slug>` path-scoping contract as a static-token connection: a path-scoped OAuth connection SHALL enforce strict project isolation, and a global OAuth connection SHALL behave as a global static-token connection. The authentication mechanism SHALL NOT change scope resolution.
+
+#### Scenario: Path-scoped OAuth connection enforces isolation
+
+- **GIVEN** a connection at `/mcp/foo` authenticated with an OAuth access token
+- **WHEN** the client calls `memory.save` with `scope='global'`
+- **THEN** the response SHALL be an MCP error with `code: 'scope_locked'`, identical to the static-token case
+
+#### Scenario: Reserved OAuth paths do not shadow MCP slugs
+
+- **GIVEN** OAuth is enabled
+- **WHEN** the server routes requests for `/authorize`, `/token`, `/register`, and `/.well-known/oauth-*`
+- **THEN** those SHALL resolve to the OAuth handlers and SHALL NOT be interpreted as `/mcp` project slugs, and `/mcp/<slug>` routing SHALL remain unchanged

--- a/openspec/specs/mcp-oauth/spec.md
+++ b/openspec/specs/mcp-oauth/spec.md
@@ -1,0 +1,154 @@
+# mcp-oauth Specification
+
+## Purpose
+
+TBD - created by archiving change oauth2-resource-server-for-remote-mcp. Update Purpose after archive.
+
+## Requirements
+
+### Requirement: OAuth is opt-in via `REMBRIC_PUBLIC_URL`
+
+The OAuth 2.1 authorization-server surface SHALL be enabled if and only if `REMBRIC_PUBLIC_URL` is set to a non-empty absolute URL, which SHALL serve as the OAuth `issuer` and the base for every absolute URL in the metadata documents. The issuer SHALL use the `https` scheme, except that an `http` scheme SHALL be accepted only for loopback hosts (`localhost`, `127.0.0.1`, `[::1]`) to support local testing (the RFC 8414 loopback exemption). When `REMBRIC_PUBLIC_URL` is unset, the server SHALL NOT expose any OAuth endpoint and SHALL NOT alter any existing behavior (including the `/mcp` `401` response).
+
+#### Scenario: OAuth disabled by default
+
+- **GIVEN** the server is started without `REMBRIC_PUBLIC_URL`
+- **WHEN** a client requests `/.well-known/oauth-authorization-server`, `/authorize`, `/token`, or `/register`
+- **THEN** the server SHALL respond `404 Not Found` and the static-token `/mcp` path SHALL behave exactly as before this change
+
+#### Scenario: OAuth enabled with issuer
+
+- **GIVEN** the server is started with `REMBRIC_PUBLIC_URL=https://rembric.example.com`
+- **WHEN** a client fetches `/.well-known/oauth-authorization-server`
+- **THEN** the response SHALL be a JSON metadata document whose `issuer` equals `https://rembric.example.com` and whose endpoint URLs are absolute under that issuer
+
+#### Scenario: Non-HTTPS issuer on a public host rejected at startup
+
+- **GIVEN** `REMBRIC_PUBLIC_URL` is set to an `http://` URL on a non-loopback host (e.g. `http://rembric.example.com`)
+- **WHEN** the server starts
+- **THEN** the server SHALL refuse to start with a clear error, because OAuth 2.1 requires the issuer to be served over TLS off-loopback
+
+#### Scenario: Loopback http issuer accepted for local testing
+
+- **GIVEN** `REMBRIC_PUBLIC_URL` is set to `http://localhost:8788` (or `http://127.0.0.1:8788`)
+- **WHEN** the server starts
+- **THEN** the server SHALL start with OAuth enabled, the issuer set to that loopback origin
+
+### Requirement: The server MUST publish OAuth authorization-server and protected-resource metadata
+
+When OAuth is enabled, the server SHALL serve `GET /.well-known/oauth-authorization-server` and `GET /.well-known/oauth-protected-resource` as JSON. The authorization-server document SHALL advertise the `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, the supported `code_challenge_methods_supported` including `S256`, `grant_types_supported` including `authorization_code` and `refresh_token`, and `response_types_supported` including `code`. The protected-resource document SHALL advertise the protected resource and its `authorization_servers`.
+
+#### Scenario: Authorization-server metadata advertises PKCE S256
+
+- **WHEN** a client fetches `/.well-known/oauth-authorization-server`
+- **THEN** the response SHALL list `S256` in `code_challenge_methods_supported` and SHALL NOT advertise `plain`
+
+#### Scenario: Protected-resource metadata points back to the issuer
+
+- **WHEN** a client fetches `/.well-known/oauth-protected-resource`
+- **THEN** the response SHALL list the configured issuer in its `authorization_servers`
+
+### Requirement: The server MUST support Dynamic Client Registration for public clients
+
+When OAuth is enabled, `POST /register` SHALL accept an OAuth Dynamic Client Registration request and SHALL create a public client: it SHALL return a generated `client_id`, SHALL NOT issue a `client_secret`, and SHALL record `token_endpoint_auth_method: none`. The server SHALL persist the registered `redirect_uris` and reject later authorization requests whose `redirect_uri` is not among them.
+
+#### Scenario: Registering a public client
+
+- **WHEN** a client POSTs valid registration metadata including one or more `redirect_uris` to `/register`
+- **THEN** the server SHALL respond `201 Created` with a `client_id`, no `client_secret`, and `token_endpoint_auth_method` of `none`
+
+#### Scenario: Authorization with an unregistered redirect URI
+
+- **GIVEN** a registered client whose `redirect_uris` do not include `https://evil.example/cb`
+- **WHEN** an `/authorize` request arrives with `redirect_uri=https://evil.example/cb`
+- **THEN** the server SHALL reject the request and SHALL NOT redirect to that URI
+
+### Requirement: Authorization Code flow MUST require PKCE S256
+
+When OAuth is enabled, `GET /authorize` SHALL implement the Authorization Code flow and SHALL require a `code_challenge` with `code_challenge_method=S256`. Requests without a `code_challenge`, or with `code_challenge_method=plain`, SHALL be rejected. Issued authorization codes SHALL be single-use, SHALL expire within 120 seconds, and SHALL be bound to the `code_challenge`, the `redirect_uri`, the `client_id`, and the granted scope.
+
+#### Scenario: Authorize without PKCE is rejected
+
+- **WHEN** an `/authorize` request omits `code_challenge`
+- **THEN** the server SHALL reject the request with an `invalid_request` error
+
+#### Scenario: Plain PKCE method is rejected
+
+- **WHEN** an `/authorize` request supplies `code_challenge_method=plain`
+- **THEN** the server SHALL reject the request with an `invalid_request` error
+
+#### Scenario: Authorization code is single-use
+
+- **GIVEN** an authorization code already exchanged once at `/token`
+- **WHEN** the same code is presented to `/token` a second time
+- **THEN** the server SHALL reject the exchange with `invalid_grant` and SHALL NOT issue a token
+
+#### Scenario: Authorization code expires
+
+- **GIVEN** an authorization code issued more than 120 seconds ago
+- **WHEN** it is presented to `/token`
+- **THEN** the server SHALL reject the exchange with `invalid_grant`
+
+### Requirement: The human MUST authenticate and consent before a code is issued
+
+`GET /authorize` SHALL only issue an authorization code after the operator is authenticated via the existing dashboard session and has explicitly granted consent for the requesting client and scope. An unauthenticated operator SHALL be redirected into the existing dashboard login flow and returned to the consent step on success.
+
+#### Scenario: Unauthenticated operator is sent to login
+
+- **GIVEN** no valid dashboard session cookie is present
+- **WHEN** the operator opens an `/authorize` URL
+- **THEN** the server SHALL redirect to `/dashboard/login` and, after successful login, SHALL return to the consent screen for the original request
+
+#### Scenario: Consent denied yields no code
+
+- **GIVEN** an authenticated operator on the consent screen
+- **WHEN** the operator denies consent
+- **THEN** the server SHALL redirect back to the client's `redirect_uri` with an `access_denied` error and SHALL NOT issue an authorization code
+
+### Requirement: The token endpoint MUST exchange codes and verify PKCE
+
+When OAuth is enabled, `POST /token` SHALL support `grant_type=authorization_code`. It SHALL recompute the SHA-256 of the presented `code_verifier`, compare it to the stored `code_challenge`, and reject the exchange with `invalid_grant` on mismatch, on a missing `code_verifier`, on a `redirect_uri` that does not match the one bound to the code, or on a `client_id` mismatch. On success it SHALL issue a short-lived opaque access token and a refresh token.
+
+#### Scenario: Successful code exchange
+
+- **GIVEN** a valid unexpired authorization code and the matching `code_verifier`, `redirect_uri`, and `client_id`
+- **WHEN** the client POSTs them to `/token`
+- **THEN** the server SHALL respond with an `access_token`, a `token_type` of `Bearer`, an `expires_in`, and a `refresh_token`
+
+#### Scenario: PKCE verifier mismatch
+
+- **GIVEN** a valid authorization code
+- **WHEN** the client POSTs a `code_verifier` whose SHA-256 does not equal the bound `code_challenge`
+- **THEN** the server SHALL reject the exchange with `invalid_grant`
+
+### Requirement: Refresh tokens MUST rotate with reuse detection
+
+When OAuth is enabled, `POST /token` SHALL support `grant_type=refresh_token`. A successful refresh SHALL issue a new access token AND a new refresh token, and SHALL mark the presented refresh token consumed. Presenting an already-consumed refresh token SHALL be treated as compromise: the server SHALL revoke the entire token family (the access/refresh tokens descended from the original grant).
+
+#### Scenario: Refresh issues a rotated pair
+
+- **GIVEN** a valid, unconsumed refresh token
+- **WHEN** the client POSTs it with `grant_type=refresh_token`
+- **THEN** the server SHALL return a new `access_token` and a new `refresh_token`, and the presented refresh token SHALL no longer be accepted
+
+#### Scenario: Refresh reuse revokes the family
+
+- **GIVEN** a refresh token that has already been rotated once
+- **WHEN** the same (now-consumed) refresh token is presented again
+- **THEN** the server SHALL reject it with `invalid_grant` and SHALL revoke all access and refresh tokens in that grant family
+
+### Requirement: Issued OAuth tokens MUST map to the existing scope grammar
+
+The scope granted at consent SHALL be expressed in the existing `TokenScope` grammar (`*`, `read:*`, `project:<id>`, `read:project:<id>`) so that OAuth-minted tokens are authorized by the same `isAuthorized()` checks as static tokens. The mapping SHALL fail closed: an absent, empty, or unrecognized requested scope SHALL yield least privilege (`read:*`); write access (`*`) SHALL be granted only when write is explicitly requested. Project restriction MAY additionally derive from the connector's request path (`/mcp/<slug>`) under the existing path-scoping contract.
+
+#### Scenario: Unknown or empty requested scope fails closed
+
+- **GIVEN** an authorization request whose `scope` is absent, empty, or unrecognized
+- **WHEN** consent is granted
+- **THEN** the minted access token SHALL receive least privilege (`read:*`), not full access
+
+#### Scenario: Read-only OAuth grant cannot write
+
+- **GIVEN** an access token minted from a grant consented as read-only (`read:*`)
+- **WHEN** the token is used to invoke `memory.save`
+- **THEN** the request SHALL be rejected with the same `403`-class authorization failure as a static `read:*` token

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       drizzle-orm:
         specifier: ^0.36.0
         version: 0.36.4(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
       hono:
         specifier: ^4.6.0
         version: 4.12.18
@@ -73,6 +76,9 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.0
         version: 7.6.13
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
       '@types/node':
         specifier: ^22.7.0
         version: 22.19.19
@@ -1840,6 +1846,18 @@ packages:
         integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==,
       }
 
+  '@types/body-parser@1.19.6':
+    resolution:
+      {
+        integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==,
+      }
+
+  '@types/connect@3.4.38':
+    resolution:
+      {
+        integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==,
+      }
+
   '@types/conventional-commits-parser@5.0.2':
     resolution:
       {
@@ -1858,6 +1876,24 @@ packages:
         integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
       }
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution:
+      {
+        integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==,
+      }
+
+  '@types/express@5.0.6':
+    resolution:
+      {
+        integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==,
+      }
+
+  '@types/http-errors@2.0.5':
+    resolution:
+      {
+        integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==,
+      }
+
   '@types/json-schema@7.0.15':
     resolution:
       {
@@ -1874,6 +1910,30 @@ packages:
     resolution:
       {
         integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==,
+      }
+
+  '@types/qs@6.15.1':
+    resolution:
+      {
+        integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==,
+      }
+
+  '@types/range-parser@1.2.7':
+    resolution:
+      {
+        integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==,
+      }
+
+  '@types/send@1.2.1':
+    resolution:
+      {
+        integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==,
+      }
+
+  '@types/serve-static@2.2.0':
+    resolution:
+      {
+        integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==,
       }
 
   '@typescript-eslint/eslint-plugin@8.59.3':
@@ -6486,6 +6546,15 @@ snapshots:
     dependencies:
       '@types/node': 22.19.19
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.19.19
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.19.19
+
   '@types/conventional-commits-parser@5.0.2':
     dependencies:
       '@types/node': 22.19.19
@@ -6494,6 +6563,21 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 22.19.19
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -6501,6 +6585,19 @@ snapshots:
   '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 22.19.19
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.19.19
 
   '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:


### PR DESCRIPTION
## Why

OAuth-capable MCP clients (Claude Code as a remote connector, ChatGPT custom connectors) only attach to authenticated MCP servers through an OAuth 2.1 flow — they mint and carry the token themselves and **cannot** accept a pasted static token. This change lets Rembric be added as such a connector while staying a single self-hosted process.

Scoped to **single-tenant private use** (your own instance), **not** the public ChatGPT app directory — that would force a hosted multi-tenant pivot, breaking the single-SQLite / operator-token invariants.

## What changed

- **Self-contained OAuth 2.1 authorization server**, built on the **official MCP SDK** (`mcpAuthRouter`). The vetted SDK owns the protocol surface — PKCE `S256`, redirect/`state` validation, metadata discovery, Dynamic Client Registration, rate limiting. Our code is only the storage + logic **provider** + the consent screen.
- **Additive, not replacing.** Off unless `REMBRIC_PUBLIC_URL` is set. The existing static operator-token path is untouched; both kinds of token authenticate `/mcp` through the same `authenticate()`.
- New `oauth_clients` / `oauth_authorization_codes` / `oauth_tokens` tables (additive migration `0013`; static `tokens` table untouched) + repository.
- `OAuthService`: DCR, single-use authorization codes, **refresh-token rotation with reuse → family revocation** (RFC 9700), 256-bit opaque secrets hashed at rest (SHA-256), **fail-closed** scope mapping, https + loopback redirect policy.
- Dashboard **consent screen** (reuses the signed dashboard session + CSRF) reached via an HMAC-signed authorize→consent hand-off.
- `/mcp` `401` advertises `WWW-Authenticate` (RFC 9728) when OAuth is enabled.

## Config

| Variable | Default | Meaning |
| --- | --- | --- |
| `REMBRIC_PUBLIC_URL` | _unset_ | Public https issuer (`http://localhost` allowed for local testing). Set it to enable OAuth; off when unset. |
| `REMBRIC_OAUTH_ACCESS_TTL` | `3600` | Access-token lifetime (s). |
| `REMBRIC_OAUTH_REFRESH_TTL` | `2592000` | Refresh-token lifetime (s, 30d). |

Signing + single-user consent login reuse existing secrets (`REMBRIC_SESSION_SECRET` / `REMBRIC_ADMIN_TOKEN`).

## Security

- Two independent adversarial reviews (Judgment Day) — **APPROVED**, no critical/real-warning findings. Fixed during review: fail-open→fail-closed scope default, https+loopback-only redirect registration (open-redirect), and a consent double-escape bug.
- PKCE is fully delegated to the SDK (our redundant impl was removed). Tokens hashed at rest; immediate revocation; access/refresh non-confusable.

## Testing

- Unit (service, provider, areq), real-HTTP OAuth dance (metadata → DCR → token → refresh), consent-route, invariants (additive migration / `tokens` untouched), and a **full-server local e2e** validating **both** auth paths.
- **803 tests green**, typecheck + lint clean.
- Validated **live** against the dev Docker stack with Claude Code end-to-end (connect → consent → `memory.save`/`memory.search`).

## Dependencies

`express` (+ `@types/express`) declared direct — already present transitively under `@modelcontextprotocol/sdk`, so **no new packages** in the lockfile. Cleared via the `npm-security-best-practices` checklist.

## Docs & spec

Lean doc footprint (no new files): `docs/agents.md` (OAuth connection paragraph), `README.md` (config row), `SECURITY.md` (endpoints in scope). OpenSpec change `oauth2-resource-server-for-remote-mcp` archived; canonical specs synced (`mcp-oauth` created, `auth` +3, `mcp-api` +2).

## Not in this PR (deferred, by decision)

- Simplifying the bundled plugins to use OAuth — orthogonal: the session-lifecycle hooks are out-of-band HTTP processes that can't ride the client's OAuth token, so they'd still need a static token. Revisit only if static-token onboarding becomes a real pain (own change + e2e).
- Public ChatGPT app-directory submission (needs multi-tenant SaaS) and RFC 8707 audience binding (relevant only if multi-tenant).