### PR TITLE
feat(server): MCP tool annotations + output schemas

### DIFF
--- a/apps/server/src/mcp/about-tool.test.ts
+++ b/apps/server/src/mcp/about-tool.test.ts
@@ -54,6 +54,8 @@ describe('memory.about handler', () => {
     expect(res.content).toHaveLength(1);
     const [entry] = res.content;
     expect(entry?.type).toBe('text');
-    expect(JSON.parse(entry?.text ?? '')).toEqual(buildAboutReport());
+    const text = entry && 'text' in entry ? entry.text : '';
+    expect(JSON.parse(text)).toEqual(buildAboutReport());
+    expect(res.structuredContent).toEqual(buildAboutReport());
   });
 });

--- a/apps/server/src/mcp/about-tool.ts
+++ b/apps/server/src/mcp/about-tool.ts
@@ -1,4 +1,8 @@
+import { z } from 'zod';
+
 import { REMBRIC_VERSION } from '../version.js';
+
+import { ok } from './result.js';
 
 // Must track the canonical installer entrypoint owned by the tui-installer
 // capability (repo-root install.sh shim). Never fork the URL or flag set here.
@@ -39,9 +43,19 @@ export function buildAboutReport(): AboutReport {
   };
 }
 
+export const aboutOutput = {
+  server: z.object({ version: z.string(), where: z.string(), update: z.string() }),
+  plugins: z.object({
+    note: z.string(),
+    status: z.string(),
+    interactive: z.string(),
+    update_all: z.string(),
+    subset: z.string(),
+  }),
+  docs: z.string(),
+};
+
 export function handleAbout(_args: Record<string, never>) {
   void _args;
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(buildAboutReport(), null, 2) }],
-  };
+  return ok(buildAboutReport());
 }

--- a/apps/server/src/mcp/project-tools.ts
+++ b/apps/server/src/mcp/project-tools.ts
@@ -9,6 +9,7 @@ import { DomainError } from '../services/errors.js';
 import { type ProjectsService } from '../services/projects.js';
 
 import { mcpError } from './errors.js';
+import { ok } from './result.js';
 import { ensureRootsDiscoveryRun } from './roots-discovery.js';
 
 /**
@@ -33,6 +34,33 @@ export const projectListSchema = {
 
 export const projectCurrentSchema = {} as const;
 
+export const projectUseOutput = {
+  slug: z.string(),
+  projectId: z.string(),
+  created: z.boolean(),
+  switched: z.boolean(),
+  source: z.string(),
+  previousSlug: z.string().nullable().optional(),
+};
+
+export const projectListOutput = {
+  projects: z.array(
+    z.object({
+      slug: z.string(),
+      displayName: z.string().nullable(),
+      archived: z.boolean(),
+      memoryCount: z.number(),
+    }),
+  ),
+};
+
+export const projectCurrentOutput = {
+  slug: z.string().nullable(),
+  projectId: z.string().nullable(),
+  source: z.string(),
+  suggestedSlugs: z.array(z.string()),
+};
+
 export interface ProjectToolDeps {
   repos: Pick<Repositories, 'memory'>;
   projects: ProjectsService;
@@ -40,12 +68,6 @@ export interface ProjectToolDeps {
   router: SessionRouter;
   /** Set by `createMcpServer` after construction to enable roots discovery. */
   getServer?: () => McpServer;
