### PR TITLE
fix(server): echo OAuth scope vocabulary in /token + ChatGPT connector docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,25 +28,29 @@
 
 ## Supported agents
 
-Rembric works with any agent that speaks MCP or HTTP. First-class plugins handle session lifecycle + per-project path-scoping automatically; everything else gets the same memory tools via a plain MCP URL.
+Rembric works with any agent that speaks MCP or HTTP. First-class plugins handle session lifecycle + per-project path-scoping automatically; everything else gets the same memory tools via a plain MCP URL. **ChatGPT** connects as a custom MCP connector over OAuth 2.1 (no static token) — see [docs/agents.md](./docs/agents.md#chatgpt-custom-mcp-connector-over-oauth).
 
 <table>
   <tr>
-    <td align="center" valign="top" width="25%">
+    <td align="center" valign="top" width="20%">
       <a href="./apps/plugin/README.md"><img src="https://matthiasroder.com/content/images/2026/01/Claude.png?size=120" alt="Claude Code" width="64" height="64" /><br/><b>Claude Code</b></a><br/>
       <sub>native plugin · 4 hooks · MCP</sub>
     </td>
-    <td align="center" valign="top" width="25%">
+    <td align="center" valign="top" width="20%">
       <a href="./apps/plugin/.opencode-plugin/README.md"><img src="https://github.com/opencode-ai.png?size=120" alt="opencode" width="64" height="64" /><br/><b>opencode</b></a><br/>
       <sub>native plugin · MCP</sub>
     </td>
-    <td align="center" valign="top" width="25%">
+    <td align="center" valign="top" width="20%">
       <a href="./docs/agents.md#codex-cli-recommended-bundled-plugin"><img src="https://github.com/openai.png?size=120" alt="Codex CLI" width="64" height="64" /><br/><b>Codex CLI</b></a><br/>
       <sub>native plugin · 4 hooks · MCP</sub>
     </td>
-    <td align="center" valign="top" width="25%">
+    <td align="center" valign="top" width="20%">
       <a href="./apps/plugin/.hermes-plugin/README.md"><img src="https://github.com/NousResearch.png?size=120" alt="Hermes Agent" width="64" height="64" /><br/><b>Hermes Agent</b></a><br/>
       <sub>native provider · MCP</sub>
+    </td>
+    <td align="center" valign="top" width="20%">
+      <a href="./docs/agents.md#chatgpt-custom-mcp-connector-over-oauth"><img src="https://github.com/openai.png?size=120" alt="ChatGPT" width="64" height="64" /><br/><b>ChatGPT</b></a><br/>
+      <sub>custom connector · OAuth · MCP</sub>
     </td>
   </tr>
 </table>

--- a/apps/server/src/dashboard/oauth-consent.test.ts
+++ b/apps/server/src/dashboard/oauth-consent.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createRepositories } from '../db/repositories/index.js';
 import { OAuthRepository } from '../db/repositories/oauth-repository.js';
 import { signAuthRequest, type AuthRequest } from '../services/oauth-areq.js';
-import { OAuthService } from '../services/oauth.js';
+import { OAuthService, resolveGrantedScope } from '../services/oauth.js';
 import { SessionsService } from '../services/sessions.js';
 import { TokensService } from '../services/tokens.js';
 import { createTestDb, type TestDb } from '../test/db.js';
