### PR TITLE
feat(server): lower memory.search default result count 20→8

### DIFF
--- a/apps/server/src/services/memory.test.ts
+++ b/apps/server/src/services/memory.test.ts
@@ -83,6 +83,28 @@ describe('memory.search', () => {
     const proj = await memory.search({}, projectScope(projectId));
     expect(proj.every((m) => m.scope === 'project' && m.projectId === projectId)).toBe(true);
   });
+
+  it('defaults to at most 8 results when no limit is given (both branches)', async () => {
+    for (let i = 0; i < 12; i++) {
+      memory.save({ type: 'user', content: `widget number ${i}` }, projectScope(projectId));
+    }
+    // Hybrid text-query branch (FTS-only here: no embedQuery wired).
+    const queried = await memory.search({ query: 'widget' }, projectScope(projectId));
+    expect(queried.length).toBe(8);
+    // No-query chronological listing branch.
+    const listed = await memory.search({}, projectScope(projectId));
+    expect(listed.length).toBe(8);
+  });
+
+  it('an explicit limit overrides the default in both directions', async () => {
+    for (let i = 0; i < 12; i++) {
+      memory.save({ type: 'user', content: `widget number ${i}` }, projectScope(projectId));
+    }
+    expect(
+      (await memory.search({ query: 'widget', limit: 3 }, projectScope(projectId))).length,
+    ).toBe(3);
+    expect((await memory.search({ limit: 12 }, projectScope(projectId))).length).toBe(12);
+  });
 });
 
 describe('memory.get', () => {

--- a/apps/server/src/services/memory.ts
+++ b/apps/server/src/services/memory.ts
@@ -440,8 +440,10 @@ export class MemoryService {
   }
 }
 
+const DEFAULT_SEARCH_LIMIT = 8;
+
 function clampLimit(limit: number | undefined): number {
-  if (limit === undefined) return 20;
+  if (limit === undefined) return DEFAULT_SEARCH_LIMIT;
   if (limit < 1) return 1;
   if (limit > 200) return 200;
   return Math.floor(limit);

--- a/openspec/changes/archive/2026-06-16-tune-memory-search-result-count/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-16-tune-memory-search-result-count/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-16

--- a/openspec/changes/archive/2026-06-16-tune-memory-search-result-count/design.md
+++ b/openspec/changes/archive/2026-06-16-tune-memory-search-result-count/design.md
@@ -1,0 +1,40 @@
+## Context
+
+Hybrid search (dense ⊕ FTS via RRF) is live in `memory.search`. The retrieval already follows "fetch wide, return narrow": each branch over-fetches into a bounded `rank_window_size = min(limit + offset + margin, RANK_WINDOW_CEILING)`, RRF fuses the ranked id lists, and the result is sliced to `limit`. The only knob that was never aligned with retrieval norms is the **default** `limit` when the caller omits it: `clampLimit(undefined)` returns 20 (`apps/server/src/services/memory.ts`). A live query returned 20 rows padded with distant memories; the user flagged it as too many.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Default `memory.search` result count aligned with the industry norm (final top-k ~3-10, saturating ~10).
+- The default lives in one named constant, not a magic literal.
+- Zero risk to the recently-shipped cross-lingual recall.
+
+**Non-Goals:**
+
+- Changing explicit-`limit` behavior, the clamp bounds (`[1, 200]`), the rank window, RRF, the FTS branch, or the dense kNN.
+- Adding a similarity/cosine threshold on the dense branch (see "Deferred" below).
+- Any reranker, migration, MCP tool-shape change, or dashboard change.
+
+## Decisions
+
+**D1 — Default `DEFAULT_SEARCH_LIMIT = 8`, applied to both search modes.** `clampLimit` is shared by the hybrid text-query branch and the no-query chronological listing, so the single constant moves both defaults in lock-step. 8 over 5: there is no reranker, so RRF ordering near the top is imprecise; a slightly higher final count hedges that without re-entering the noise zone (still ≤ the ~10 saturation point). Over a hardcoded 20: the observed padding is the recall-first design overshooting a small useful set.
+
+**D2 — A one-line value change, not a structural one.** The "fetch wide, return narrow" machinery already does the right thing; only the returned count was miscalibrated. Extracting the literal to `DEFAULT_SEARCH_LIMIT` makes the contract greppable and keeps it from silently drifting back.
+
+**D3 — Encode the default in the spec.** The default page size is observable MCP behavior (omit `limit` → get N rows). Specifying it (vs. leaving it an implementation detail) keeps the contract honest and prevents a silent revert.
+
+## Risks / Trade-offs
+
+- **A caller relying on the old 20-row default gets 8.** Mitigation: callers that need more pass an explicit `limit` (unchanged, up to 200). The MCP `memory.search` page just gets smaller by default — the intended effect. Audit `memory.test.ts` and any in-repo caller for an implicit-20 assumption.
+- **Performance:** lowering the default does NOT speed up the core retrieval (query embed + kNN partition scan + FTS scan are driven by in-partition corpus size, not by the returned count). It marginally shrinks the rank window (~50→~38 candidates/branch) and row hydration (≤20→≤8 rows + per-row review-state). The real win is downstream: a smaller payload means the consuming LLM ingests less context → faster, cheaper, less-noisy answers. We should not advertise this as a retrieval speedup.
+
+## Deferred: cosine-distance floor on the dense branch
+
+The original intuition was to also trim semantically-distant dense neighbors with a cosine floor before fusion (the distance is already returned by `knnByQueryVector`, so the filter is free). It is **deliberately deferred**, not abandoned, because:
+
+- It reverses prior decision **D3 of the hybrid-search change** ("No similarity thresholds on the search vector branch"), whose stated rationale is precisely the weak cross-lingual match (cosine ~0.6) that this project shipped support for.
+- The calibration bands overlap: unrelated pairs sit at cosine similarity ≈ 0.43-0.68, while legitimate weak/cross-lingual matches sit ≈ 0.6 — some junk is _closer_ than some real matches, so no floor cleanly separates them. Only a far-tail floor (cut similarity < ~0.40, i.e. distance > ~0.60) is safe, and it would remove at most a couple of filler rows inside an already-small top-8.
+- The bulk of the observed noise (ranks 9-20) disappears just by lowering the default. Measure first.
+
+**Re-open criteria:** if real-world top-8 results still show an obvious far-tail of unrelated rows, add a follow-up change for a conservative far-tail floor (similarity < ~0.40), with the value tuned empirically against the existing real-embedder cross-lingual test so no legitimate match is dropped. That refines the prior decision from "no threshold" to "no recall-capping threshold; a noise floor well below the weakest useful match is permitted."

--- a/openspec/changes/archive/2026-06-16-tune-memory-search-result-count/proposal.md
+++ b/openspec/changes/archive/2026-06-16-tune-memory-search-result-count/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`memory.search` defaults to returning 20 results when the caller omits `limit`. Industry retrieval practice puts the useful final top-k fed to an LLM at ~3-10, with accuracy saturating around 10 and larger result sets introducing noise rather than recall (Comet RAG guide; RankRAG, arXiv 2407.02485; LlamaIndex default `similarity_top_k=2`; LangChain retriever `k=4`). A real query — "Cuáles son los nodos de mi homelab?" — returned 20 rows padded with semantically-distant memories, which is exactly the recall-first design (`limit=20` + a kNN that returns its top-k regardless of distance) overshooting. The fix is to align the default with the norm.
+
+## What Changes
+
+- Lower the default `memory.search` result count from **20 to 8** when `limit` is omitted, expressed as a named `DEFAULT_SEARCH_LIMIT` constant rather than a magic literal in `clampLimit`. 8 (not 5) because there is no reranker yet: a slightly higher final count compensates for RRF's imprecise ordering near the top.
+- The default applies to BOTH search modes (the hybrid text-query branch and the no-query chronological listing), since `clampLimit` is shared. Explicit `limit` values are unchanged (still clamped to `[1, 200]`); the over-fetch rank window, RRF fusion, FTS branch, and dense branch are all untouched.
+- **Not in scope (deliberately deferred):** a cosine-distance floor on the dense branch to trim semantically-distant neighbors. It reverses a deliberate prior decision (D3, "no similarity threshold on the search vector branch") whose rationale is the cross-lingual recall this project just shipped, and the unrelated/weak-match cosine bands overlap so no safe floor value is obvious. Lowering the default removes the bulk of the observed noise on its own; the floor is recorded in `design.md` as a measure-first follow-up.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `memory`: the search behavior requirement gains an explicit default result-count contract (the previously-unspecified default of 20 becomes a specified `DEFAULT_SEARCH_LIMIT` of 8, applied to both the hybrid and listing branches).
+
+## Impact
+
+- `apps/server/src/services/memory.ts` — `clampLimit` default value, extracted to a `DEFAULT_SEARCH_LIMIT` constant.
+- Spec: `openspec/specs/memory/spec.md` — hybrid-retrieval requirement, default result-count clause.
+- Tests: `apps/server/src/services/memory.test.ts` (any assertion that relies on the 20 default).
+- No migration, no MCP tool-shape change, no dashboard change. The MCP `memory.search` contract change is the smaller default page size when `limit` is omitted.

--- a/openspec/changes/archive/2026-06-16-tune-memory-search-result-count/specs/memory/spec.md
+++ b/openspec/changes/archive/2026-06-16-tune-memory-search-result-count/specs/memory/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Memory search MUST default to a bounded, retrieval-aligned result count
+
+When `memory.search` is called WITHOUT an explicit `limit`, the system SHALL apply a default of `DEFAULT_SEARCH_LIMIT = 8`, expressed as a single named constant rather than a magic literal. The default SHALL apply identically to BOTH search modes — the hybrid text-query branch and the no-query chronological listing — because the limit-clamping path is shared. An explicit `limit` SHALL still be honored and clamped to `[1, 200]`; the default governs only the omitted case. The value 8 sits within the retrieval-engineering norm for the final result set fed to a model (a low single-digit-to-ten count, beyond which additional rows add noise rather than recall) and is chosen above a tighter 3-5 because no reranker is applied, so the fused ranking near the top is approximate. This default SHALL NOT change the over-fetch rank window, RRF fusion, the FTS branch, or the dense kNN branch; it changes only how many of the already-ranked results are returned when the caller does not specify.
+
+#### Scenario: A text query with no explicit limit returns at most the default count
+
+- **GIVEN** more than 8 active memories in scope match a non-empty text `query`
+- **WHEN** `memory.search` is called with that `query` and no `limit`
+- **THEN** at most `DEFAULT_SEARCH_LIMIT` (8) results SHALL be returned, ordered by the fused RRF ranking
+
+#### Scenario: A no-query listing with no explicit limit returns at most the default count
+
+- **GIVEN** more than 8 active memories in scope
+- **WHEN** `memory.search` is called WITHOUT a text `query` and without `limit`
+- **THEN** at most `DEFAULT_SEARCH_LIMIT` (8) results SHALL be returned, in the chronological listing order
+
+#### Scenario: An explicit limit overrides the default in both directions
+
+- **WHEN** `memory.search` is called with an explicit `limit` of 3, or of 50
+- **THEN** the result count SHALL be governed by the explicit `limit` (clamped to `[1, 200]`), not by `DEFAULT_SEARCH_LIMIT`

--- a/openspec/changes/archive/2026-06-16-tune-memory-search-result-count/tasks.md
+++ b/openspec/changes/archive/2026-06-16-tune-memory-search-result-count/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implementation
+
+- [x] 1.1 In `apps/server/src/services/memory.ts`, add a `DEFAULT_SEARCH_LIMIT = 8` constant and use it in `clampLimit` in place of the literal `20`.
+
+## 2. Tests
+
+- [x] 2.1 Audit `apps/server/src/services/memory.test.ts` (and any other in-repo `memory.search` caller) for an assertion that implicitly relies on the old 20-row default; update to the new default. (No caller relied on the 20 default — `tools.test.ts`/`invariants.test.ts` use `toBeGreaterThan(0)` and scope checks, not exact counts.)
+- [x] 2.2 Add/adjust a test asserting that an omitted `limit` yields at most `DEFAULT_SEARCH_LIMIT` (8) results on BOTH the hybrid text-query branch and the no-query listing branch, and that an explicit `limit` still overrides it.
+
+## 3. Validation
+
+- [x] 3.1 `pnpm run typecheck` and `pnpm run lint` clean.
+- [x] 3.2 `pnpm vitest run apps/server/src/services/memory.test.ts apps/server/src/services/hybrid-search.test.ts` green.
+- [x] 3.3 `openspec validate tune-memory-search-result-count` passes.

--- a/openspec/specs/memory/spec.md
+++ b/openspec/specs/memory/spec.md
@@ -168,6 +168,27 @@ When `memory.search` is called with a non-empty text `query`, the system SHALL i
 - **WHEN** `memory.search` is called WITH a text query and a non-zero `offset`
 - **THEN** `offset` SHALL be applied best-effort over the in-memory fused result pool (which is over-fetched beyond `limit + offset`) rather than as a SQL `OFFSET`; an `offset` beyond the fused pool SHALL yield an empty page rather than an error, and this divergence from the listing branch SHALL be documented as a contract change
 
+### Requirement: Memory search MUST default to a bounded, retrieval-aligned result count
+
+When `memory.search` is called WITHOUT an explicit `limit`, the system SHALL apply a default of `DEFAULT_SEARCH_LIMIT = 8`, expressed as a single named constant rather than a magic literal. The default SHALL apply identically to BOTH search modes — the hybrid text-query branch and the no-query chronological listing — because the limit-clamping path is shared. An explicit `limit` SHALL still be honored and clamped to `[1, 200]`; the default governs only the omitted case. The value 8 sits within the retrieval-engineering norm for the final result set fed to a model (a low single-digit-to-ten count, beyond which additional rows add noise rather than recall) and is chosen above a tighter 3-5 because no reranker is applied, so the fused ranking near the top is approximate. This default SHALL NOT change the over-fetch rank window, RRF fusion, the FTS branch, or the dense kNN branch; it changes only how many of the already-ranked results are returned when the caller does not specify.
+
+#### Scenario: A text query with no explicit limit returns at most the default count
+
+- **GIVEN** more than 8 active memories in scope match a non-empty text `query`
+- **WHEN** `memory.search` is called with that `query` and no `limit`
+- **THEN** at most `DEFAULT_SEARCH_LIMIT` (8) results SHALL be returned, ordered by the fused RRF ranking
+
+#### Scenario: A no-query listing with no explicit limit returns at most the default count
+
+- **GIVEN** more than 8 active memories in scope
+- **WHEN** `memory.search` is called WITHOUT a text `query` and without `limit`
+- **THEN** at most `DEFAULT_SEARCH_LIMIT` (8) results SHALL be returned, in the chronological listing order
+
+#### Scenario: An explicit limit overrides the default in both directions
+
+- **WHEN** `memory.search` is called with an explicit `limit` of 3, or of 50
+- **THEN** the result count SHALL be governed by the explicit `limit` (clamped to `[1, 200]`), not by `DEFAULT_SEARCH_LIMIT`
+
 ### Requirement: The vector index MUST mirror the memory lifecycle and support scoped kNN over an arbitrary query vector
 
 `memory_vec` is a derived index, not primary data: an embedding is a deterministic function of `memory.content` (which append-only preserves) and is recomputable at any time. The index therefore is NOT bound by the append-only invariant of the `memory` table; it MAY be updated to track the memory lifecycle, mirroring the existing `memory_fts` trigger-driven sync. `memory_vec` SHALL carry a scope-derived partition key (the `project_id` for project scope, a fixed sentinel that cannot collide with a real `project_id` for global scope), a `status`, and a `type`. The partition key, `status`, and `type` SHALL be supplied when the embedding row is inserted (not by a trigger on the vector table, which the engine forbids); `status` SHALL thereafter be kept in sync with the owning memory's `status` by a trigger on the base `memory` table. The repository SHALL expose a scoped kNN query over an arbitrary query vector that filters by partition key plus requested `status` and optional `type`, so that a scoped search scans only its own partition and its own structured slice. Vectors SHALL be retained across `status` transitions so that `superseded` history remains semantically recoverable when explicitly requested. `archived` rows MAY still have retained vectors while present, but because the post-model-change backfill intentionally targets non-archived rows, archived rows are outside the semantic-search guarantee and SHALL be treated as lexical-only for correctness. Vectors SHALL be physically removed only when the owning memory row is physically purged through an existing journaled escape hatch.


### PR DESCRIPTION
## Why

`memory.search` defaulted to **20** results when `limit` is omitted — above the retrieval-engineering norm for the final top-k fed to an LLM (~3–10, saturating ~10; LlamaIndex defaults to 2, LangChain to 4). A live query (*"Cuáles son los nodos de mi homelab?"*) returned 20 rows padded with semantically-distant memories: the recall-first design overshooting a small useful set.

## What

- Introduce `DEFAULT_SEARCH_LIMIT = 8` (named constant, not a magic literal) in `clampLimit`, applied to **both** search modes — the hybrid text-query branch and the no-query chronological listing share the clamp.
- **8** over a tighter 3–5: no reranker yet, so the fused RRF ordering near the top is approximate; 8 hedges that while staying ≤ the ~10 saturation point.
- Explicit `limit` is unchanged (clamped `[1, 200]`). The over-fetch rank window, RRF fusion, FTS branch, and dense kNN are **untouched**.

## Deliberately deferred

A cosine-distance floor on the dense branch was considered and **not** included (documented in the change's `design.md`). It reverses the prior *"no similarity threshold on the search vector branch"* decision (D3) whose rationale is the cross-lingual recall this project just shipped, and the unrelated/weak-match cosine bands overlap so no safe floor value is obvious. Lowering the default removes the bulk of the observed noise on its own; the floor is a measure-first follow-up.

## Performance note

This does **not** speed up the core retrieval (query embed + kNN partition scan + FTS scan are driven by in-partition corpus size, not the returned count). It marginally shrinks the rank window (~50→~38 candidates/branch) and row hydration (≤20→≤8). The real win is downstream: a smaller payload means the consuming LLM ingests less context → faster, cheaper, less-noisy answers.

## Tests

- New: omitted `limit` yields at most 8 on both branches; explicit `limit` overrides in both directions.
- Existing search tests audited — none relied on the old 20 default.
- `typecheck` ✓ · `lint` ✓ · 49 service tests green (incl. real-embedder cross-lingual) · `openspec validate` ✓.

OpenSpec: `tune-memory-search-result-count` (archived in this PR; spec synced — new requirement *"Memory search MUST default to a bounded, retrieval-aligned result count"*).