-}
-
-function ok(payload: unknown) {
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }],
-  };
 }
 
 function routerKey(): { tokenId: string; mcpSessionId: string } | null {

--- a/apps/server/src/mcp/relations-tools.ts
+++ b/apps/server/src/mcp/relations-tools.ts
@@ -5,6 +5,7 @@ import { DomainError } from '../services/errors.js';
 import { type RelationsService, type RelationView } from '../services/relations.js';
 
 import { mcpError } from './errors.js';
+import { ok } from './result.js';
 import { suggestTopicKey } from './topic-key.js';
 
 /**
@@ -61,14 +62,27 @@ export const compareSchema = {
   evidence: z.unknown().optional(),
 };
 
+export const suggestTopicKeyOutput = {
+  topic_key: z.string(),
+};
+
+export const judgeOutput = {
+  ok: z.literal(true),
+  judgmentId: z.string(),
+  relation: z.string(),
+  status: z.string(),
+  judgedAt: z.string(),
+};
+
+export const compareOutput = {
+  ok: z.literal(true),
+  judgmentId: z.string(),
+  relation: z.string(),
+  status: z.string(),
+};
+
 export interface RelationsToolDeps {
   relations: RelationsService;
-}
-
-function ok(payload: unknown) {
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }],
-  };
 }
 
 export function buildRelationsHandlers(deps: RelationsToolDeps) {

--- a/apps/server/src/mcp/result.ts
+++ b/apps/server/src/mcp/result.ts
@@ -1,0 +1,12 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+// `structuredContent` is the JSON round-trip of the payload so it equals the
+// wire JSON (Dates → ISO strings) the outputSchema validates before transport.
+// Every caller passes an object, so the parsed JSON is always a record.
+export function ok(payload: unknown): CallToolResult {
+  const text = JSON.stringify(payload, null, 2);
+  return {
+    content: [{ type: 'text', text }],
+    structuredContent: JSON.parse(text) as Record<string, unknown>,
+  };
+}

--- a/apps/server/src/mcp/server.ts
+++ b/apps/server/src/mcp/server.ts
@@ -1,5 +1,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { RootsListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  RootsListChangedNotificationSchema,
+  type ToolAnnotations,
+} from '@modelcontextprotocol/sdk/types.js';
 
 import type { Repositories } from '../db/repositories/index.js';
 import type { SessionRouter } from '../server/session-router.js';
@@ -10,38 +13,59 @@ import type { PromptsService } from '../services/prompts.js';
 import type { RelationsService } from '../services/relations.js';
 import type { CandidateOptions } from '../services/save-time-candidates.js';
 
-import { handleAbout } from './about-tool.js';
+import { aboutOutput, handleAbout } from './about-tool.js';
 import { buildInstructions } from './instructions.js';
 import {
   buildProjectHandlers,
+  projectCurrentOutput,
   projectCurrentSchema,
+  projectListOutput,
   projectListSchema,
+  projectUseOutput,
   projectUseSchema,
 } from './project-tools.js';
 import {
   buildRelationsHandlers,
+  compareOutput,
   compareSchema,
+  judgeOutput,
   judgeSchema,
+  suggestTopicKeyOutput,
   suggestTopicKeySchema,
 } from './relations-tools.js';
 import {
   buildSessionsHandlers,
+  capturePassiveOutput,
   capturePassiveSchema,
+  contextOutput,
   contextSchema,
+  doctorOutput,
+  sessionGetOutput,
   sessionGetSchema,
   type DoctorReport,
+  savePromptOutput,
   savePromptSchema,
+  searchPromptsOutput,
   searchPromptsSchema,
+  sessionEndOutput,
   sessionEndSchema,
+  sessionStartOutput,
   sessionStartSchema,
+  sessionSummaryOutput,
   sessionSummarySchema,
+  statsOutput,
+  timelineOutput,
   timelineSchema,
 } from './sessions-tools.js';
 import {
   buildHandlers,
+  memoryConfirmOutput,
   memoryConfirmSchema,
+  memoryGetOutput,
   memoryGetSchema,
+  memorySaveOutput,
   memorySaveSchema,
+  memorySearchOutput,
   memorySearchSchema,
 } from './tools.js';
 
@@ -89,6 +113,33 @@ const GET_DESCRIPTION =
 const CONFIRM_DESCRIPTION =
   'Record a confirmation event for the head of the supersedes chain reachable from this id. Call this when the user explicitly endorses a memory ("yes, that\'s right", "still true") so future retrievals can prioritise it.';
 
+// Rembric is append-only (rows are never deleted; supersede is a reversible,
+// journaled status flip) and a closed local store, so destructiveHint and
+// openWorldHint are false for EVERY tool — defined once here so no per-tool
+// factory can get them wrong.
+const NON_DESTRUCTIVE_CLOSED = { destructiveHint: false, openWorldHint: false } as const;
+
+const READ_ANNOTATIONS = (title: string): ToolAnnotations => ({
+  title,
+  ...NON_DESTRUCTIVE_CLOSED,
+  readOnlyHint: true,
+  idempotentHint: true,
+});
+
+const WRITE_ANNOTATIONS = (title: string): ToolAnnotations => ({
+  title,
+  ...NON_DESTRUCTIVE_CLOSED,
+  readOnlyHint: false,
+  idempotentHint: false,
+});
+
+const IDEMPOTENT_WRITE_ANNOTATIONS = (title: string): ToolAnnotations => ({
+  title,
+  ...NON_DESTRUCTIVE_CLOSED,
+  readOnlyHint: false,
+  idempotentHint: true,
+});
+
 export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
   const server = new McpServer(
     {
@@ -114,22 +165,42 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
   });
   server.registerTool(
     'memory.save',
-    { description: SAVE_DESCRIPTION, inputSchema: memorySaveSchema },
+    {
+      description: SAVE_DESCRIPTION,
+      inputSchema: memorySaveSchema,
+      outputSchema: memorySaveOutput,
+      annotations: WRITE_ANNOTATIONS('Save memory'),
+    },
     handlers.save,
   );
   server.registerTool(
     'memory.search',
-    { description: SEARCH_DESCRIPTION, inputSchema: memorySearchSchema },
+    {
+      description: SEARCH_DESCRIPTION,
+      inputSchema: memorySearchSchema,
+      outputSchema: memorySearchOutput,
+      annotations: READ_ANNOTATIONS('Search memories'),
+    },
     handlers.search,
   );
   server.registerTool(
     'memory.get',
-    { description: GET_DESCRIPTION, inputSchema: memoryGetSchema },
+    {
+      description: GET_DESCRIPTION,
+      inputSchema: memoryGetSchema,
+      outputSchema: memoryGetOutput,
+      annotations: READ_ANNOTATIONS('Get memory'),
+    },
     handlers.get,
   );
   server.registerTool(
     'memory.confirm',
-    { description: CONFIRM_DESCRIPTION, inputSchema: memoryConfirmSchema },
+    {
+      description: CONFIRM_DESCRIPTION,
+      inputSchema: memoryConfirmSchema,
+      outputSchema: memoryConfirmOutput,
+      annotations: WRITE_ANNOTATIONS('Confirm memory'),
+    },
     handlers.confirm,
   );
 
@@ -153,6 +224,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'Start an agent session. In normal operation you do NOT need to call this — the host registers the session automatically (Claude Code/Codex hooks and the Hermes/opencode providers POST to the sessions endpoint on startup). Call it only when running without that host wiring and you need an explicit session to wrap with memory.session_summary. Args: { agent?, description?, project? (slug, overrides roots) }. Returns: { sessionId, scope, projectId, startedAt }.',
       inputSchema: sessionStartSchema,
+      outputSchema: sessionStartOutput,
+      annotations: WRITE_ANNOTATIONS('Start session'),
     },
     sessions.sessionStart,
   );
@@ -162,6 +235,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'End the active session without writing a summary. Prefer memory.session_summary unless the session is being abandoned.',
       inputSchema: sessionEndSchema,
+      outputSchema: sessionEndOutput,
+      annotations: IDEMPOTENT_WRITE_ANNOTATIONS('End session'),
     },
     sessions.sessionEnd,
   );
@@ -171,6 +246,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'Save the end-of-session summary AND a short title. Call this at the END OF EVERY TURN that did real work — never end a working turn silent; do NOT wait for the literal word "done"/"listo". Args: { summary (<=2000 chars, server rejects longer with invalid_input — keep it tight), title? (<=100 chars, descriptive of work done, NOT the cwd) }. Body: Goal · Instructions · Discoveries · Accomplished · Next Steps · Relevant Files. Does NOT end the session — use memory.session_end for that.',
       inputSchema: sessionSummarySchema,
+      outputSchema: sessionSummaryOutput,
+      annotations: IDEMPOTENT_WRITE_ANNOTATIONS('Save session summary'),
     },
     sessions.sessionSummary,
   );
@@ -180,6 +257,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'Get recent context for this scope: recentSessions (with summaries), recentMemories (sorted by last_seen_at), pendingJudgments (aged unresolved relation pairs to close with memory.judge), and needsReview (active memories past their re-verification shelf life — re-affirm with memory.confirm, supersede with memory.save+topic_key, or judge if they contradict another memory). Call this when starting or resuming work that may have prior context, after a /compact event, or when asked "what did we do" — before acting, but only if you lack the prior detail you need (do not load it speculatively on every session start). Default sizes are small; the response includes a `clamped:true` flag if you asked for too much.',
       inputSchema: contextSchema,
+      outputSchema: contextOutput,
+      annotations: READ_ANNOTATIONS('Recent context'),
     },
     sessions.context,
   );
@@ -189,6 +268,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         "Fetch one session by id with its FULL, untruncated summary — memory.context only returns a short snippet. Scope-enforced: a cross-scope or soft-deleted id returns not_found. Use to resume work surfaced in memory.context when the snippet isn't enough (cross-client / multi-agent handoff).",
       inputSchema: sessionGetSchema,
+      outputSchema: sessionGetOutput,
+      annotations: READ_ANNOTATIONS('Get session'),
     },
     sessions.sessionGet,
   );
@@ -198,6 +279,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'Drill into chronological neighbors of a specific memory. Returns memories before and after the target within the same session (or, when the target has no session, a ±2h time window with fallback:"time_window").',
       inputSchema: timelineSchema,
+      outputSchema: timelineOutput,
+      annotations: READ_ANNOTATIONS('Memory timeline'),
     },
     sessions.timeline,
   );
@@ -207,6 +290,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'Bulk-save learnings: extract numbered/bulleted items from a `## Key Learnings:` section in the given text and save each as a separate memory (type=reference). No-op when no learnings block is found. Call this when you have produced (or the user supplied) a Key Learnings list worth persisting — e.g. when wrapping up a task — instead of issuing many individual memory.save calls.',
       inputSchema: capturePassiveSchema,
+      outputSchema: capturePassiveOutput,
+      annotations: WRITE_ANNOTATIONS('Capture learnings'),
     },
     sessions.capturePassive,
   );
@@ -216,6 +301,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         "Persist the user's most recent prompt for the active session/project so future sessions can read it via memory.context.recentPrompts (and so the operator can browse them at /dashboard/prompts). Call this when the user states a goal or constraint worth remembering. REQUIRED fields: content (verbatim text, ≤20k chars) AND title (≤100 chars, scannable label for retrieval lists — a prompt without a title is not searchable in practice). Optional: tags (string[] for categorical filtering — fed into the FTS5 index alongside content), replaces (id of a predecessor prompt to atomically refine — the old row is soft-deleted and the new row links via `replaces[]`). When the refined predecessor does not exist, is in another scope, or is already deleted, the call is rejected with `prompt_not_found` / `prompt_scope_mismatch` / `prompt_already_deleted`.",
       inputSchema: savePromptSchema,
+      outputSchema: savePromptOutput,
+      annotations: WRITE_ANNOTATIONS('Save prompt'),
     },
     sessions.savePrompt,
   );
@@ -225,6 +312,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'Search curated prompts in the active scope. With `query`, runs an FTS5 MATCH over `content + tags` (token-aware); without it, falls back to recency. Filters: `sessionId`, `agent`, `includeDeleted` (default false). Returns `{ scope, prompts[], total, clamped }`. Use when the user references a prior goal/directive and you need to retrieve the exact wording.',
       inputSchema: searchPromptsSchema,
+      outputSchema: searchPromptsOutput,
+      annotations: READ_ANNOTATIONS('Search prompts'),
     },
     sessions.searchPrompts,
   );
@@ -234,6 +323,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'Read-only operational diagnostics. Returns DB/LLM/embeddings/consolidation health plus warnings. Use at session start when behavior seems off.',
       inputSchema: {},
+      outputSchema: doctorOutput,
+      annotations: READ_ANNOTATIONS('Diagnostics'),
     },
     sessions.doctor,
   );
@@ -243,6 +334,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'Read-only guidance to update/upgrade Rembric: returns the running server version + the canonical installer commands to update client plugins. Call when the operator asks how to update or upgrade Rembric (server or plugins). Surfaces commands for the operator to run; never executes them.',
       inputSchema: {},
+      outputSchema: aboutOutput,
+      annotations: READ_ANNOTATIONS('About Rembric'),
     },
     handleAbout,
   );
@@ -252,6 +345,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'Read-only counters: memoriesByStatus, memoriesByType, sessionsByStatus, scoped to the active project (or global).',
       inputSchema: {},
+      outputSchema: statsOutput,
+      annotations: READ_ANNOTATIONS('Stats'),
     },
     sessions.stats,
   );
@@ -273,6 +368,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'Activate a project for this MCP session by slug. By default, never creates and never switches mid-session. Pass autocreate:true to mint a new project (slug must match strict regex). Pass confirmSwitch:true to replace the current project (only allowed when no session is active — close it first via memory.session_summary). ASK THE USER before passing either flag.',
       inputSchema: projectUseSchema,
+      outputSchema: projectUseOutput,
+      annotations: WRITE_ANNOTATIONS('Use project'),
     },
     projectHandlers.use,
   );
@@ -282,6 +379,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'List existing projects and their memory counts. Use when the user references a project that may not be active in this session.',
       inputSchema: projectListSchema,
+      outputSchema: projectListOutput,
+      annotations: READ_ANNOTATIONS('List projects'),
     },
     projectHandlers.list,
   );
@@ -291,6 +390,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'Report the project active in this session (slug, projectId, source) plus any pending suggestedSlugs surfaced by roots-based discovery.',
       inputSchema: projectCurrentSchema,
+      outputSchema: projectCurrentOutput,
+      annotations: READ_ANNOTATIONS('Current project'),
     },
     projectHandlers.current,
   );
@@ -303,6 +404,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'Suggest a stable topic_key for an evolving memory based on type + title/content. Deterministic — no LLM. Call before memory.save when updating a topic you have saved before, so the new row supersedes the previous one atomically instead of fragmenting the result set.',
       inputSchema: suggestTopicKeySchema,
+      outputSchema: suggestTopicKeyOutput,
+      annotations: READ_ANNOTATIONS('Suggest topic key'),
     },
     relationsHandlers.suggestTopicKey,
   );
@@ -312,6 +415,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'Close a pending judgment surfaced by memory.save.candidates[]. Pass the judgmentId, a relation (supersedes/conflicts_with/related/compatible/scoped/not_conflict), optional reason and confidence. relation=supersedes atomically marks the candidate target memory as superseded.',
       inputSchema: judgeSchema,
+      outputSchema: judgeOutput,
+      annotations: WRITE_ANNOTATIONS('Judge memories'),
     },
     relationsHandlers.judge,
   );
@@ -321,6 +426,8 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       description:
         'Proactively record a verdict on two arbitrary memories without a preceding save. Idempotent: re-calling with the same (memoryIdA, memoryIdB) pair updates the existing row. Use when independent analysis finds two memories that are related or contradict; for save-time candidates use memory.judge instead.',
       inputSchema: compareSchema,
+      outputSchema: compareOutput,
+      annotations: IDEMPOTENT_WRITE_ANNOTATIONS('Compare memories'),
     },
     relationsHandlers.compare,
   );

--- a/apps/server/src/mcp/sessions-tools.ts
+++ b/apps/server/src/mcp/sessions-tools.ts
@@ -14,6 +14,7 @@ import { projectScope, SCOPE_GLOBAL, type Scope } from '../services/scope.js';
 
 import { mcpError } from './errors.js';
 import { pendingSuggestionGate, suggestionPendingMessage } from './project-suggestion-gate.js';
+import { ok } from './result.js';
 import { ensureRootsDiscoveryRun } from './roots-discovery.js';
 
 /**
@@ -102,11 +103,164 @@ export interface DoctorReport {
   warnings: string[];
 }
 
-function ok(payload: unknown) {
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }],
-  };
-}
+const counts = z.record(z.string(), z.number());
+
+const promptRow = z.object({
+  id: z.string(),
+  content: z.string(),
+  title: z.string(),
+  tags: z.array(z.string()).nullable(),
+  sessionId: z.string().nullable(),
+  projectId: z.string().nullable(),
+  agent: z.string().nullable(),
+  replaces: z.array(z.string()).nullable(),
+  deletedAt: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+const memoryNeighbor = z.object({
+  id: z.string(),
+  type: z.string(),
+  content: z.string(),
+  status: z.string(),
+  createdAt: z.string(),
+  sessionId: z.string().nullable(),
+});
+
+export const sessionStartOutput = {
+  sessionId: z.string(),
+  scope: z.string(),
+  projectId: z.string().nullable(),
+  startedAt: z.string(),
+  title: z.string().nullable(),
+  reused: z.boolean(),
+};
+
+export const sessionEndOutput = {
+  ok: z.literal(true),
+  sessionId: z.string(),
+  endedAt: z.string().nullable(),
+};
+
+export const sessionSummaryOutput = {
+  ok: z.literal(true),
+  sessionId: z.string(),
+  summary: z.string(),
+  title: z.string().nullable(),
+  summaryFinal: z.boolean(),
+  titleFinal: z.boolean(),
+};
+
+export const contextOutput = {
+  scope: z.string(),
+  recentSessions: z.array(
+    z.object({
+      id: z.string(),
+      agent: z.string(),
+      startedAt: z.string(),
+      endedAt: z.string().nullable(),
+      status: z.string(),
+      title: z.string().nullable(),
+      summary: z.string().nullable(),
+    }),
+  ),
+  recentPrompts: z.array(
+    z.object({
+      id: z.string(),
+      content: z.string(),
+      agent: z.string().nullable(),
+      createdAt: z.string(),
+    }),
+  ),
+  recentMemories: z.array(
+    z.object({
+      id: z.string(),
+      type: z.string(),
+      snippet: z.string(),
+      status: z.string(),
+      createdAt: z.string(),
+    }),
+  ),
+  pendingJudgments: z.array(
+    z.object({
+      judgmentId: z.string(),
+      sourceId: z.string(),
+      targetId: z.string(),
+      sourceSnippet: z.string(),
+      targetSnippet: z.string(),
+      ageMs: z.number(),
+    }),
+  ),
+  needsReview: z.array(
+    z.object({
+      id: z.string(),
+      type: z.string(),
+      snippet: z.string(),
+      reviewAfter: z.string(),
+      ageMs: z.number(),
+    }),
+  ),
+  clamped: z.boolean(),
+};
+
+export const sessionGetOutput = {
+  id: z.string(),
+  agent: z.string(),
+  status: z.string(),
+  startedAt: z.string(),
+  endedAt: z.string().nullable(),
+  title: z.string().nullable(),
+  summary: z.string().nullable(),
+};
+
+export const timelineOutput = {
+  target: z.object({ id: z.string(), createdAt: z.string() }),
+  before: z.array(memoryNeighbor),
+  after: z.array(memoryNeighbor),
+  fallback: z.string().nullable(),
+};
+
+export const capturePassiveOutput = {
+  saved: z.number(),
+  ids: z.array(z.string()),
+};
+
+export const savePromptOutput = {
+  ok: z.literal(true),
+  id: z.string(),
+  createdAt: z.string(),
+  replaces: z.array(z.string()).optional(),
+};
+
+export const searchPromptsOutput = {
+  scope: z.string(),
+  prompts: z.array(promptRow),
+  total: z.number(),
+  clamped: z.boolean(),
+};
+
+export const doctorOutput = {
+  db: z.object({
+    open: z.boolean(),
+    journalMode: z.string(),
+    integrity: z.string(),
+    sizeBytes: z.number(),
+  }),
+  embeddings: z.object({ model: z.string(), backlog: z.number() }),
+  consolidation: z.object({
+    lastRunAt: z.string().nullable(),
+    lastRunOps: counts,
+  }),
+  sessions: z.object({ active: z.number() }),
+  warnings: z.array(z.string()),
+};
+
+export const statsOutput = {
+  scope: z.string(),
+  memoriesByStatus: counts,
+  memoriesByType: counts,
+  sessionsByStatus: counts,
+};
 
 /**
  * Resolve the effective scope for a session-tool call.

--- a/apps/server/src/mcp/tools.ts
+++ b/apps/server/src/mcp/tools.ts
@@ -15,6 +15,7 @@ import { isAuthorized } from '../services/tokens.js';
 
 import { mcpError } from './errors.js';
 import { pendingSuggestionGate, suggestionPendingMessage } from './project-suggestion-gate.js';
+import { ok } from './result.js';
 import { ensureRootsDiscoveryRun } from './roots-discovery.js';
 
 /**
@@ -72,6 +73,82 @@ export const memoryConfirmSchema = {
   id: z.string().min(1),
 };
 
+const relationView = z.object({
+  kind: z.string(),
+  targetId: z.string(),
+  judgmentId: z.string().optional(),
+  status: z.string(),
+  reason: z.string().nullable().optional(),
+  confidence: z.number().nullable().optional(),
+});
+
+const candidate = z.object({
+  judgmentId: z.string(),
+  targetId: z.string(),
+  snippet: z.string(),
+  similarity: z.number(),
+  source: z.string(),
+});
+
+const memoryRow = z.object({
+  id: z.string(),
+  scope: z.string(),
+  projectId: z.string().nullable(),
+  type: z.string(),
+  content: z.string(),
+  tags: z.array(z.string()),
+  status: z.string(),
+  createdAt: z.string(),
+  lastSeenAt: z.string().nullable(),
+  relations: z.array(relationView),
+  reviewState: z.string().optional(),
+  reviewAfter: z.string().nullable().optional(),
+});
+
+export const memorySaveOutput = {
+  id: z.string(),
+  status: z.string(),
+  createdAt: z.string(),
+  candidates: z.array(candidate),
+  judgmentRequired: z.boolean(),
+};
+
+export const memorySearchOutput = {
+  count: z.number(),
+  memories: z.array(memoryRow),
+};
+
+export const memoryGetOutput = {
+  memory: z.object({
+    id: z.string(),
+    scope: z.string(),
+    projectId: z.string().nullable(),
+    type: z.string(),
+    content: z.string(),
+    tags: z.array(z.string()),
+    status: z.string(),
+    replaces: z.array(z.string()),
+    createdAt: z.string(),
+  }),
+  head: z.object({ id: z.string(), content: z.string(), status: z.string() }),
+  predecessors: z.array(
+    z.object({
+      id: z.string(),
+      content: z.string(),
+      status: z.string(),
+      createdAt: z.string(),
+    }),
+  ),
+  confirmationCount: z.number(),
+  relations: z.array(relationView),
+  reviewState: z.string().optional(),
+  reviewAfter: z.string().nullable().optional(),
+};
+
+export const memoryConfirmOutput = {
+  ok: z.literal(true),
+};
+
 export interface ToolDeps {
   memory: MemoryService;
   /** Optional — when present, save surfaces candidates + writes pending relations. */
@@ -111,17 +188,6 @@ export function buildHandlers(deps: ToolDeps) {
     search: handleSearch.bind(null, deps),
     get: handleGet.bind(null, deps),
     confirm: handleConfirm.bind(null, deps),
-  };
-}
-
-function ok(payload: unknown) {
-  return {
-    content: [
-      {
-        type: 'text' as const,
-        text: JSON.stringify(payload, null, 2),
-      },
-    ],
   };
 }
 