@@ -96,10 +96,12 @@ describe('OAuth consent route', () => {
     const url = new URL(loc);
     expect(url.searchParams.get('code')).toBeTruthy();
     expect(url.searchParams.get('state')).toBe('st-9');
-    // The issued code is redeemable for the granted (write) scope.
+    // The issued code redeems to the granted OAuth scope ("mcp"), which
+    // derives to the write-capable authz TokenScope.
     const code = url.searchParams.get('code')!;
     const pair = oauth.redeemCode({ code, clientId, redirectUri: REDIRECT });
-    expect(pair.scope).toBe('*');
+    expect(pair.scope).toBe('mcp');
+    expect(resolveGrantedScope(pair.scope)).toBe('*');
   });
 
   it('POST deny redirects with access_denied and issues no code', async () => {

--- a/apps/server/src/dashboard/oauth-consent.ts
+++ b/apps/server/src/dashboard/oauth-consent.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 
 import { verifyAuthRequest } from '../services/oauth-areq.js';
-import { resolveGrantedScope, type OAuthService } from '../services/oauth.js';
+import { grantedOAuthScope, resolveGrantedScope, type OAuthService } from '../services/oauth.js';
 import type { SessionsService } from '../services/sessions.js';
 
 import { btn, flash } from './components.js';
@@ -38,13 +38,12 @@ export function createOAuthConsentRouter(deps: OAuthConsentDeps): Hono {
     if (!client) return c.html(renderError('Unknown OAuth client.'), 400);
 
     const session = c.get('session' as never) as ResolvedSession;
-    const granted = resolveGrantedScope(areq.scope);
     return c.html(
       renderConsent({
         blob,
         clientName: client.clientName ?? areq.clientId,
         redirectHost: safeHost(areq.redirectUri),
-        granted,
+        grantedScope: grantedOAuthScope(areq.scope),
         csrf: csrfInput(session.session, deps.sessions, FORM),
       }),
     );
@@ -65,12 +64,11 @@ export function createOAuthConsentRouter(deps: OAuthConsentDeps): Hono {
       );
     }
 
-    const scope = resolveGrantedScope(areq.scope);
     const code = deps.oauth.issueCode({
       clientId: areq.clientId,
       redirectUri: areq.redirectUri,
       codeChallenge: areq.codeChallenge,
-      scope,
+      scope: grantedOAuthScope(areq.scope),
       subject: session.tokenId,
     });
     return c.redirect(buildRedirect(areq.redirectUri, { code, state: areq.state }));
@@ -120,12 +118,12 @@ function renderConsent(o: {
   blob: string;
   clientName: string;
   redirectHost: string;
-  granted: string;
+  grantedScope: string;
   csrf: ReturnType<typeof csrfInput>;
 }): string {
   // `html` escapes every interpolated string once — do NOT pre-escape here
   // (that double-encodes, e.g. "&" → "&amp;amp;").
-  const access = o.granted === 'read:*' ? 'Read-only' : 'Read & write';
+  const access = resolveGrantedScope(o.grantedScope) === 'read:*' ? 'Read-only' : 'Read & write';
   return consentShell(html`
     ${consentBrand()}
     <h1><span class="hl-lime">Authorize</span> Application.</h1>
@@ -136,7 +134,8 @@ function renderConsent(o: {
     <div class="consent-grant">
       <span class="lbl">Granted access</span>
       <span class="val"
-        ><span style="color:var(--lime)">${access}</span> · scope <code>${o.granted}</code></span
+        ><span style="color:var(--lime)">${access}</span> · scope
+        <code>${o.grantedScope}</code></span
       >
     </div>
     <p class="consent-note">

--- a/apps/server/src/server/bootstrap.ts
+++ b/apps/server/src/server/bootstrap.ts
@@ -13,7 +13,7 @@ import { AgentSessionsService } from '../services/agent-sessions.js';
 import { EmbeddingWorker } from '../services/embedding-worker.js';
 import { DomainError } from '../services/errors.js';
 import { MemoryService } from '../services/memory.js';
-import { OAuthService } from '../services/oauth.js';
+import { OAuthService, SUPPORTED_OAUTH_SCOPES } from '../services/oauth.js';
 import { ProjectsService } from '../services/projects.js';
 import { PromptsService } from '../services/prompts.js';
 import { RelationsService } from '../services/relations.js';
@@ -294,7 +294,7 @@ export async function bootstrap(
             provider: oauthProvider,
             service: oauthService,
             issuer: oauthIssuer,
-            scopesSupported: ['mcp', 'read'],
+            scopesSupported: [...SUPPORTED_OAUTH_SCOPES],
           }
         : null,
     dashboard: {

--- a/apps/server/src/server/oauth-http.test.ts
+++ b/apps/server/src/server/oauth-http.test.ts
@@ -91,13 +91,14 @@ describe('OAuth authorization server over HTTP (SDK router + our provider)', () 
     const client = (await regRes.json()) as { client_id: string };
     expect(client.client_id).toMatch(/^oauthc_/);
 
-    // Simulate consent approval: mint a code for the registered client.
+    // Simulate consent approval: mint a code with the granted OAuth scope
+    // (the advertised vocabulary, as the consent screen stores it).
     const { verifier, challenge } = pkce();
     const code = oauth.issueCode({
       clientId: client.client_id,
       redirectUri: REDIRECT,
       codeChallenge: challenge,
-      scope: '*',
+      scope: 'mcp',
       subject: 'operator',
     });
 
@@ -111,10 +112,12 @@ describe('OAuth authorization server over HTTP (SDK router + our provider)', () 
     expect(tok.status).toBe(200);
     expect(tok.body.access_token).toBeTruthy();
     expect(tok.body.token_type).toBe('Bearer');
+    // /token echoes the requested OAuth scope vocabulary, NOT the internal "*".
+    expect(tok.body.scope).toBe('mcp');
     const refreshToken = tok.body.refresh_token as string;
     expect(refreshToken).toBeTruthy();
 
-    // Resolve the minted access token through the service (same path /mcp uses).
+    // ...while the internal authz scope derives to the write-capable TokenScope.
     expect(oauth.authenticateAccessToken(tok.body.access_token as string)?.scope).toBe('*');
 
     const refreshed = await form('/token', {

--- a/apps/server/src/services/oauth.test.ts
+++ b/apps/server/src/services/oauth.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { OAuthRepository } from '../db/repositories/oauth-repository.js';
 import { createTestDb, type TestDb } from '../test/db.js';
 
-import { OAuthError, OAuthService, resolveGrantedScope } from './oauth.js';
+import { grantedOAuthScope, OAuthError, OAuthService, resolveGrantedScope } from './oauth.js';
 
 const TTL = { accessTtlMs: 3_600_000, refreshTtlMs: 30 * 86_400_000 };
 
@@ -260,5 +260,29 @@ describe('resolveGrantedScope', () => {
 
   it('grants write when both read and write are requested', () => {
     expect(resolveGrantedScope('read mcp')).toBe('*');
+  });
+});
+
+describe('grantedOAuthScope', () => {
+  it('echoes requested scopes restricted to the advertised set', () => {
+    expect(grantedOAuthScope('mcp read')).toBe('mcp read');
+    expect(grantedOAuthScope('mcp')).toBe('mcp');
+    expect(grantedOAuthScope('read')).toBe('read');
+  });
+
+  it('drops unsupported scopes', () => {
+    expect(grantedOAuthScope('mcp openid profile')).toBe('mcp');
+    expect(grantedOAuthScope('write admin')).toBe('read');
+  });
+
+  it('fails closed to read when nothing supported is requested', () => {
+    expect(grantedOAuthScope(undefined)).toBe('read');
+    expect(grantedOAuthScope('')).toBe('read');
+    expect(grantedOAuthScope('garbage')).toBe('read');
+  });
+
+  it('round-trips through resolveGrantedScope to the right authz scope', () => {
+    expect(resolveGrantedScope(grantedOAuthScope('mcp read'))).toBe('*');
+    expect(resolveGrantedScope(grantedOAuthScope('read'))).toBe('read:*');
   });
 });

--- a/apps/server/src/services/oauth.ts
+++ b/apps/server/src/services/oauth.ts
@@ -50,7 +50,8 @@ export interface IssueCodeInput {
   clientId: string;
   redirectUri: string;
   codeChallenge: string;
-  scope: TokenScope;
+  /** OAuth scope string in the advertised vocabulary (e.g. "mcp read"). */
+  scope: string;
   subject: string;
 }
 
@@ -58,7 +59,8 @@ export interface TokenPair {
   accessToken: string;
   refreshToken: string;
   expiresInSeconds: number;
-  scope: TokenScope;
+  /** Granted OAuth scope string, echoed back to the client in /token. */
+  scope: string;
 }
 
 export interface ResolvedAccessToken {
@@ -174,7 +176,7 @@ export class OAuthService {
     return this.issueTokenPair({
       clientId: code.clientId,
       familyId: `oauthf_${ulid(this.now().getTime())}`,
-      scope: code.scope as TokenScope,
+      scope: code.scope,
       subject: code.subject,
     });
   }
@@ -214,7 +216,7 @@ export class OAuthService {
     return this.issueTokenPair({
       clientId: refresh.clientId,
       familyId: refresh.familyId,
-      scope: refresh.scope as TokenScope,
+      scope: refresh.scope,
       subject: refresh.subject,
     });
   }
@@ -226,7 +228,10 @@ export class OAuthService {
     if (token.revokedAt) return null;
     if (token.expiresAt.getTime() <= this.now().getTime()) return null;
     return {
-      scope: token.scope as TokenScope,
+      // Stored scope is the granted OAuth string; derive the authz TokenScope
+      // at read time. Back-compatible with tokens that stored a TokenScope
+      // directly: resolveGrantedScope('*')='*', resolveGrantedScope('read:*')='read:*'.
+      scope: resolveGrantedScope(token.scope),
       subject: token.subject,
       clientId: token.clientId,
       expiresAtSeconds: Math.floor(token.expiresAt.getTime() / 1000),
@@ -245,7 +250,7 @@ export class OAuthService {
   private issueTokenPair(input: {
     clientId: string;
     familyId: string;
-    scope: TokenScope;
+    scope: string;
     subject: string;
   }): TokenPair {
     const accessSecret = generateSecret();
@@ -263,7 +268,7 @@ export class OAuthService {
   private insertToken(
     kind: 'access' | 'refresh',
     secret: string,
-    grant: { clientId: string; familyId: string; scope: TokenScope; subject: string },
+    grant: { clientId: string; familyId: string; scope: string; subject: string },
     ttlMs: number,
   ): OAuthToken {
     const ts = this.now();
@@ -299,6 +304,23 @@ export function resolveGrantedScope(requestedScope: string | undefined): TokenSc
     (t) => t === '*' || t === 'mcp' || t === 'mcp:write' || t.endsWith(':write'),
   );
   return wantsWrite ? '*' : 'read:*';
+}
+
+/** OAuth scopes advertised in the metadata and grantable at consent. */
+export const SUPPORTED_OAUTH_SCOPES = ['mcp', 'read'] as const;
+
+/**
+ * The OAuth scope string to grant: the requested scopes restricted to the
+ * advertised set, echoed verbatim in the token response so the client sees
+ * its requested scopes as granted. Falls closed to `read` when nothing
+ * supported was requested.
+ */
+export function grantedOAuthScope(requestedScope: string | undefined): string {
+  const supported = SUPPORTED_OAUTH_SCOPES as readonly string[];
+  const kept = (requestedScope ?? '')
+    .split(/\s+/)
+    .filter((t) => supported.includes(t.toLowerCase()));
+  return kept.length > 0 ? kept.join(' ') : 'read';
 }
 
 function generateSecret(): string {

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
 # Agent integration
 
-Rembric ships first-class plugins for **Claude Code**, **Codex CLI**, **Hermes Agent**, and **opencode**.
+Rembric ships first-class plugins for **Claude Code**, **Codex CLI**, **Hermes Agent**, and **opencode**. **ChatGPT** connects as a custom MCP connector over OAuth 2.1 (no plugin) — see [ChatGPT](#chatgpt-custom-mcp-connector-over-oauth).
 
 > **Install with the TUI — the single, recommended path.** [`install.sh`](../install.sh) (canonical URL `https://raw.githubusercontent.com/susomejias/rembric/main/install.sh`) is one brand-styled menu that prepares the server and installs / updates / uninstalls every client plugin, detecting what you have and at which version. Inspect-first: `curl -fsSL https://raw.githubusercontent.com/susomejias/rembric/main/install.sh -o rembric-install.sh && less rembric-install.sh && sh rembric-install.sh`. Pin a release with `--ref=<tag>`. The per-client commands in the sections below are what the installer runs under the hood — documented here as the **manual fallback**.
 
@@ -36,6 +36,45 @@ Two of its lists ask the agent to act, and they are deliberately different shape
 When a session's snippet isn't enough — typically when **resuming work in another client (multi-agent / cross-client handoff)** — call `memory.session_get({ sessionId })` to fetch that session's **full, untruncated** summary on demand. It is read-only and scope-enforced: a session id outside the caller's scope (or soft-deleted) returns `not_found`. Truncation is display-only; the full summary always stays in storage (cap: the server-side `SUMMARY_MAX_CHARS`).
 
 ## Validated configs
+
+### ChatGPT (custom MCP connector over OAuth)
+
+ChatGPT connects as a **custom MCP connector** (no plugin, no static token) using the OAuth path above. Validated end-to-end (connect → consent → `memory.*`).
+
+1. **Enable OAuth on the server**: set `REMBRIC_PUBLIC_URL` to the public **https** origin (e.g. `https://memory.example.com`) — the OAuth issuer, **without** the `/mcp` suffix. ChatGPT reaches the server from OpenAI's backend, so a public HTTPS endpoint is required (`http://localhost` works only for local clients, not ChatGPT). Recreate the container so it loads the env.
+2. **Add the connector** in ChatGPT → Settings → Apps → Developer mode → new connector:
+   - URL: `https://memory.example.com/mcp/<slug>` (the `/<slug>` binds it to that project; omit for global).
+   - Authentication: **OAuth**. Leave the advanced panel alone — the server advertises Dynamic Client Registration, so ChatGPT registers itself automatically (no client id/secret).
+3. **Consent**: the browser lands on the Rembric consent screen → sign in with your `REMBRIC_ADMIN_TOKEN` → **Authorize**. ChatGPT manages the token (refresh included) from then on.
+
+Per-project = one connector per `/mcp/<slug>`. Developer mode is a beta ChatGPT feature; on Business/Enterprise an admin can publish the connector workspace-wide.
+
+ChatGPT has no session-lifecycle hooks (those are plugin-only), so drive the flow from the model with a custom instruction. Recommended (Settings → Personalization → Custom instructions), tuned to use Rembric as the long-term memory:
+
+```text
+Use Rembric (connected via MCP) as my canonical long-term memory. It is the
+source of truth about who I am, my preferences, decisions, and work context —
+above your built-in memory.
+
+- BEFORE your first substantive reply in a conversation, or whenever the request
+  depends on who I am / my preferences / prior work: call memory.context (or
+  memory.search by topic) and ground your answer in what it returns. Don't
+  assume; if Rembric doesn't have it, say so.
+- The MOMENT something durable comes up (a preference, decision, stable fact
+  about me, discovery, config): save it immediately with memory.save. If it
+  updates something already stored, pass topic_key to supersede it.
+- If memory.save returns candidates[] (possible conflicts), resolve them with
+  memory.judge.
+- If your built-in memory and Rembric disagree, Rembric wins; reconcile by
+  saving the correct version to Rembric.
+- Before closing a work topic: call memory.session_summary (title + goal /
+  findings / done / next steps).
+
+Do this as a natural part of the flow; don't ask permission unless the content
+is sensitive.
+```
+
+> ChatGPT calls MCP tools when it judges them relevant, not on every turn — occasionally you'll still nudge it ("save that to Rembric"). The tool descriptions already prompt proactive use; the instruction reinforces it.
 
 ### Claude Code (plain JSON, if not using the plugin)
 

--- a/openspec/changes/archive/2026-06-15-oauth-scope-echo-and-chatgpt-docs/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-15-oauth-scope-echo-and-chatgpt-docs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/archive/2026-06-15-oauth-scope-echo-and-chatgpt-docs/design.md
+++ b/openspec/changes/archive/2026-06-15-oauth-scope-echo-and-chatgpt-docs/design.md
@@ -1,0 +1,51 @@
+## Context
+
+`resolveGrantedScope(requestedScope)` maps an OAuth scope string → `TokenScope`. The OAuth change stored its _output_ (`TokenScope`) on the code/token and echoed that in `/token`. So `scope_supported = [mcp, read]` is advertised, the client requests `mcp read`, and we reply `scope: "*"` — a vocabulary the client never asked for → ChatGPT's "not all permissions granted" warning. Authorization itself is fine (`*` is a valid `TokenScope`); only the wire echo is wrong.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The `/token` response echoes the granted scopes in the advertised OAuth vocabulary, so the client's requested-vs-granted comparison passes.
+- Internal authorization is unchanged: `isAuthorized()` still receives a real `TokenScope`.
+- Zero migration; backward-compatible with tokens already issued in prod.
+- Single source of truth for the advertised scope list.
+
+**Non-Goals:**
+
+- Per-scope tool gating, richer scopes, RFC 8707 audience binding (out of scope; deferred).
+- Any change to the static-token path, PKCE (SDK-owned), or the consent/login flow beyond the displayed scope text.
+
+## Decisions
+
+### D1 — Store the OAuth scope string; derive `TokenScope` at read time
+
+The code/token `scope` column holds the **granted OAuth scope string** (advertised vocabulary). `authenticateAccessToken` returns `resolveGrantedScope(token.scope)` as the authz `TokenScope`. `/token` echoes the stored string.
+
+- _Why:_ puts the protocol vocabulary on the wire (what the client expects) while keeping `resolveGrantedScope` as the single authz mapper — just moved from write-time to read-time.
+- _Alternative considered:_ add a second column (`oauth_scope` + `token_scope`). Rejected: needs a migration for no benefit — one column + a read-time map is sufficient and `resolveGrantedScope` is pure.
+
+### D2 — Backward compatibility is free
+
+`resolveGrantedScope` is idempotent on the values prod already stored: `resolveGrantedScope("*") === "*"` and `resolveGrantedScope("read:*") === "read:*"` (neither matches the write-trigger set beyond `*` itself). So existing access/refresh tokens keep authorizing exactly as before; no backfill, no migration.
+
+```
+old token.scope="*"      → authenticateAccessToken → resolveGrantedScope("*")       → "*"      (unchanged)
+old token.scope="read:*" → authenticateAccessToken → resolveGrantedScope("read:*")  → "read:*" (unchanged)
+new token.scope="mcp read" → authenticateAccessToken → resolveGrantedScope("mcp read") → "*"   (write)
+new token.scope="read"     → authenticateAccessToken → resolveGrantedScope("read")     → "read:*"
+```
+
+### D3 — `grantedOAuthScope` filters to the advertised set, fail-closed
+
+The granted OAuth string = requested scopes ∩ `SUPPORTED_OAUTH_SCOPES`, joined; empty → `read` (least privilege). `SUPPORTED_OAUTH_SCOPES = ['mcp','read']` is exported and consumed by both `mcpAuthRouter({scopesSupported})` and the grant filter, so the advertised set and the grantable set cannot drift.
+
+## Risks / Trade-offs
+
+- **[Risk] An existing test asserts the old vocabulary** → `oauth-consent.test.ts` checks `redeemCode(...).scope === '*'` while consenting `scope: 'mcp'`. → Mitigation: update it to assert `resolveGrantedScope(pair.scope) === '*'` (authz scope) — the only test that changes; `auth.test.ts` / `oauth-http.test.ts` / `oauth-e2e.test.ts` were verified to pass unchanged because they exercise `*`/`read:*` which round-trip.
+- **[Trade-off] The `scope` column's stored vocabulary now differs between pre- and post-fix rows** (`*` vs `mcp`) → Accepted: `resolveGrantedScope` normalizes both at read time, so the mix is invisible to authz. Documented in D2.
+- **[Risk] Consent display showed `scope *`** → now shows the OAuth scope (`mcp read`); the human-readable access label (`Read & write` / `Read-only`) still derives from `resolveGrantedScope`.
+
+## Open Questions
+
+- None. Scope is intentionally narrow.

--- a/openspec/changes/archive/2026-06-15-oauth-scope-echo-and-chatgpt-docs/proposal.md
+++ b/openspec/changes/archive/2026-06-15-oauth-scope-echo-and-chatgpt-docs/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+When an OAuth client (ChatGPT) connects, the `/token` response returns Rembric's **internal** `TokenScope` (`*` / `read:*`) as the `scope`, not the **advertised OAuth scope vocabulary** (`mcp` / `read`) the client requested. ChatGPT compares its requested scopes against the granted `scope` string, finds neither `mcp` nor `read`, and warns _"no se concedieron todos los permisos solicitados"_. The tools still work (the token carries `*` internally), but the warning is wrong and erodes trust.
+
+The root cause: we conflated the **wire-protocol scope** (OAuth names, what the client speaks) with the **authorization scope** (`TokenScope`, what `isAuthorized()` consumes). `resolveGrantedScope` is a mapper from the former to the latter; the bug stored its _output_ instead of its _input_.
+
+Separately, ChatGPT is now a validated OAuth client but is absent from the documented supported-agents surface, and the recommended "Rembric-as-memory" custom instruction only exists in Spanish.
+
+## What Changes
+
+- **Decouple OAuth scope from `TokenScope`.** Store the granted **OAuth scope string** (`mcp` / `read`, restricted to the advertised set) on the authorization code and token; echo it verbatim in the `/token` response so the client sees its requested scopes as granted. Derive the internal `TokenScope` at **authorization read time** via `resolveGrantedScope`. **Backward-compatible**: tokens already issued (0.21.16) that stored `*` / `read:*` still resolve correctly, because `resolveGrantedScope` maps those to themselves.
+- Single-source the advertised scopes as `SUPPORTED_OAUTH_SCOPES` (used by both the metadata router and the grant filter).
+- Update the consent screen to display the granted OAuth scope vocabulary.
+- **Docs (same PR):** add ChatGPT to the supported clients (README + `docs/agents.md`), document the OAuth connector connection for ChatGPT, and add the recommended memory-first custom instruction **in English**.
+
+No change to: the `/mcp` authorization path (`isAuthorized` still receives a real `TokenScope`), token hashing, PKCE (SDK-owned), the append-only / scope-at-service-layer invariants, or the `oauth_*` schema (the `scope` column stays `text`; only its stored vocabulary changes — no migration).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `mcp-oauth`: the scope-grammar requirement is refined — the `/token` response (and the stored grant) SHALL use the advertised OAuth scope vocabulary; the internal `TokenScope` is derived from it at authorization time. Fail-closed mapping is preserved.
+
+## Impact
+
+- **Code:** `apps/server/src/services/oauth.ts` (`IssueCodeInput`/`TokenPair` scope → `string`; `authenticateAccessToken` derives `TokenScope`; new `SUPPORTED_OAUTH_SCOPES` + `grantedOAuthScope`); `apps/server/src/dashboard/oauth-consent.ts` (store + display granted OAuth scope); `apps/server/src/server/bootstrap.ts` (`scopesSupported` from the single source).
+- **Tests:** update `oauth-consent.test.ts` (granted scope is now an OAuth string); add `grantedOAuthScope` unit tests + a `/token`-echoes-`mcp`/`read` assertion in `oauth-http.test.ts`. `auth.test.ts` / `oauth-e2e.test.ts` unaffected (verified: `*`/`read:*` map to themselves).
+- **Docs:** `README.md` (supported-agents table + config note), `docs/agents.md` (ChatGPT connection + English recommended instruction).
+- **Spec:** delta to `openspec/specs/mcp-oauth/spec.md`.
+- **No migration**, no new dependency.

--- a/openspec/changes/archive/2026-06-15-oauth-scope-echo-and-chatgpt-docs/specs/mcp-oauth/spec.md
+++ b/openspec/changes/archive/2026-06-15-oauth-scope-echo-and-chatgpt-docs/specs/mcp-oauth/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Issued OAuth tokens MUST map to the existing scope grammar
+
+The `/token` response and the stored grant SHALL express scope in the **advertised OAuth scope vocabulary** (`SUPPORTED_OAUTH_SCOPES`, e.g. `mcp`, `read`) — the granted scope SHALL be the requested scopes restricted to that advertised set, echoed verbatim in the token response so the client observes its requested scopes as granted. The internal `TokenScope` (`*`, `read:*`, `project:<id>`, `read:project:<id>`) used by `isAuthorized()` SHALL be **derived from the granted OAuth scope at authorization time**, not stored as the wire scope. The derivation SHALL fail closed: an absent, empty, or unrecognized requested scope SHALL yield least privilege (`read:*`); write access (`*`) SHALL be granted only when a write-capable scope is explicitly requested. Project restriction MAY additionally derive from the connector's request path (`/mcp/<slug>`) under the existing path-scoping contract.
+
+#### Scenario: Token response echoes the requested OAuth scope vocabulary
+
+- **GIVEN** a client that requested `scope=mcp read` (the advertised scopes)
+- **WHEN** consent is granted and the code is exchanged at `/token`
+- **THEN** the token response `scope` SHALL be `mcp read` (the advertised vocabulary), NOT the internal `TokenScope` (`*`)
+
+#### Scenario: Internal authorization scope is derived at read time
+
+- **GIVEN** an access token whose stored grant is `mcp read`
+- **WHEN** the token authenticates a `/mcp` request
+- **THEN** `isAuthorized()` SHALL receive a real `TokenScope` (`*`) derived from the granted OAuth scope, authorizing exactly as a static `*` token
+
+#### Scenario: Unknown or empty requested scope fails closed
+
+- **GIVEN** an authorization request whose `scope` is absent, empty, or unrecognized
+- **WHEN** consent is granted
+- **THEN** the derived authorization scope SHALL be least privilege (`read:*`), not full access
+
+#### Scenario: Read-only OAuth grant cannot write
+
+- **GIVEN** an access token minted from a grant consented as read-only (`read`)
+- **WHEN** the token is used to invoke `memory.save`
+- **THEN** the request SHALL be rejected with the same `403`-class authorization failure as a static `read:*` token

--- a/openspec/changes/archive/2026-06-15-oauth-scope-echo-and-chatgpt-docs/tasks.md
+++ b/openspec/changes/archive/2026-06-15-oauth-scope-echo-and-chatgpt-docs/tasks.md
@@ -1,0 +1,31 @@
+## 1. Decouple OAuth scope from TokenScope (services/oauth.ts)
+
+- [x] 1.1 Change `IssueCodeInput.scope` and `TokenPair.scope` from `TokenScope` to `string` (the granted OAuth scope string); drop the `as TokenScope` casts in `redeemCode`/`refresh`/`issueTokenPair`/`insertToken`.
+- [x] 1.2 In `authenticateAccessToken`, return `scope: resolveGrantedScope(token.scope)` (derive the authz `TokenScope` at read time). `ResolvedAccessToken.scope` stays `TokenScope`.
+- [x] 1.3 Add `export const SUPPORTED_OAUTH_SCOPES = ['mcp','read'] as const` and `export function grantedOAuthScope(requested?: string): string` (requested ∩ supported, joined; empty → `read`).
+
+## 2. Consent (dashboard/oauth-consent.ts)
+
+- [x] 2.1 Store the granted OAuth scope string: `issueCode({ scope: grantedOAuthScope(areq.scope) })` instead of `resolveGrantedScope(...)`.
+- [x] 2.2 Display the granted OAuth scope vocabulary (e.g. `mcp read`) in the consent grant box; keep the human label (`Read & write` / `Read-only`) derived via `resolveGrantedScope`.
+
+## 3. Single-source the advertised scopes (server/bootstrap.ts)
+
+- [x] 3.1 Pass `scopesSupported: SUPPORTED_OAUTH_SCOPES` to the http `oauth` block instead of the inline `['mcp','read']` literal.
+
+## 4. Tests
+
+- [x] 4.1 Update `oauth-consent.test.ts`: the approve flow stores an OAuth string — assert `resolveGrantedScope(pair.scope) === '*'` (authz scope) rather than `pair.scope === '*'`.
+- [x] 4.2 Add `grantedOAuthScope` unit tests (mcp read → "mcp read"; read → "read"; unknown/empty → "read"; drops unsupported tokens) in `oauth.test.ts`.
+- [x] 4.3 In `oauth-http.test.ts`, assert the `/token` response `scope` echoes `mcp` (the requested advertised vocabulary), not `*`.
+- [x] 4.4 Confirm `auth.test.ts` and `oauth-e2e.test.ts` stay green unchanged (backward-compat: `*`/`read:*` round-trip).
+
+## 5. Docs (same PR)
+
+- [x] 5.1 Add ChatGPT to the supported clients in `README.md` (supported-agents table, as an MCP/OAuth connector — no native plugin).
+- [x] 5.2 In `docs/agents.md`, extend the OAuth section with how to connect ChatGPT (custom connector, `/mcp/<slug>` URL, consent with admin token) and the recommended memory-first custom instruction **in English**.
+
+## 6. Verify (no regression)
+
+- [x] 6.1 `pnpm run typecheck` + `pnpm run lint` clean.
+- [x] 6.2 Full server suite green: `pnpm --filter @rembric/server exec vitest run` (incl. invariants; backward-compat confirmed).

--- a/openspec/specs/mcp-oauth/spec.md
+++ b/openspec/specs/mcp-oauth/spec.md
@@ -139,16 +139,28 @@ When OAuth is enabled, `POST /token` SHALL support `grant_type=refresh_token`. A
 
 ### Requirement: Issued OAuth tokens MUST map to the existing scope grammar
 
-The scope granted at consent SHALL be expressed in the existing `TokenScope` grammar (`*`, `read:*`, `project:<id>`, `read:project:<id>`) so that OAuth-minted tokens are authorized by the same `isAuthorized()` checks as static tokens. The mapping SHALL fail closed: an absent, empty, or unrecognized requested scope SHALL yield least privilege (`read:*`); write access (`*`) SHALL be granted only when write is explicitly requested. Project restriction MAY additionally derive from the connector's request path (`/mcp/<slug>`) under the existing path-scoping contract.
+The `/token` response and the stored grant SHALL express scope in the **advertised OAuth scope vocabulary** (`SUPPORTED_OAUTH_SCOPES`, e.g. `mcp`, `read`) — the granted scope SHALL be the requested scopes restricted to that advertised set, echoed verbatim in the token response so the client observes its requested scopes as granted. The internal `TokenScope` (`*`, `read:*`, `project:<id>`, `read:project:<id>`) used by `isAuthorized()` SHALL be **derived from the granted OAuth scope at authorization time**, not stored as the wire scope. The derivation SHALL fail closed: an absent, empty, or unrecognized requested scope SHALL yield least privilege (`read:*`); write access (`*`) SHALL be granted only when a write-capable scope is explicitly requested. Project restriction MAY additionally derive from the connector's request path (`/mcp/<slug>`) under the existing path-scoping contract.
+
+#### Scenario: Token response echoes the requested OAuth scope vocabulary
+
+- **GIVEN** a client that requested `scope=mcp read` (the advertised scopes)
+- **WHEN** consent is granted and the code is exchanged at `/token`
+- **THEN** the token response `scope` SHALL be `mcp read` (the advertised vocabulary), NOT the internal `TokenScope` (`*`)
+
+#### Scenario: Internal authorization scope is derived at read time
+
+- **GIVEN** an access token whose stored grant is `mcp read`
+- **WHEN** the token authenticates a `/mcp` request
+- **THEN** `isAuthorized()` SHALL receive a real `TokenScope` (`*`) derived from the granted OAuth scope, authorizing exactly as a static `*` token
 
 #### Scenario: Unknown or empty requested scope fails closed
 
 - **GIVEN** an authorization request whose `scope` is absent, empty, or unrecognized
 - **WHEN** consent is granted
-- **THEN** the minted access token SHALL receive least privilege (`read:*`), not full access
+- **THEN** the derived authorization scope SHALL be least privilege (`read:*`), not full access
 
 #### Scenario: Read-only OAuth grant cannot write
 
-- **GIVEN** an access token minted from a grant consented as read-only (`read:*`)
+- **GIVEN** an access token minted from a grant consented as read-only (`read`)
 - **WHEN** the token is used to invoke `memory.save`
 - **THEN** the request SHALL be rejected with the same `403`-class authorization failure as a static `read:*` token


### PR DESCRIPTION
## Why

Two related follow-ups to the OAuth 2.1 connector (shipped in #161 / 0.21.16), found while connecting ChatGPT live:

1. **Scope-echo bug.** The `/token` response returned Rembric's internal `TokenScope` (`*` / `read:*`) as the granted `scope` instead of the advertised OAuth vocabulary (`mcp` / `read`). ChatGPT compared its requested scopes against the response and warned *"not all requested permissions granted"* — even though the tools worked (the token is `*` internally). Root cause: the wire scope and the authorization scope were conflated.
2. **ChatGPT undocumented.** ChatGPT is now a validated OAuth client but was absent from the supported-agents surface, and the recommended "Rembric-as-memory" instruction only existed in Spanish.

Built via the OpenSpec flow (`/opsx:explore` → `propose` → `apply` → `archive`); change `oauth-scope-echo-and-chatgpt-docs` archived with the `mcp-oauth` spec delta.

## The fix (decouple OAuth scope from `TokenScope`)

- Store the **granted OAuth scope string** on the code/token and echo it verbatim in `/token`, so the client sees its requested scopes as granted.
- Derive the internal `TokenScope` at **authorization read time** via `resolveGrantedScope` (the existing mapper — just moved from write-time to read-time). `isAuthorized()` still receives a real `TokenScope`.
- `SUPPORTED_OAUTH_SCOPES` is the single source for both the metadata router's `scopesSupported` and the grant filter; `grantedOAuthScope` restricts the request to the advertised set, fail-closed to `read`.
- Consent screen stores + displays the OAuth vocabulary.

### Backward-compatible (no migration)

Tokens already issued in prod stored `*` / `read:*`; `resolveGrantedScope` is idempotent on those (`resolveGrantedScope('*')='*'`, `resolveGrantedScope('read:*')='read:*'`), so they keep authorizing unchanged. The `scope` column stays `text` — only its stored vocabulary changes for new tokens.

```
new token.scope="mcp read" → /token echoes "mcp read" (ChatGPT happy) → authz derives "*"
old token.scope="*"        → unchanged at authz ("*")
```

## Docs (same PR)

- `README.md`: ChatGPT in the supported-agents table (custom connector · OAuth · MCP).
- `docs/agents.md`: ChatGPT connection guide (custom connector, `/mcp/<slug>`, OAuth/DCR, consent with admin token) + the recommended **English** memory-first custom instruction.

## Tests

- New `grantedOAuthScope` unit tests; `/token`-echoes-`mcp` assertion in the real-HTTP test; `oauth-consent.test` updated (granted scope is now an OAuth string).
- `auth.test` / `oauth-e2e` unchanged — backward-compat verified.
- **808 server tests green**, typecheck + lint clean. No new dependency.