### PR TITLE
docs(agents): recommend disabling ChatGPT native memory

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -46,6 +46,7 @@ ChatGPT connects as a **custom MCP connector** (no plugin, no static token) usin
    - URL: `https://memory.example.com/mcp/<slug>` (the `/<slug>` binds it to that project; omit for global).
    - Authentication: **OAuth**. Leave the advanced panel alone — the server advertises Dynamic Client Registration, so ChatGPT registers itself automatically (no client id/secret).
 3. **Consent**: the browser lands on the Rembric consent screen → sign in with your `REMBRIC_ADMIN_TOKEN` → **Authorize**. ChatGPT manages the token (refresh included) from then on.
+4. **Disable ChatGPT's native memory** _(optional but recommended)_: in Settings → Personalization → Memory, turn off **Reference saved memories** (and **Reference chat history**). This stops ChatGPT from falling back to its own store, so it leans on Rembric as the single source of truth — fewer stale or duplicated facts, and the custom instruction below has nothing to compete with. Leave it on if you deliberately want both stores.
 
 Per-project = one connector per `/mcp/<slug>`. Developer mode is a beta ChatGPT feature; on Business/Enterprise an admin can publish the connector workspace-wide.
 


### PR DESCRIPTION
## What

Adds an **optional but recommended** step to the ChatGPT custom-connector setup in `docs/agents.md`: disable ChatGPT's native memory (Settings → Personalization → Memory → turn off *Reference saved memories* / *Reference chat history*).

## Why

With native memory on, ChatGPT can fall back to its own store and the custom instruction ends up competing with it. Turning it off makes Rembric the single source of truth — fewer stale/duplicated facts and a cleaner flow. The step is explicitly optional for anyone who deliberately wants both stores.

## Scope

- Docs-only, single line added to the ChatGPT section.
- README unchanged — it already links to this section, so the detail stays centralized in `docs/agents.md`.