--- a/apps/server/src/test/mcp-integration.test.ts
+++ b/apps/server/src/test/mcp-integration.test.ts
@@ -155,6 +155,115 @@ describe('MCP protocol conformance', () => {
     await client.close();
   });
 
+  it('advertises behavioral annotations consistent with the append-only/closed-store invariants', async () => {
+    // Read tools never mutate. Every Rembric tool is non-destructive (rows are
+    // never deleted; supersede is a reversible status flip) and closed-world
+    // (single local store) — so destructiveHint/openWorldHint are false for ALL
+    // tools. The name sets below are exhaustive against the registered tools;
+    // a newly-registered tool with no entry fails the partition assertion.
+    const READ_TOOLS = new Set([
+      'memory.search',
+      'memory.get',
+      'memory.context',
+      'memory.session_get',
+      'memory.timeline',
+      'memory.search_prompts',
+      'memory.doctor',
+      'memory.about',
+      'memory.stats',
+      'memory.suggest_topic_key',
+      'project.list',
+      'project.current',
+    ]);
+    const WRITE_TOOLS = new Set([
+      'memory.save',
+      'memory.confirm',
+      'memory.capture_passive',
+      'memory.save_prompt',
+      'memory.session_start',
+      'memory.session_summary',
+      'memory.session_end',
+      'memory.judge',
+      'memory.compare',
+      'project.use',
+    ]);
+
+    const client = await connect();
+    const { tools } = await client.listTools();
+
+    // Every registered tool is partitioned into exactly one of the two sets —
+    // catches an un-annotated new tool.
+    const registered = tools.map((t) => t.name).sort();
+    expect(registered).toEqual([...READ_TOOLS, ...WRITE_TOOLS].sort());
+
+    for (const tool of tools) {
+      const ann = tool.annotations;
+      expect(ann, `${tool.name} must declare annotations`).toBeDefined();
+      expect(ann?.destructiveHint, `${tool.name} destructiveHint`).toBe(false);
+      expect(ann?.openWorldHint, `${tool.name} openWorldHint`).toBe(false);
+      expect(typeof ann?.title, `${tool.name} title`).toBe('string');
+      expect(ann?.readOnlyHint, `${tool.name} readOnlyHint`).toBe(READ_TOOLS.has(tool.name));
+    }
+
+    await client.close();
+  });
+
+  it('every tool advertises an outputSchema', async () => {
+    const client = await connect();
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      expect(tool.outputSchema, `${tool.name} must declare an outputSchema`).toBeDefined();
+    }
+    await client.close();
+  });
+
+  it('returns conforming structuredContent for the tools not exercised elsewhere', async () => {
+    // The SDK validates structuredContent against the registered outputSchema
+    // on every call, so a non-throwing call with structuredContent present IS
+    // the schema conformance test. The save→search→get→confirm/context/session/
+    // timeline/judge/compare/doctor/suggest_topic_key paths are covered by other
+    // tests in this file; this fills the gap for the rest.
+    const client = await connect();
+
+    const about = await client.callTool({ name: 'memory.about', arguments: {} });
+    expect(about.structuredContent).toBeDefined();
+
+    const stats = await client.callTool({ name: 'memory.stats', arguments: {} });
+    expect(stats.structuredContent).toBeDefined();
+
+    const savePrompt = await client.callTool({
+      name: 'memory.save_prompt',
+      arguments: { content: 'a goal worth remembering', title: 'goal' },
+    });
+    expect(savePrompt.structuredContent).toBeDefined();
+
+    const searchPrompts = await client.callTool({
+      name: 'memory.search_prompts',
+      arguments: { query: 'goal' },
+    });
+    expect(searchPrompts.structuredContent).toBeDefined();
+
+    const capture = await client.callTool({
+      name: 'memory.capture_passive',
+      arguments: { text: '## Key Learnings:\n- first learning\n- second learning\n' },
+    });
+    expect(capture.structuredContent).toBeDefined();
+
+    const use = await client.callTool({
+      name: 'project.use',
+      arguments: { slug: 'outputschema-proj', autocreate: true },
+    });
+    expect(use.structuredContent).toBeDefined();
+
+    const list = await client.callTool({ name: 'project.list', arguments: {} });
+    expect(list.structuredContent).toBeDefined();
+
+    const current = await client.callTool({ name: 'project.current', arguments: {} });
+    expect(current.structuredContent).toBeDefined();
+
+    await client.close();
+  });
+
   it('round-trips save → search → get → confirm against /mcp (global scope)', async () => {
     const client = await connect();
 

--- a/openspec/changes/align-memory-stats-with-spec/.openspec.yaml
+++ b/openspec/changes/align-memory-stats-with-spec/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-16

--- a/openspec/changes/align-memory-stats-with-spec/design.md
+++ b/openspec/changes/align-memory-stats-with-spec/design.md
@@ -1,0 +1,52 @@
+## Context
+
+`handleStats` (`apps/server/src/mcp/sessions-tools.ts`) returns:
+
+```
+{ scope, memoriesByStatus, memoriesByType, sessionsByStatus }
+```
+
+The `mcp-api` spec §"memory.stats returns counters by scope and status" requires:
+
+```
+{ memoriesByStatus, memoriesByType, memoriesByScope, sessionsByStatus, totalProjects, totalTokens }
+```
+
+Divergence: `memoriesByScope`, `totalProjects`, `totalTokens` are absent from the handler; `scope` is present but unspecified. Surfaced by the `add-mcp-tool-output-schemas` change, whose `statsOutput` schema mirrors the handler (so no runtime validation error today — the schema is simply narrower than the spec demands).
+
+## Goals / Non-Goals
+
+**Goals:** one agreed shape for `memory.stats` across spec, handler, and `outputSchema`; reuse existing repo counters; stay additive (no removal of currently-returned fields).
+
+**Non-Goals:** changing other tools; introducing new SQL outside `db/`; a DB migration.
+
+## Decisions
+
+### Decision 1 — Extend the handler to the spec (don't shrink the spec to the handler)
+
+CLAUDE.md: specs are the authoritative contract. So add the three missing fields rather than delete the requirement. `memoriesByScope` = counts keyed by `global`/`project:<id>` (or a `{ global, project }` record); `totalProjects` and `totalTokens` from cheap counts.
+
+### Decision 2 — Resolve the `Record<string, number>` wording
+
+Spec §387 says "each value being a `Record<string, number>`". That fits `memoriesByScope` but is wrong for `totalProjects`/`totalTokens`, which are scalars. The spec text must be corrected to type those two as `number`. This is the one substantive spec edit.
+
+### Decision 3 — Source counts from repositories (no SQL in services)
+
+Use `memory-repository` for `memoriesByScope` (extend `countByProject`/add a scope rollup), and add small `count()` methods to the projects and tokens repositories if absent. All SQL stays under `db/` per the data-access invariant.
+
+### Decision 4 — Keep `scope`
+
+The handler already returns `scope`; it's useful and harmless. Add it to the spec rather than drop it.
+
+## Risks / Trade-offs
+
+- [`totalTokens` semantics ambiguous — count of token rows vs. sum of something] → define as count of active token rows (operator-facing counter), state it in the spec.
+- [Widening `statsOutput` before the handler returns the fields would break the tool] → land handler + schema + spec together in one change; the SDK validates on every call so a mismatch fails tests immediately.
+
+## Migration Plan
+
+Additive; no DB migration. Ship handler + `statsOutput` + spec text together. Rollback = revert the three-field addition.
+
+## Open Questions
+
+- Exact shape of `memoriesByScope`: `{ global: n, "project:<id>": n, ... }` vs a fixed `{ global, project }` rollup. Pick during apply based on what the dashboard/operator wants.

--- a/openspec/changes/align-memory-stats-with-spec/proposal.md
+++ b/openspec/changes/align-memory-stats-with-spec/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The `mcp-api` spec (§ "memory.stats returns counters by scope and status") requires `memory.stats` to return `{ memoriesByStatus, memoriesByType, memoriesByScope, sessionsByStatus, totalProjects, totalTokens }`. The shipped handler (`apps/server/src/mcp/sessions-tools.ts::handleStats`) returns only `{ scope, memoriesByStatus, memoriesByType, sessionsByStatus }` — `memoriesByScope`, `totalProjects`, and `totalTokens` are missing, and `scope` is returned but unspecified. This pre-existing impl↔spec divergence was surfaced while adding `outputSchema` to the tool (the new `statsOutput` schema codifies the handler's actual shape, making the gap explicit). Left unreconciled, the spec is a lie and the new `outputSchema` enshrines the wrong contract.
+
+## What Changes
+
+- Reconcile handler and spec. Recommended direction: **extend the handler** to honor the spec (the spec is the authoritative contract per CLAUDE.md), then widen `statsOutput` to match.
+- Add `memoriesByScope` (counts keyed by scope), `totalProjects`, `totalTokens` to `handleStats`, sourced from existing repository counters (`memory-repository.countByProject`, a projects count, a tokens count) — no new SQL outside `db/`.
+- Decide the shape of `totalProjects`/`totalTokens`: the spec says "each value being a `Record<string, number>`", which fits `memoriesByScope` but reads oddly for two scalars — clarify in the spec whether they are scalars (`number`) or records, and update §387 wording accordingly.
+- Keep or formally spec the extra `scope` field the handler already returns.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `mcp-api`: clarify/finalize the `memory.stats` response requirement so the spec and the handler (and its `outputSchema`) agree.
+
+## Impact
+
+- Code: `apps/server/src/mcp/sessions-tools.ts` (`handleStats` + `statsOutput`); possibly new lightweight count methods in `apps/server/src/db/repositories/` (projects/tokens counts) — SQL stays under `db/`.
+- Spec: `openspec/specs/mcp-api/spec.md` §"memory.stats" — finalize field list + value types.
+- Tests: extend `mcp-integration.test.ts` stats assertions.
+- No DB migration. Additive to the response (existing clients reading the current fields keep working).

--- a/openspec/changes/align-memory-stats-with-spec/specs/mcp-api/spec.md
+++ b/openspec/changes/align-memory-stats-with-spec/specs/mcp-api/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: The MCP server MUST expose two observability tools
+
+The `/mcp` and `/mcp/<slug>` endpoints SHALL register `memory.doctor` and `memory.stats`.
+
+#### Scenario: `memory.doctor` returns an operational report
+
+- **WHEN** an MCP client calls `memory.doctor`
+- **THEN** the server SHALL return `{ db: { open, journalMode, integrity, sizeBytes }, embeddings: { model, backlog }, consolidation: { lastRunAt, lastRunOps }, sessions: { active }, warnings: string[] }` — the report SHALL NOT contain an `llm` block, and the `embeddings` block SHALL NOT contain `enabled` (embeddings are always on); `model` SHALL identify the compiled-in embedding model
+
+#### Scenario: `memory.stats` returns counters by scope and status
+
+- **WHEN** an MCP client calls `memory.stats`
+- **THEN** the server SHALL return `{ scope, memoriesByStatus, memoriesByType, memoriesByScope, sessionsByStatus, totalProjects, totalTokens }` scoped to the request context, where:
+  - `scope` is a string (`global` or `project:<id>`) identifying the resolved scope,
+  - `memoriesByStatus`, `memoriesByType`, `memoriesByScope`, and `sessionsByStatus` are each a `Record<string, number>` of counts,
+  - `totalProjects` and `totalTokens` are each a `number`
+- **AND** the response SHALL conform to the tool's declared `outputSchema`
+
+#### Scenario: A read-only token calls `memory.doctor` or `memory.stats`
+
+- **WHEN** the caller's scope is `read:*` or `read:project:<id>`
+- **THEN** both tools SHALL succeed (they are read-only by design)

--- a/openspec/changes/align-memory-stats-with-spec/tasks.md
+++ b/openspec/changes/align-memory-stats-with-spec/tasks.md
@@ -1,0 +1,17 @@
+## 1. Repository counts
+
+- [ ] 1.1 Ensure `db/repositories` can produce: memory counts grouped by scope (`memoriesByScope`), total project count, total token count. Reuse existing methods where present (`memory-repository.countByProject`); add small `count()` methods to the projects and tokens repositories if missing. No SQL outside `db/`.
+
+## 2. Handler + output schema
+
+- [ ] 2.1 Extend `handleStats` (`apps/server/src/mcp/sessions-tools.ts`) to also return `memoriesByScope`, `totalProjects`, `totalTokens` (keep `scope`, `memoriesByStatus`, `memoriesByType`, `sessionsByStatus`).
+- [ ] 2.2 Widen `statsOutput` to match: add `memoriesByScope: z.record(z.string(), z.number())`, `totalProjects: z.number()`, `totalTokens: z.number()`.
+
+## 3. Spec + tests
+
+- [ ] 3.1 The spec delta (this change) finalizes the field list and value types; verify `openspec validate` passes.
+- [ ] 3.2 Extend `mcp-integration.test.ts` to assert `memory.stats` returns the full field set with correct types (the SDK validates structuredContent against the widened `statsOutput`).
+
+## 4. Verify
+
+- [ ] 4.1 `pnpm run typecheck`, `pnpm run lint`, full `pnpm vitest run` (server) pass.

--- a/openspec/changes/archive/2026-06-16-add-mcp-tool-annotations/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-16-add-mcp-tool-annotations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-16

--- a/openspec/changes/archive/2026-06-16-add-mcp-tool-annotations/design.md
+++ b/openspec/changes/archive/2026-06-16-add-mcp-tool-annotations/design.md
@@ -1,0 +1,84 @@
+## Context
+
+Every Rembric MCP tool is registered via `server.registerTool(name, { description, inputSchema }, handler)` in `apps/server/src/mcp/server.ts`. None declares `annotations`. The MCP SDK (`@modelcontextprotocol/sdk@1.29.0`) accepts an `annotations` field on the registration config (`mcp.js:706` destructures it; `ToolAnnotations` = `{ title?, readOnlyHint?, destructiveHint?, idempotentHint?, openWorldHint? }`) and forwards it verbatim in `tools/list`. Clients that read these hints (ChatGPT's connector UI is the visible case) otherwise assume the cautious default: not-read-only, destructive, open-world.
+
+Two load-bearing Rembric invariants make the correct annotation values unambiguous:
+
+- **Append-only memory** — rows are never `DELETE`d and `content` is never `UPDATE`d; lifecycle is `status` flips plus `replaces` links, every consolidation op journaled and reversible. Therefore **no** tool performs a destructive (irreversible) update.
+- **Closed local store** — Rembric is a single SQLite file behind one Node process, not a gateway to an open external world. `openWorldHint:false` everywhere.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Every registered MCP tool advertises behavioral annotations that match reality, so annotation-aware clients render read tools as read-only and stop labeling everything destructive.
+- A test pins the contract so a future tool registration can't silently regress it.
+- Purely additive: no change to tool inputs, outputs, descriptions, or the four shipping clients.
+
+**Non-Goals:**
+
+- `outputSchema` / `structuredContent` (see Decision 3 — deferred, not rejected).
+- Re-wording tool descriptions (a separate `mcp-api` requirement already governs the protocol-teaching descriptions).
+- Any change to scope enforcement, session lifecycle, or DB.
+
+## Decisions
+
+### Decision 1 — Annotation matrix
+
+Classify each tool and assign hints. `destructiveHint:false` and `openWorldHint:false` are universal (invariants above). `title` is a short human label for client UIs.
+
+| Tool                       | readOnly | idempotent | rationale                                                        |
+| -------------------------- | -------- | ---------- | ---------------------------------------------------------------- |
+| `memory.search`            | ✅       | ✅         | pure read                                                        |
+| `memory.get`               | ✅       | ✅         | pure read                                                        |
+| `memory.context`           | ✅       | ✅         | read (reading does NOT clear `needs_review` by design)           |
+| `memory.session_get`       | ✅       | ✅         | pure read                                                        |
+| `memory.timeline`          | ✅       | ✅         | pure read                                                        |
+| `memory.search_prompts`    | ✅       | ✅         | pure read                                                        |
+| `memory.doctor`            | ✅       | ✅         | read-only diagnostics                                            |
+| `memory.about`             | ✅       | ✅         | read-only guidance                                               |
+| `memory.stats`             | ✅       | ✅         | read-only counters                                               |
+| `memory.suggest_topic_key` | ✅       | ✅         | deterministic, no write                                          |
+| `project.list`             | ✅       | ✅         | pure read                                                        |
+| `project.current`          | ✅       | ✅         | pure read                                                        |
+| `memory.save`              | ❌       | ❌         | appends a row                                                    |
+| `memory.confirm`           | ❌       | ❌         | appends a confirmation event                                     |
+| `memory.capture_passive`   | ❌       | ❌         | appends N rows                                                   |
+| `memory.save_prompt`       | ❌       | ❌         | appends a prompt row                                             |
+| `memory.session_start`     | ❌       | ❌         | opens a session                                                  |
+| `memory.session_summary`   | ❌       | ✅         | latest-call-wins on the active session → idempotent in effect    |
+| `memory.session_end`       | ❌       | ✅         | idempotent on already-ended sessions (existing spec)             |
+| `memory.judge`             | ❌       | ❌         | closes a pending judgment (status flip, append-only, reversible) |
+| `memory.compare`           | ❌       | ✅         | idempotent upsert on `(memoryIdA, memoryIdB)` (existing spec)    |
+| `project.use`              | ❌       | ❌         | activates / may autocreate a project                             |
+
+`readOnlyHint` defaults to false when omitted, but we set it **explicitly** on write tools too so the test can assert presence rather than absence, and so the matrix is self-documenting at the call site.
+
+### Decision 2 — Where annotations live
+
+At each `registerTool` config object, via one of three module-scope factories — `READ_ANNOTATIONS(title)`, `WRITE_ANNOTATIONS(title)`, `IDEMPOTENT_WRITE_ANNOTATIONS(title)` — invoked inline next to `description`/`inputSchema`. The factories stamp the universal invariants (`destructiveHint:false`, `openWorldHint:false`) so they cannot be mistyped per-call, while the category + title stay visible at the registration site. Rejected alternative: a central `ANNOTATIONS` map keyed by tool name — that hides the hint behind a name lookup. Also rejected: fully inline boolean literals on all 22 tools — 4 fields × 22 is duplication that invites a `destructiveHint:true` typo. The factory call (`READ_ANNOTATIONS('Search memories')`) keeps the per-tool decision adjacent while the SDK still emits real per-tool annotations; the integration test enforces global consistency.
+
+### Decision 3 — Defer `outputSchema` (the actual ChatGPT tooltip), with rationale
+
+ChatGPT's tooltip recommends adding `outputSchema`. It is legitimate per the MCP spec, but it is **not** additive metadata the way annotations are, and it is deliberately excluded from this change:
+
+- **Hard contract change.** SDK 1.29.0 `mcp.js:199-208`: if a tool declares `outputSchema`, its handler **must** return `structuredContent` that validates against the schema, or the call fails with `Output validation error`. Today all handlers return `ok(payload)` = a single `text` block of `JSON.stringify(payload)` (`apps/server/src/mcp/tools.ts:117`). Adding `outputSchema` forces every one of ~25 handlers to also emit validated `structuredContent`.
+- **Fragile across branches.** The payloads are dynamic: `memory.context` (`recentSessions`/`recentMemories`/`pendingJudgments`/`needsReview`/`clamped`), `memory.save` (`candidates[]`), `memory.timeline` (`fallback:"time_window"`), plus `not_found`/error shapes. A schema correct for the happy path but wrong for an edge branch passes tests and then breaks that tool in production for **all four clients**.
+- **Conflicts with a repo invariant.** "Never hand-write row/DTO shapes — derive from schema types." There is no existing zod schema for tool outputs; authoring 25 by hand is exactly the duplication that invariant forbids, and it would drift from the real payloads.
+- **Low marginal benefit here.** Results are already serialized JSON in the `text` block, which models parse fine. `outputSchema` mainly helps clients that _validate/render_ structured output — a real but smaller win than fixing the wrong destructive/read-only labels.
+
+Recommendation for the operator: if `outputSchema` is still wanted after seeing this, do it as a separate spec-driven change that (a) introduces zod output schemas derived from the entity/projection types, (b) routes them through a single `ok(payload, schema)` helper that emits both `text` and `structuredContent`, and (c) backs every conditional branch and error shape with a test before flipping it on per-tool. Not safe to land unattended.
+
+## Risks / Trade-offs
+
+- [A client mis-reads `idempotentHint` and skips a legitimate re-call] → idempotent hints are only set where the existing specs already guarantee idempotency (`session_end`, `compare`) or where re-running is provably side-effect-free (reads, `suggest_topic_key`); `session_summary` is latest-wins so re-call is safe.
+- [A future tool is added without annotations, silently regressing the contract] → mitigated by the invariant-style test that enumerates the registered tools and asserts the matrix.
+- [`destructiveHint:false` on `memory.judge`/`project.use` looks aggressive] → justified: supersede is a reversible journaled `status` flip (append-only invariant), and `project.use` never deletes. Documented in the matrix so a reviewer can challenge it against the invariant, not a guess.
+
+## Migration Plan
+
+Single additive code change + test; no migration, no rollback complexity. Reverting is deleting the `annotations` fields. No client needs to change.
+
+## Open Questions
+
+- Should `title` strings be user-facing product copy reviewed by the operator, or are the terse engineering labels fine? Defaulting to terse labels matching the tool name; trivial to adjust later.

--- a/openspec/changes/archive/2026-06-16-add-mcp-tool-annotations/proposal.md
+++ b/openspec/changes/archive/2026-06-16-add-mcp-tool-annotations/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Rembric registers ~25 MCP tools with `description` + `inputSchema` only — no `annotations`. Annotation-aware clients (ChatGPT's connector UI, and any client honoring the 2025-06-18 hint vocabulary) therefore fall back to the most cautious defaults and render **every** tool as destructive / public-write / open-world. That is factually wrong: read tools (`memory.search`, `get`, `context`, `session_get`, `timeline`, `search_prompts`, `doctor`, `about`, `stats`, `suggest_topic_key`, `project.list`, `project.current`) never mutate, and per Rembric's append-only invariant **no** tool is destructive — even a supersede is a reversible, journaled `status` flip. Mislabeling reads as destructive pushes clients to gate them behind confirmations or avoid them, degrading the experience for no reason.
+
+## What Changes
+
+- Add a `ToolAnnotations` object to every `server.registerTool(...)` call in `apps/server/src/mcp/server.ts` (and the `memory.about` registration), carrying `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint`.
+- Read-only tools get `readOnlyHint: true`; **all** tools get `destructiveHint: false` (append-only invariant) and `openWorldHint: false` (closed local store). Idempotent tools (`memory.compare`, `memory.session_end`, `suggest_topic_key`, reads) get `idempotentHint: true`.
+- Add an invariant-style test asserting the annotation contract holds for the full tool set (read tools `readOnlyHint:true`; every tool `destructiveHint:false` + `openWorldHint:false`).
+- **Explicitly out of scope**: `outputSchema` / `structuredContent`. Deferred with a documented tradeoff (see `design.md`) — it is a hard, fragile contract change across four clients, not additive metadata. This change is metadata-only and non-breaking.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `mcp-api`: add a requirement that every registered MCP tool advertises behavioral annotations consistent with the append-only / closed-store invariants.
+
+## Impact
+
+- Code: `apps/server/src/mcp/server.ts` (tool registrations), one new/extended test under `apps/server/src/mcp/` or `apps/server/src/test/`.
+- Spec: `openspec/specs/mcp-api/spec.md` (new requirement + scenarios).
+- Clients: purely additive — no change to tool inputs, outputs, or descriptions; existing four clients (Claude Code, Codex, Hermes, opencode) and tests are unaffected. Annotation-aware UIs (ChatGPT connector) immediately render correct read/destructive/world hints.
+- No DB migration, no dependency change.

--- a/openspec/changes/archive/2026-06-16-add-mcp-tool-annotations/specs/mcp-api/spec.md
+++ b/openspec/changes/archive/2026-06-16-add-mcp-tool-annotations/specs/mcp-api/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Every MCP tool MUST advertise behavioral annotations
+
+Every tool registered on the MCP server SHALL declare an `annotations` object consistent with Rembric's append-only and closed-store invariants. The annotation set SHALL satisfy:
+
+- Read-only tools (`memory.search`, `memory.get`, `memory.context`, `memory.session_get`, `memory.timeline`, `memory.search_prompts`, `memory.doctor`, `memory.about`, `memory.stats`, `memory.suggest_topic_key`, `project.list`, `project.current`) SHALL carry `readOnlyHint: true`.
+- Mutating tools SHALL carry `readOnlyHint: false`.
+- Because no tool performs an irreversible destructive update (supersede is a reversible, journaled `status` flip; rows are never deleted), **every** tool SHALL carry `destructiveHint: false`.
+- Because Rembric is a closed local store, **every** tool SHALL carry `openWorldHint: false`.
+- Tools whose repeated invocation is side-effect-free or last-call-wins (`memory.compare`, `memory.session_end`, `memory.session_summary`, `memory.suggest_topic_key`, and all read-only tools) SHALL carry `idempotentHint: true`.
+
+Annotations are advisory metadata only: they SHALL NOT change tool inputs, outputs, or the `text` result contract.
+
+#### Scenario: Read-only tools report readOnlyHint
+
+- **WHEN** a client calls `tools/list`
+- **THEN** each of `memory.search`, `memory.get`, `memory.context`, `memory.session_get`, `memory.timeline`, `memory.search_prompts`, `memory.doctor`, `memory.about`, `memory.stats`, `memory.suggest_topic_key`, `project.list`, and `project.current` SHALL report `annotations.readOnlyHint === true`
+
+#### Scenario: No tool is advertised as destructive
+
+- **WHEN** a client calls `tools/list`
+- **THEN** every registered tool SHALL report `annotations.destructiveHint === false`
+
+#### Scenario: No tool is advertised as open-world
+
+- **WHEN** a client calls `tools/list`
+- **THEN** every registered tool SHALL report `annotations.openWorldHint === false`
+
+#### Scenario: Mutating tools are not marked read-only
+
+- **WHEN** a client calls `tools/list`
+- **THEN** `memory.save`, `memory.confirm`, `memory.capture_passive`, `memory.save_prompt`, `memory.session_start`, `memory.session_summary`, `memory.session_end`, `memory.judge`, `memory.compare`, and `project.use` SHALL report `annotations.readOnlyHint === false`
+
+#### Scenario: Annotations do not alter the result contract
+
+- **WHEN** any annotated tool is invoked successfully
+- **THEN** the result SHALL still be returned as a `text` content block (no `structuredContent` is required), unchanged from the pre-annotation behavior

--- a/openspec/changes/archive/2026-06-16-add-mcp-tool-annotations/tasks.md
+++ b/openspec/changes/archive/2026-06-16-add-mcp-tool-annotations/tasks.md
@@ -1,0 +1,16 @@
+## 1. Annotate tool registrations
+
+- [x] 1.1 In `apps/server/src/mcp/server.ts`, add an `annotations` object to the `registerTool` config of each read-only tool (`memory.search`, `memory.get`, `memory.context`, `memory.session_get`, `memory.timeline`, `memory.search_prompts`, `memory.doctor`, `memory.about`, `memory.stats`, `memory.suggest_topic_key`, `project.list`, `project.current`) with `readOnlyHint:true`, `destructiveHint:false`, `idempotentHint:true`, `openWorldHint:false`, and a terse `title`.
+- [x] 1.2 Add `annotations` to each mutating tool (`memory.save`, `memory.confirm`, `memory.capture_passive`, `memory.save_prompt`, `memory.session_start`, `memory.judge`, `project.use`) with `readOnlyHint:false`, `destructiveHint:false`, `idempotentHint:false`, `openWorldHint:false`, and a `title`.
+- [x] 1.3 Add `annotations` to the idempotent-mutating tools (`memory.session_summary`, `memory.session_end`, `memory.compare`) with `readOnlyHint:false`, `destructiveHint:false`, `idempotentHint:true`, `openWorldHint:false`, and a `title`.
+
+## 2. Pin the contract with a test
+
+- [x] 2.1 Add a test (in `apps/server/src/test/mcp-integration.test.ts`, alongside the existing `listTools` test) that builds the MCP server, lists registered tools, and asserts: every tool has `annotations.destructiveHint===false` and `annotations.openWorldHint===false`; the 12 read tools have `readOnlyHint===true`; the 10 mutating tools have `readOnlyHint===false`.
+- [x] 2.2 Assert the read/mutating tool name sets in the test are exhaustive against the registered tool list (a newly-registered tool with no annotation entry fails the test).
+
+## 3. Verify
+
+- [x] 3.1 `pnpm run typecheck` passes.
+- [x] 3.2 `pnpm run lint` passes.
+- [x] 3.3 `pnpm vitest run` for the affected mcp test files passes (new test + existing `server`/`tools`/`sessions-tools` tests green). Verified: `mcp-integration` 28/28 (incl. new annotations test) + `src/mcp/` suite & `invariants` 147/147.

--- a/openspec/changes/archive/2026-06-16-add-mcp-tool-output-schemas/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-16-add-mcp-tool-output-schemas/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-16

--- a/openspec/changes/archive/2026-06-16-add-mcp-tool-output-schemas/design.md
+++ b/openspec/changes/archive/2026-06-16-add-mcp-tool-output-schemas/design.md
@@ -1,0 +1,56 @@
+## Context
+
+`add-mcp-tool-annotations` (archived 2026-06-16) deferred `outputSchema` with a tradeoff analysis. Re-examining the SDK (`@modelcontextprotocol/sdk@1.29.0`, `dist/cjs/server/mcp.js`) lowered the risk materially:
+
+- `validateToolOutput` (line ~186): if `tool.outputSchema` is set and a **success** result lacks `structuredContent` → throws; if `structuredContent` is present it is parsed against the schema, throwing on mismatch.
+- **Line ~166: `if (result.isError) return;`** — output validation is SKIPPED for error results. Every Rembric error goes through `mcpError()` (`errors.ts`, sets `isError:true`), so error/`not_found`/`scope_locked`/`forbidden` shapes never need to appear in any output schema.
+- zod object parsing **strips** unknown keys (does not reject), so over-returning a field never fails validation. The only failure modes are a declared-required field being absent or a present field having the wrong type.
+
+These three facts collapse the "fragile across branches" concern: schemas model only the success shape, only required-when-always-present fields are required, and everything conditional is `.optional()`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Every tool advertises an accurate `outputSchema`; success calls return conforming `structuredContent`.
+- The `text` content block and all error results are byte-for-byte unchanged (four clients unaffected).
+- Eliminate the four duplicate `ok()` helpers in favor of one.
+
+**Non-Goals:**
+
+- Modeling error payloads (skipped by the SDK).
+- Changing any handler's business logic, scope resolution, or input contract.
+- Strict/exhaustive nested modeling where a field is genuinely dynamic (`doctor` health dump) — a faithful-but-tolerant schema is acceptable there.
+
+## Decisions
+
+### Decision 1 — `structuredContent = JSON.parse(JSON.stringify(payload))`
+
+Handlers build payloads containing `Date` objects (`createdAt: m.createdAt`) and conditionally-spread fields. The current `ok()` serializes via `JSON.stringify` (Dates → ISO strings) only into the `text` block. If `structuredContent` carried the raw payload, a `Date` object would fail a `z.string()` timestamp field, and validation runs **before** transport serialization (so the Date is still a Date at validation time). Round-tripping through `JSON.parse(JSON.stringify(payload))` makes `structuredContent` identical to the wire JSON: Dates become ISO strings uniformly, `undefined` is dropped, and every timestamp field is modeled as `z.string()`. Rejected alternative: `z.date()` per timestamp — brittle (some handlers already pre-call `.toISOString()`, others pass raw Dates) and the advertised JSON Schema would still be a string. The round-trip normalizes both producers into one rule.
+
+### Decision 2 — One shared `ok()` in `result.ts`
+
+The four identical `ok()` copies (`tools.ts`, `sessions-tools.ts`, `project-tools.ts`, `relations-tools.ts`) are replaced by a single `apps/server/src/mcp/result.ts` export. Centralizing is the only way to attach `structuredContent` once rather than in four places, and it removes duplication the repo already dislikes. `about-tool.ts` (which hand-builds its result) is updated to use it too.
+
+### Decision 3 — Output schemas as raw zod shapes, co-located per handler file
+
+Mirror the `inputSchema` convention exactly: each output schema is a `ZodRawShape` literal (`{ field: z.… }`), which `registerTool` accepts and `normalizeObjectSchema` wraps, and it lives in the SAME handler file as its `inputSchema` (`memory*Output` in `tools.ts`, session/context/doctor/stats outputs in `sessions-tools.ts`, `project*Output` in `project-tools.ts`, judge/compare/suggest in `relations-tools.ts`, `aboutOutput` in `about-tool.ts`). File-local sub-objects (`relationView`, `candidate`, `memoryRow` in `tools.ts`; `promptRow`, `memoryNeighbor`, `counts` in `sessions-tools.ts`) are `z.object(...)` — none is shared across files, so no central module is needed. Timestamps → `z.string()`; nullable DB columns → `.nullable()`; conditionally-spread fields (`reviewState`, `previousSlug`, `replaces`, `fallback`) → `.optional()`/`.nullable()`. (An earlier draft put all schemas in a single `output-schemas.ts`; dropped in review for breaking the established co-location convention — the `outputSchema` belongs next to the `inputSchema` it complements.)
+
+### Decision 4 — Tests are end-to-end calls
+
+The in-memory `Client` already exercises most tools in `mcp-integration.test.ts`. Because the SDK validates `structuredContent` against the schema on every call, **calling a tool is the schema test** — a wrong schema throws `Output validation error` and fails the test. Extend the suite so every one of the ~24 tools is invoked at least once and its `structuredContent` is asserted present. This catches the only real failure mode (required field absent / wrong type) for each tool's happy path.
+
+## Risks / Trade-offs
+
+- [A conditional success branch not hit by tests has a wrong required field] → Mitigation: model conditionally-present fields as `.optional()` by default; only mark a field required when the code path unconditionally sets it. The round-trip + unknown-key-stripping means over-modeling is safe; under-optionalizing is the only risk, handled by conservative optionality.
+- [`doctor` health dump drifts from its schema] → model its known top-level keys (`db`, `embeddings`, `consolidation`, `sessions`, `warnings`) per `DoctorReport`; these are stable typed fields, low drift risk.
+- [`JSON.parse(JSON.stringify())` double-encode cost] → negligible for these small payloads; bounded by existing response sizes.
+- [Future tool registered without `outputSchema`] → the integration test enumerates tools and asserts each returns `structuredContent`, catching an un-schemaed new tool.
+
+## Migration Plan
+
+Additive. Revert = drop `outputSchema` fields + restore per-file `ok()`. No migration, no client change, no data change.
+
+## Open Questions
+
+- None blocking. If a specific client mis-handles `structuredContent`, the `text` block remains the fallback every client already reads.

--- a/openspec/changes/archive/2026-06-16-add-mcp-tool-output-schemas/proposal.md
+++ b/openspec/changes/archive/2026-06-16-add-mcp-tool-output-schemas/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Rembric's MCP tools declare `inputSchema` but no `outputSchema`. Per the MCP spec (2025-06-18) and ChatGPT's connector UI recommendation, advertising an `outputSchema` lets annotation-aware clients validate and structurally render tool results instead of re-parsing an opaque JSON text blob. This is the follow-up the operator green-lit after `add-mcp-tool-annotations`: add `outputSchema` to **all** ~24 tools.
+
+## What Changes
+
+- Introduce a single shared `ok(payload)` result builder (replacing the four duplicate per-file copies) that returns BOTH the existing `text` content block AND a `structuredContent` object. `structuredContent` is `JSON.parse(JSON.stringify(payload))` so it is exactly the wire JSON (Dates → ISO strings) the schema validates against.
+- Add a per-tool zod `outputSchema` (success shape only) to every `server.registerTool(...)` call. Error/`not_found`/`scope_locked` results are unaffected — the SDK skips output validation for `isError:true` results (`mcp.js:166`), and all Rembric errors flow through `mcpError()`.
+- Add tests asserting each tool returns a `structuredContent` that conforms (the SDK throws `Output validation error` on mismatch, so calling every tool through the in-memory client is itself the validation).
+- **Not breaking**: the `text` content block is unchanged, so the four existing clients keep working byte-for-byte; `structuredContent` is purely additive.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `mcp-api`: add a requirement that every registered MCP tool advertises an `outputSchema` and returns conforming `structuredContent` on success, without altering the `text` result or error contract.
+
+## Impact
+
+- Code: new `apps/server/src/mcp/result.ts` (shared `ok`) + `apps/server/src/mcp/output-schemas.ts` (zod success schemas); `server.ts` registrations gain `outputSchema`; the four handler files (`tools.ts`, `sessions-tools.ts`, `project-tools.ts`, `relations-tools.ts`) drop their local `ok()` and import the shared one; `about-tool.ts` returns `structuredContent`.
+- Tests: extend `apps/server/src/test/mcp-integration.test.ts`.
+- Clients: additive; no input/description/error change. No DB migration, no dependency change.

--- a/openspec/changes/archive/2026-06-16-add-mcp-tool-output-schemas/specs/mcp-api/spec.md
+++ b/openspec/changes/archive/2026-06-16-add-mcp-tool-output-schemas/specs/mcp-api/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Every MCP tool MUST advertise an output schema and return conforming structured content
+
+Every tool registered on the MCP server SHALL declare an `outputSchema` describing the shape of its **successful** result, and on success SHALL return a `structuredContent` object that conforms to that schema. The `structuredContent` SHALL be the JSON-normalized form of the response (timestamps as ISO strings), equal in meaning to the existing `text` content block.
+
+This requirement is additive and SHALL NOT change:
+- the `text` content block returned by any tool (clients that read only `text` are unaffected), or
+- error results — results returned via `mcpError` carry `isError: true`, for which output-schema validation is not performed.
+
+#### Scenario: A successful tool call returns structured content
+
+- **WHEN** any registered tool is invoked and succeeds
+- **THEN** the result SHALL include a `structuredContent` object conforming to the tool's declared `outputSchema`
+- **AND** the result SHALL still include the equivalent `text` content block
+
+#### Scenario: Every tool advertises an output schema
+
+- **WHEN** a client calls `tools/list`
+- **THEN** every tool entry SHALL include an `outputSchema`
+
+#### Scenario: Error results are exempt from output-schema validation
+
+- **WHEN** a tool returns an error via `mcpError` (e.g. `not_found`, `scope_locked`, `forbidden`, `invalid_input`)
+- **THEN** the result SHALL carry `isError: true` and SHALL NOT be required to include `structuredContent`
+
+#### Scenario: Structured content matches the text payload
+
+- **WHEN** a tool succeeds and returns both `text` and `structuredContent`
+- **THEN** parsing the `text` JSON SHALL yield the same object as `structuredContent`

--- a/openspec/changes/archive/2026-06-16-add-mcp-tool-output-schemas/tasks.md
+++ b/openspec/changes/archive/2026-06-16-add-mcp-tool-output-schemas/tasks.md
@@ -1,0 +1,24 @@
+## 1. Shared result builder
+
+- [x] 1.1 Create `apps/server/src/mcp/result.ts` exporting `ok(payload)` that returns `{ content: [{type:'text', text: JSON.stringify(payload,null,2)}], structuredContent: JSON.parse(JSON.stringify(payload)) }`, typed against the SDK `CallToolResult`.
+- [x] 1.2 Delete the local `ok()` in `tools.ts`, `sessions-tools.ts`, `project-tools.ts`, `relations-tools.ts` and import the shared one. Update `about-tool.ts` to use it.
+
+## 2. Output schemas
+
+- [x] 2.1 Create `apps/server/src/mcp/output-schemas.ts` with one raw-shape zod `outputSchema` per tool (success shape only), plus reused sub-objects (`relationView`, `searchRow`, `candidate`, `promptRow`, `sessionRow`, `memoryNeighbor`). Timestamps `z.string()`; nullable columns `.nullable()`; conditional fields `.optional()`.
+- [x] 2.2 Cover all ~24 tools: save, search, get, confirm, session_start, session_end, session_summary, context, session_get, timeline, capture_passive, save_prompt, search_prompts, doctor, about, stats, project.use, project.list, project.current, suggest_topic_key, judge, compare.
+
+## 3. Wire registrations
+
+- [x] 3.1 Add `outputSchema: <tool>Output` to every `server.registerTool(...)` config in `apps/server/src/mcp/server.ts`.
+
+## 4. Tests
+
+- [x] 4.1 In `apps/server/src/test/mcp-integration.test.ts`, add a test that asserts every tool from `listTools()` has an `outputSchema`.
+- [x] 4.2 Add/extend tests so every tool is invoked once and its result `structuredContent` is asserted present (the SDK validates conformance on each call). Cover read tools, write tools, and the project/relations tools.
+
+## 5. Verify
+
+- [x] 5.1 `pnpm run typecheck` passes.
+- [x] 5.2 `pnpm run lint` passes.
+- [x] 5.3 Full `pnpm vitest run` (server) passes — any output-schema mismatch surfaces as `Output validation error` on the offending tool call.

--- a/openspec/specs/mcp-api/spec.md
+++ b/openspec/specs/mcp-api/spec.md
@@ -883,3 +883,70 @@ A connection authenticated by an OAuth access token SHALL be subject to the iden
 - **GIVEN** OAuth is enabled
 - **WHEN** the server routes requests for `/authorize`, `/token`, `/register`, and `/.well-known/oauth-*`
 - **THEN** those SHALL resolve to the OAuth handlers and SHALL NOT be interpreted as `/mcp` project slugs, and `/mcp/<slug>` routing SHALL remain unchanged
+
+### Requirement: Every MCP tool MUST advertise behavioral annotations
+
+Every tool registered on the MCP server SHALL declare an `annotations` object consistent with Rembric's append-only and closed-store invariants. The annotation set SHALL satisfy:
+
+- Read-only tools (`memory.search`, `memory.get`, `memory.context`, `memory.session_get`, `memory.timeline`, `memory.search_prompts`, `memory.doctor`, `memory.about`, `memory.stats`, `memory.suggest_topic_key`, `project.list`, `project.current`) SHALL carry `readOnlyHint: true`.
+- Mutating tools SHALL carry `readOnlyHint: false`.
+- Because no tool performs an irreversible destructive update (supersede is a reversible, journaled `status` flip; rows are never deleted), **every** tool SHALL carry `destructiveHint: false`.
+- Because Rembric is a closed local store, **every** tool SHALL carry `openWorldHint: false`.
+- Tools whose repeated invocation is side-effect-free or last-call-wins (`memory.compare`, `memory.session_end`, `memory.session_summary`, `memory.suggest_topic_key`, and all read-only tools) SHALL carry `idempotentHint: true`.
+
+Annotations are advisory metadata only: they SHALL NOT change tool inputs, outputs, or the `text` result contract.
+
+#### Scenario: Read-only tools report readOnlyHint
+
+- **WHEN** a client calls `tools/list`
+- **THEN** each of `memory.search`, `memory.get`, `memory.context`, `memory.session_get`, `memory.timeline`, `memory.search_prompts`, `memory.doctor`, `memory.about`, `memory.stats`, `memory.suggest_topic_key`, `project.list`, and `project.current` SHALL report `annotations.readOnlyHint === true`
+
+#### Scenario: No tool is advertised as destructive
+
+- **WHEN** a client calls `tools/list`
+- **THEN** every registered tool SHALL report `annotations.destructiveHint === false`
+
+#### Scenario: No tool is advertised as open-world
+
+- **WHEN** a client calls `tools/list`
+- **THEN** every registered tool SHALL report `annotations.openWorldHint === false`
+
+#### Scenario: Mutating tools are not marked read-only
+
+- **WHEN** a client calls `tools/list`
+- **THEN** `memory.save`, `memory.confirm`, `memory.capture_passive`, `memory.save_prompt`, `memory.session_start`, `memory.session_summary`, `memory.session_end`, `memory.judge`, `memory.compare`, and `project.use` SHALL report `annotations.readOnlyHint === false`
+
+#### Scenario: Annotations do not alter the result contract
+
+- **WHEN** any annotated tool is invoked successfully
+- **THEN** the result SHALL still be returned as a `text` content block (no `structuredContent` is required), unchanged from the pre-annotation behavior
+
+### Requirement: Every MCP tool MUST advertise an output schema and return conforming structured content
+
+Every tool registered on the MCP server SHALL declare an `outputSchema` describing the shape of its **successful** result, and on success SHALL return a `structuredContent` object that conforms to that schema. The `structuredContent` SHALL be the JSON-normalized form of the response (timestamps as ISO strings), equal in meaning to the existing `text` content block.
+
+This requirement is additive and SHALL NOT change:
+
+- the `text` content block returned by any tool (clients that read only `text` are unaffected), or
+- error results — results returned via `mcpError` carry `isError: true`, for which output-schema validation is not performed.
+
+#### Scenario: A successful tool call returns structured content
+
+- **WHEN** any registered tool is invoked and succeeds
+- **THEN** the result SHALL include a `structuredContent` object conforming to the tool's declared `outputSchema`
+- **AND** the result SHALL still include the equivalent `text` content block
+
+#### Scenario: Every tool advertises an output schema
+
+- **WHEN** a client calls `tools/list`
+- **THEN** every tool entry SHALL include an `outputSchema`
+
+#### Scenario: Error results are exempt from output-schema validation
+
+- **WHEN** a tool returns an error via `mcpError` (e.g. `not_found`, `scope_locked`, `forbidden`, `invalid_input`)
+- **THEN** the result SHALL carry `isError: true` and SHALL NOT be required to include `structuredContent`
+
+#### Scenario: Structured content matches the text payload
+
+- **WHEN** a tool succeeds and returns both `text` and `structuredContent`
+- **THEN** parsing the `text` JSON SHALL yield the same object as `structuredContent`


### PR DESCRIPTION
## What

Adds two pieces of MCP tool metadata to all 22 tools, so annotation-aware clients (e.g. ChatGPT connectors) treat the tools correctly:

1. **`annotations`** — `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint` + `title`. Read tools are `readOnlyHint:true`; **every** tool is `destructiveHint:false` (append-only invariant — supersede is a reversible, journaled `status` flip) and `openWorldHint:false` (closed local store). Three factories share a `NON_DESTRUCTIVE_CLOSED` base so the universal invariants can't be mistyped per-tool. Fixes the connector UI defaulting every tool to *destructive / public-write / open-world*.

2. **`outputSchema` + `structuredContent`** — a shared `ok()` builder (`result.ts`) returns the existing `text` block **plus** a `structuredContent` object. `structuredContent` is the JSON round-trip of the payload, so timestamps are ISO strings matching the `z.string()` schemas and it equals the wire JSON. Zod output shapes are **co-located** with each tool's `inputSchema`. Error results (`mcpError` → `isError:true`) are exempt from output validation per the SDK.

## Why it's safe

- The `text` content block is byte-for-byte unchanged → the four existing clients (Claude Code, Codex, Hermes, opencode) are unaffected; `structuredContent` is purely additive.
- The MCP SDK validates `structuredContent` against the `outputSchema` on **every** call, so the integration tests (every tool exercised) are themselves the conformance check. One real mismatch was caught and fixed during development (`prompt.replaces` is `null`, not `[]`).

## Spec

`openspec/specs/mcp-api/spec.md` gains two requirements (tool annotations; output schema + structured content). OpenSpec changes archived under `openspec/changes/archive/2026-06-16-*`.

## Follow-up (not implemented here)

While adding `statsOutput` I found `memory.stats` has **long diverged** from its spec §"memory.stats returns counters" (handler omits `memoriesByScope` / `totalProjects` / `totalTokens`). Pre-existing, out of scope. This PR includes an **apply-ready proposal** (`openspec/changes/align-memory-stats-with-spec/`, `docs:` commit) to reconcile it later — no code change.

## Verification

- `pnpm run typecheck` ✓ · `pnpm run lint` ✓ · full `pnpm test` ✓ (pre-push)
- Reviewed via `/simplify`, `/code-review` (clean), and `/judgment-day` (APPROVED after 2 micro-fixes).