### PR TITLE
fix(plugin): use real codex plugin add/remove verbs in installer

### DIFF
--- a/apps/plugin/README.md
+++ b/apps/plugin/README.md
@@ -25,7 +25,7 @@ It is an orchestrator — it routes to each client's real mechanism (the per-cli
 | Client           | Manual command                                                                                                                                                                                |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Claude Code**  | `claude plugin marketplace add https://github.com/susomejias/rembric.git && claude plugin install rembric@rembric`                                                                            |
-| **Codex CLI**    | `codex plugin marketplace add https://github.com/susomejias/rembric.git && codex plugin install rembric`                                                                                      |
+| **Codex CLI**    | `codex plugin marketplace add https://github.com/susomejias/rembric.git && codex plugin add rembric@rembric`                                                                                  |
 | **Hermes Agent** | `curl -fsSL https://raw.githubusercontent.com/susomejias/rembric/main/apps/plugin/.hermes-plugin/install.sh \| sh && hermes plugins enable rembric`                                           |
 | **opencode**     | `curl -fsSL https://raw.githubusercontent.com/susomejias/rembric/main/apps/plugin/.opencode-plugin/install.sh \| sh` then paste the printed MCP block into `~/.config/opencode/opencode.json` |
 

--- a/apps/plugin/install.sh
+++ b/apps/plugin/install.sh
@@ -634,9 +634,9 @@ marketplace_cmds() { # $1 client, $2 action → print (and optionally run) CLI
       rem="claude plugin uninstall rembric@rembric" ;;
     codex)
       add="codex plugin marketplace add https://github.com/susomejias/rembric.git"
-      ins="codex plugin install rembric"
-      upd="codex plugin marketplace upgrade rembric"
-      rem="codex plugin uninstall rembric" ;;
+      ins="codex plugin add rembric@rembric"
+      upd="codex plugin marketplace upgrade rembric && codex plugin add rembric@rembric"
+      rem="codex plugin remove rembric@rembric" ;;
   esac
   case "$action" in
     install)   say "  Run:"; say "    ${BOLD}$add${RESET}"; say "    ${BOLD}$ins${RESET}"; cmd="$ins" ;;

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -99,7 +99,7 @@ is sensitive.
 
 ```bash
 codex plugin marketplace add https://github.com/susomejias/rembric.git
-codex plugin install rembric
+codex plugin add rembric@rembric
 ```
 
 The marketplace `source` is `git-subdir` against `./plugin`, so Codex clones the repo subtree on install. Repo access (SSH key / PAT) gates discovery, exactly like the Claude Code plugin.
@@ -181,16 +181,13 @@ If you only use one client, set up just that one. If you use both, you need both
 Codex caches plugins by `version` under `~/.codex/plugins/cache/<marketplace>/<plugin>/<version>/`, so the cache invalidates when we bump `apps/plugin/.codex-plugin/plugin.json`. Official commands (`developers.openai.com/codex/plugins`):
 
 ```shell
-# refresh ALL configured marketplaces
-codex plugin marketplace upgrade
-
-# or refresh a specific one
+# refresh the marketplace snapshot, then re-install from it (the snapshot
+# refresh alone does NOT pull the new version into the local cache)
 codex plugin marketplace upgrade rembric
+codex plugin add rembric@rembric
 ```
 
-After the marketplace catalog refresh, Codex picks up the new version on the next plugin load. If Codex reports it's still on the cached version, fall back to a clean cycle from inside Codex's `/plugins` panel: select the plugin, **Uninstall plugin**, then **Install plugin** again (the docs do not yet expose a per-plugin `update` command — this is the supported alternative).
-
-Restart `codex` after the update so the bridge and hooks re-spawn from the new cache path.
+The Codex CLI has no dedicated per-plugin `update` verb, so re-running `codex plugin add` against the refreshed snapshot is the upgrade mechanism — this is exactly what the TUI installer's Update action runs for you. (`codex plugin marketplace upgrade` with no argument refreshes ALL configured marketplaces.) Restart `codex` after the update so the bridge and hooks re-spawn from the new cache path.
 
 ### Hermes Agent (memory provider plugin)
 
@@ -281,7 +278,7 @@ Credentials, slug source, and update flow are independent per client. The Rembri
 | Client          | Credentials from                                  | Slug from                                                          | Update                                                                                        |
 | --------------- | ------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
 | **Claude Code** | Wizard → keychain (`${user_config.*}`)             | `.rembric` file via the bridge                                     | `/plugin update rembric@rembric`                                                              |
-| **Codex CLI**   | Shell env (`export REMBRIC_*`)                     | `.rembric` file via the bridge                                     | `codex plugin marketplace upgrade rembric` + restart                                          |
+| **Codex CLI**   | Shell env (`export REMBRIC_*`)                     | `.rembric` file via the bridge                                     | `codex plugin marketplace upgrade rembric && codex plugin add rembric@rembric` + restart       |
 | **Hermes Agent**| Shell env OR `~/.rembric/.env` preload             | Cascade (env / `rembric.json` / `.rembric` / URL parse)            | Re-run the curl-installer                                                                     |
 
 Both the Hermes MCP bridge entry (`mcp_servers.rembric`) and the Hermes provider read the same shell env, so a single shell rc edit covers them. No keychain (Hermes has no `userConfig` equivalent; `get_config_schema()` is provider-managed storage in `~/.hermes/rembric.json`).

--- a/install.test.ts
+++ b/install.test.ts
@@ -184,7 +184,7 @@ describe('agent routing', () => {
     const { code, out } = run(['--agent=codex', '--action=install'], { home });
     expect(code).toBe(0);
     expect(out).toContain('codex plugin marketplace add');
-    expect(out).toContain('codex plugin install rembric');
+    expect(out).toContain('codex plugin add rembric@rembric');
   });
 
   it('claude uninstall prints the marketplace command and the conservative note', () => {
@@ -203,13 +203,13 @@ describe('agent routing', () => {
     const codex = run(['--agent=codex', '--action=update'], { home });
     expect(codex.code).toBe(0);
     expect(codex.out).toContain('codex plugin marketplace upgrade rembric');
-    expect(codex.out).not.toContain('codex plugin install');
+    expect(codex.out).not.toContain('codex plugin install'); // no such subcommand in the Codex CLI
   });
 
   it('a comma-separated --agent list drives multiple agents in one run', () => {
     const { code, out } = run(['--agent=codex,claude', '--action=install'], { home });
     expect(code).toBe(0);
-    expect(out).toContain('codex plugin install rembric');
+    expect(out).toContain('codex plugin add rembric@rembric');
     expect(out).toContain('claude plugin install rembric@rembric');
   });
 

--- a/openspec/changes/archive/2026-06-18-fix-codex-plugin-cli-verbs/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-18-fix-codex-plugin-cli-verbs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-18

--- a/openspec/changes/archive/2026-06-18-fix-codex-plugin-cli-verbs/design.md
+++ b/openspec/changes/archive/2026-06-18-fix-codex-plugin-cli-verbs/design.md
@@ -1,0 +1,63 @@
+## Context
+
+The Codex CLI `plugin` command surface (verified live against `codex-cli 0.141.0`):
+
+```
+$ codex plugin --help
+Commands:
+  add          Install a plugin from a configured marketplace snapshot
+  list         List plugins available from configured marketplace snapshots
+  marketplace  Add, list, upgrade, or remove configured plugin marketplaces
+  remove       Remove an installed plugin from local config and cache
+```
+
+`codex plugin add --help` documents the selector as `PLUGIN[@MARKETPLACE]` — either `rembric@rembric` or `rembric --marketplace rembric`. The marketplace name `rembric` comes from our `.codex-plugin/marketplace.json` (`name: "rembric"`), which is what `codex plugin marketplace add` registers. This mirrors the Claude Code selector we already use (`rembric@rembric`).
+
+There is no `codex plugin update` / `codex plugin install` / `codex plugin uninstall`. The historical proposal `add-codex-distribution` guessed these verbs from the agentmemory reference and flagged them as unverified; the guess was wrong.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- The TUI installer's Codex install/uninstall/update paths run real Codex CLI commands that succeed.
+- Docs, test, and specs quote the same correct commands so they don't drift back.
+
+**Non-Goals**
+
+- No change to the marketplace manifest, the bridge, the hooks, or any per-client primitive.
+- No change to the post-install hook-enablement guidance (`codex features enable plugin_hooks`, `/hooks` trust, `REMBRIC_*` export) — that part was already correct.
+
+## Decisions
+
+### Decision 1: install → `codex plugin add rembric@rembric`, uninstall → `codex plugin remove rembric@rembric`
+
+Use the fully-qualified `PLUGIN@MARKETPLACE` selector (`rembric@rembric`) rather than bare `rembric`, matching the Claude Code line and removing any ambiguity if a second marketplace ever defines a `rembric` plugin.
+
+### Decision 2: update = refresh snapshot **then** re-add
+
+`codex plugin marketplace upgrade rembric` only refreshes the Git marketplace _snapshot_; it does not re-install the already-cached plugin from that new snapshot. The Codex CLI exposes no per-plugin update verb. So the installer's update path chains both:
+
+```
+codex plugin marketplace upgrade rembric && codex plugin add rembric@rembric
+```
+
+`codex plugin add` against an already-installed plugin re-installs from the refreshed snapshot (verified: re-running `add` reports "Added plugin … Installed plugin root: …/<version>"), which is the actual upgrade mechanism. This is the closest correct analogue to Claude Code's single `claude plugin update`.
+
+The installer's `update` action sets `add=''` (no `marketplace add`) before printing — the marketplace is already registered on update, so only the upgrade+re-add chain runs. That existing branch logic is unchanged; only the command string it carries changes.
+
+### Decision 3: keep the no-`install`-verb guard in the test
+
+The update-scenario test keeps `expect(codex.out).not.toContain('codex plugin install')`. Since the corrected verb is `add`, this assertion now doubles as a regression guard against the exact bug being fixed — if anyone reintroduces an `install` verb anywhere in the Codex output, the test fails.
+
+## Risks / Trade-offs
+
+- **`codex plugin add` re-install semantics could change upstream.** Low risk: the `add` verb is the documented install primitive and behaves idempotently today. If a future Codex CLI adds a dedicated `update`, the installer's update string is the single place to change. Mitigation: the e2e installer playbook exercises the printed commands.
+- **Marketplace name coupling.** `rembric@rembric` assumes the marketplace registers as `rembric` (it does, per the manifest `name`). If the manifest name ever changes, the selector must change with it — same coupling the Claude Code line already has.
+
+## Migration Plan
+
+None. Users who hit the failed `codex plugin install` simply re-run the installer (or `codex plugin add rembric@rembric`) once the fix ships. No state to migrate; the failed run left only the registered marketplace, which the corrected flow reuses.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-06-18-fix-codex-plugin-cli-verbs/proposal.md
+++ b/openspec/changes/archive/2026-06-18-fix-codex-plugin-cli-verbs/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Installing the Codex plugin from the TUI fails. The installer prints and runs `codex plugin install rembric`, but the Codex CLI (verified against `codex-cli 0.141.0`) has **no `install` subcommand** under `codex plugin` — it aborts with `error: unrecognized subcommand 'install'` (it even suggests `list`). The marketplace is added successfully, then the install step dies, leaving the user with a half-wired plugin.
+
+The real Codex `plugin` subcommands are:
+
+- `codex plugin add <PLUGIN[@MARKETPLACE]>` — install from a configured marketplace snapshot
+- `codex plugin remove <PLUGIN[@MARKETPLACE]>` — uninstall
+- `codex plugin marketplace upgrade <name>` — refresh the marketplace snapshot (does **not** by itself re-install the cached plugin)
+
+The wrong verbs (`install` / `uninstall`) were carried verbatim from the original `add-codex-distribution` proposal, where the commands were documented as "not yet empirically verified" (a known risk recorded in that change's design.md). They are wrong in the installer, the user-facing docs, the installer test, and the two specs that quote them.
+
+## What Changes
+
+- **`apps/plugin/install.sh` (the fix):** the Codex `marketplace_cmds` block uses the correct verbs — install → `codex plugin add rembric@rembric`, uninstall → `codex plugin remove rembric@rembric`. The update path refreshes the snapshot **and** re-adds (`codex plugin marketplace upgrade rembric && codex plugin add rembric@rembric`), because a snapshot refresh alone does not pull the new version into the local cache — there is no per-plugin update verb in the Codex CLI.
+- **Docs:** `docs/agents.md` and `apps/plugin/README.md` update the quoted Codex marketplace command from `codex plugin install rembric` to `codex plugin add rembric@rembric`.
+- **Test:** `install.test.ts` asserts the corrected verb in the Codex install + multi-agent scenarios; the update scenario keeps the guard that the output never contains `codex plugin install` (no such subcommand).
+- **Specs:** `codex-distribution` and `tui-installer` update the scenarios that quote the Codex install command to the correct `codex plugin add rembric@rembric` form.
+
+No load-bearing server invariant (append-only memory, scope-at-service, `topic_key`, judgment freshness) is touched. This is a correctness fix to the distribution surface and its documentation — no behavioural change to the server, the bridge, the hooks, or the marketplace manifest.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `codex-distribution`: the marketplace-install scenario and the `docs/agents.md` recommendation quote the correct `codex plugin add rembric@rembric` verb instead of the non-existent `codex plugin install rembric`.
+- `tui-installer`: the "Marketplace client prints CLI commands" scenario asserts the installer prints `codex plugin add rembric@rembric` instead of `codex plugin install rembric`.
+
+## Impact
+
+- **Modified files**: `apps/plugin/install.sh`, `docs/agents.md`, `apps/plugin/README.md`, `install.test.ts`, `openspec/specs/codex-distribution/spec.md`, `openspec/specs/tui-installer/spec.md`.
+- **Unchanged (deliberately)**: the Codex marketplace manifest (`.codex-plugin/marketplace.json`), the bridge, hooks, and every per-client primitive — only the install/uninstall/update _verbs_ the installer drives are corrected.
+- **Versioning**: `apps/plugin/install.sh` sits in the unified `plugin` release-please component; a fix here bumps the shared `plugin` version (CHANGELOG scoped by conventional commit).
+- **No supply-chain surface change**: no new dependency, no `.npmrc` / `pnpm-workspace.yaml` / lockfile / Dockerfile change.

--- a/openspec/changes/archive/2026-06-18-fix-codex-plugin-cli-verbs/specs/codex-distribution/spec.md
+++ b/openspec/changes/archive/2026-06-18-fix-codex-plugin-cli-verbs/specs/codex-distribution/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Codex marketplace declaration
+
+The repository SHALL host a Codex marketplace manifest at `.codex-plugin/marketplace.json` at the repo root, installable via `codex plugin marketplace add <repo>`. The `source.path` entry SHALL point at `./apps/plugin` so the marketplace's `git-subdir` extraction targets the relocated plugin tree.
+
+#### Scenario: git-subdir source
+
+- **WHEN** `.codex-plugin/marketplace.json` is loaded
+- **THEN** it declares exactly one plugin entry named `rembric`
+- **AND** the entry's `source` object is `{ "source": "git-subdir", "url": "https://github.com/susomejias/rembric.git", "path": "./apps/plugin", "ref": "main" }`
+- **AND** the entry declares `policy.installation: "AVAILABLE"` and `policy.authentication: "ON_INSTALL"` and `category: "Memory"`
+
+#### Scenario: Marketplace metadata
+
+- **WHEN** the marketplace is loaded
+- **THEN** the top-level object contains `name: "rembric"` and `interface.displayName: "Rembric"`
+
+#### Scenario: Marketplace install resolves the relocated plugin tree
+
+- **GIVEN** a clean Codex CLI installation with no `rembric` plugin cached
+- **WHEN** the user runs `codex plugin marketplace add https://github.com/susomejias/rembric.git` followed by `codex plugin add rembric@rembric`
+- **THEN** Codex SHALL clone the repo, extract the subtree at `./apps/plugin` per the `source.path`, and cache it under `~/.codex/plugins/cache/rembric/<version>/`
+- **AND** the cached directory SHALL contain `.codex-plugin/plugin.json`, `.codex-plugin/mcp.json`, `bin/rembric-bridge.mjs`, `bin/rembric-dotenv.mjs`, `hooks/hooks.codex.json`, and the relevant `scripts/` files
+
+### Requirement: `docs/agents.md` recommends the plugin install as primary
+
+The Codex section of `docs/agents.md` SHALL recommend the **TUI installer** (`apps/plugin/install.sh` / the root shim) as the primary install path. It SHALL retain the Codex marketplace plugin install (`codex plugin marketplace add … && codex plugin add rembric@rembric`) and the manual `config.toml` fallback, but both SHALL appear under an explicitly-labelled "Manual / advanced" subsection, not as the lead instruction. The section SHALL document the credential flow, and the platform-required enablement steps for plugin hooks (which Codex gates behind an under-development feature flag and a per-hook trust review as of `codex-cli 0.130.0`). The "trust each of the N plugin-bundled hooks" guidance SHALL enumerate the FIVE hooks (`SessionStart`, `UserPromptSubmit`, `Stop`, `PreCompact`, `PostCompact`).
+
+#### Scenario: Codex section leads with the TUI installer
+
+- **WHEN** a reader opens the Codex section of `docs/agents.md`
+- **THEN** the first install instruction SHALL be the TUI installer
+- **AND** the `codex plugin marketplace add` / `codex plugin add` commands and the manual `config.toml` SHALL appear only under a manual / advanced heading

--- a/openspec/changes/archive/2026-06-18-fix-codex-plugin-cli-verbs/specs/tui-installer/spec.md
+++ b/openspec/changes/archive/2026-06-18-fix-codex-plugin-cli-verbs/specs/tui-installer/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Per-client install / update / uninstall routing
+
+For each present client the installer SHALL offer Install, Update, and Uninstall, routing each to that client's real primitive. For opencode and Hermes, install/update SHALL delegate to the client `install.sh` (re-running it performs an update) and uninstall SHALL delegate to the client `uninstall.sh`. For Claude Code and Codex, the installer SHALL print the client's marketplace CLI commands for each action and, only when the client binary is detected on `PATH`, MAY offer to run them; the installer SHALL NOT create or rely on a repo-side install script for these two clients. The offer to run the marketplace commands SHALL be presented as an interactive `[y/N]` prompt when a controlling terminal is available; in addition, when the opt-in `--yes` flag (alias `-y`) is set the installer SHALL execute those commands directly without prompting, including under headless invocation (e.g. `curl … | sh`), but still ONLY when the client binary is detected on `PATH`. When `--yes` is set but the client binary is absent, the installer SHALL print the commands and SHALL NOT execute anything. When `--yes` is not set and there is no controlling terminal, the installer SHALL only print the commands, as today.
+
+The Codex CLI exposes the plugin verbs `codex plugin add <PLUGIN[@MARKETPLACE]>` (install), `codex plugin remove <PLUGIN[@MARKETPLACE]>` (uninstall), and `codex plugin marketplace upgrade <name>` (refresh the marketplace snapshot). There is NO `codex plugin install` / `codex plugin uninstall` / per-plugin `codex plugin update` subcommand. The installer SHALL therefore use `codex plugin add rembric@rembric` for install, `codex plugin remove rembric@rembric` for uninstall, and `codex plugin marketplace upgrade rembric && codex plugin add rembric@rembric` for update (the snapshot refresh alone does not re-install the cached plugin).
+
+#### Scenario: opencode update re-runs its installer
+
+- **WHEN** the user selects Update for opencode
+- **THEN** the installer SHALL invoke the opencode `install.sh` (which overwrites the installed files)
+
+#### Scenario: Marketplace client prints CLI commands
+
+- **WHEN** the user selects Install for Codex
+- **THEN** the installer SHALL print `codex plugin marketplace add …` and `codex plugin add rembric@rembric`
+- **AND** it SHALL NOT attempt to copy plugin files itself
+
+#### Scenario: Marketplace client run-through gated on binary presence
+
+- **WHEN** the user selects Install for Claude Code and the `claude` binary is on `PATH`
+- **THEN** the installer MAY offer to run the `/plugin marketplace add` + `/plugin install` commands
+- **AND** when the binary is absent, the installer SHALL print the commands for the user to run manually
+
+#### Scenario: --yes executes the marketplace command headlessly when the binary is present
+
+- **WHEN** the installer runs headless as `--agent=claude --action=update --yes` (or `-y`) and the `claude` binary is on `PATH`
+- **THEN** it SHALL execute `claude plugin update rembric@rembric` directly without any prompt
+- **AND** the same SHALL hold for Codex (`codex plugin marketplace upgrade rembric && codex plugin add rembric@rembric`) and for the install/uninstall actions of both clients
+
+#### Scenario: --yes with an absent binary executes nothing
+
+- **WHEN** the installer runs headless as `--agent=codex --action=update --yes` and the `codex` binary is NOT on `PATH`
+- **THEN** it SHALL print the marketplace command(s) and SHALL NOT execute anything
+
+#### Scenario: Without --yes a headless run only prints
+
+- **WHEN** the installer runs headless as `--agent=claude --action=update` (no `--yes`) and the `claude` binary is on `PATH`
+- **THEN** it SHALL only print the marketplace command and SHALL NOT execute it

--- a/openspec/changes/archive/2026-06-18-fix-codex-plugin-cli-verbs/tasks.md
+++ b/openspec/changes/archive/2026-06-18-fix-codex-plugin-cli-verbs/tasks.md
@@ -1,0 +1,23 @@
+## 1. Installer fix
+
+- [x] 1.1 In `apps/plugin/install.sh` `marketplace_cmds()`, change the Codex block: `ins` → `codex plugin add rembric@rembric`; `rem` → `codex plugin remove rembric@rembric`; `upd` → `codex plugin marketplace upgrade rembric && codex plugin add rembric@rembric`. Leave the Claude block and the surrounding print/run logic untouched.
+- [x] 1.2 `sh -n apps/plugin/install.sh` passes (POSIX-clean).
+
+## 2. Docs
+
+- [x] 2.1 `docs/agents.md` — change the Codex manual command block from `codex plugin install rembric` to `codex plugin add rembric@rembric`.
+- [x] 2.2 `apps/plugin/README.md` — change the Codex CLI row in the manual-command table from `codex plugin install rembric` to `codex plugin add rembric@rembric`.
+
+## 3. Test
+
+- [x] 3.1 `install.test.ts` — update the Codex install scenario and the comma-separated multi-agent scenario to assert `codex plugin add rembric@rembric`; keep the update scenario's `not.toContain('codex plugin install')` guard (annotate it as "no such subcommand in the Codex CLI").
+
+## 4. Specs (archived into authoritative on `/opsx:archive`)
+
+- [x] 4.1 `codex-distribution` delta: the "Marketplace install resolves the relocated plugin tree" scenario and the `docs/agents.md` recommendation requirement quote `codex plugin add rembric@rembric`.
+- [x] 4.2 `tui-installer` delta: the "Marketplace client prints CLI commands" scenario asserts the installer prints `codex plugin add rembric@rembric`.
+
+## 5. Verification
+
+- [x] 5.1 `pnpm --filter @rembric/server exec vitest run ../../install.test.ts` green (all installer tests).
+- [x] 5.2 Live check against the real Codex CLI: `codex plugin marketplace add … && codex plugin add rembric@rembric` installs the plugin (cached under `~/.codex/plugins/cache/rembric/rembric/<version>/`).

--- a/openspec/specs/codex-distribution/spec.md
+++ b/openspec/specs/codex-distribution/spec.md
@@ -41,7 +41,7 @@ The repository SHALL host a Codex marketplace manifest at `.codex-plugin/marketp
 #### Scenario: Marketplace install resolves the relocated plugin tree
 
 - **GIVEN** a clean Codex CLI installation with no `rembric` plugin cached
-- **WHEN** the user runs `codex plugin marketplace add https://github.com/susomejias/rembric.git` followed by `codex plugin install rembric`
+- **WHEN** the user runs `codex plugin marketplace add https://github.com/susomejias/rembric.git` followed by `codex plugin add rembric@rembric`
 - **THEN** Codex SHALL clone the repo, extract the subtree at `./apps/plugin` per the `source.path`, and cache it under `~/.codex/plugins/cache/rembric/<version>/`
 - **AND** the cached directory SHALL contain `.codex-plugin/plugin.json`, `.codex-plugin/mcp.json`, `bin/rembric-bridge.mjs`, `bin/rembric-dotenv.mjs`, `hooks/hooks.codex.json`, and the relevant `scripts/` files
 
@@ -197,13 +197,13 @@ Codex install material SHALL document the credential flow given Codex's lack of 
 
 ### Requirement: `docs/agents.md` recommends the plugin install as primary
 
-The Codex section of `docs/agents.md` SHALL recommend the **TUI installer** (`apps/plugin/install.sh` / the root shim) as the primary install path. It SHALL retain the Codex marketplace plugin install (`codex plugin marketplace add … && codex plugin install rembric`) and the manual `config.toml` fallback, but both SHALL appear under an explicitly-labelled "Manual / advanced" subsection, not as the lead instruction. The section SHALL document the credential flow, and the platform-required enablement steps for plugin hooks (which Codex gates behind an under-development feature flag and a per-hook trust review as of `codex-cli 0.130.0`). The "trust each of the N plugin-bundled hooks" guidance SHALL enumerate the FIVE hooks (`SessionStart`, `UserPromptSubmit`, `Stop`, `PreCompact`, `PostCompact`).
+The Codex section of `docs/agents.md` SHALL recommend the **TUI installer** (`apps/plugin/install.sh` / the root shim) as the primary install path. It SHALL retain the Codex marketplace plugin install (`codex plugin marketplace add … && codex plugin add rembric@rembric`) and the manual `config.toml` fallback, but both SHALL appear under an explicitly-labelled "Manual / advanced" subsection, not as the lead instruction. The section SHALL document the credential flow, and the platform-required enablement steps for plugin hooks (which Codex gates behind an under-development feature flag and a per-hook trust review as of `codex-cli 0.130.0`). The "trust each of the N plugin-bundled hooks" guidance SHALL enumerate the FIVE hooks (`SessionStart`, `UserPromptSubmit`, `Stop`, `PreCompact`, `PostCompact`).
 
 #### Scenario: Codex section leads with the TUI installer
 
 - **WHEN** a reader opens the Codex section of `docs/agents.md`
 - **THEN** the first install instruction SHALL be the TUI installer
-- **AND** the `codex plugin marketplace add` / `codex plugin install` commands and the manual `config.toml` SHALL appear only under a manual / advanced heading
+- **AND** the `codex plugin marketplace add` / `codex plugin add` commands and the manual `config.toml` SHALL appear only under a manual / advanced heading
 
 #### Scenario: Platform-required hook enablement enumerates five hooks
 

--- a/openspec/specs/tui-installer/spec.md
+++ b/openspec/specs/tui-installer/spec.md
@@ -154,6 +154,8 @@ For each of the four clients the installer SHALL determine (a) whether the clien
 
 For each present client the installer SHALL offer Install, Update, and Uninstall, routing each to that client's real primitive. For opencode and Hermes, install/update SHALL delegate to the client `install.sh` (re-running it performs an update) and uninstall SHALL delegate to the client `uninstall.sh`. For Claude Code and Codex, the installer SHALL print the client's marketplace CLI commands for each action and, only when the client binary is detected on `PATH`, MAY offer to run them; the installer SHALL NOT create or rely on a repo-side install script for these two clients. The offer to run the marketplace commands SHALL be presented as an interactive `[y/N]` prompt when a controlling terminal is available; in addition, when the opt-in `--yes` flag (alias `-y`) is set the installer SHALL execute those commands directly without prompting, including under headless invocation (e.g. `curl … | sh`), but still ONLY when the client binary is detected on `PATH`. When `--yes` is set but the client binary is absent, the installer SHALL print the commands and SHALL NOT execute anything. When `--yes` is not set and there is no controlling terminal, the installer SHALL only print the commands, as today.
 
+The Codex CLI exposes the plugin verbs `codex plugin add <PLUGIN[@MARKETPLACE]>` (install), `codex plugin remove <PLUGIN[@MARKETPLACE]>` (uninstall), and `codex plugin marketplace upgrade <name>` (refresh the marketplace snapshot). There is NO `codex plugin install` / `codex plugin uninstall` / per-plugin `codex plugin update` subcommand. The installer SHALL therefore use `codex plugin add rembric@rembric` for install, `codex plugin remove rembric@rembric` for uninstall, and `codex plugin marketplace upgrade rembric && codex plugin add rembric@rembric` for update (the snapshot refresh alone does not re-install the cached plugin).
+
 #### Scenario: opencode update re-runs its installer
 
 - **WHEN** the user selects Update for opencode
@@ -162,7 +164,7 @@ For each present client the installer SHALL offer Install, Update, and Uninstall
 #### Scenario: Marketplace client prints CLI commands
 
 - **WHEN** the user selects Install for Codex
-- **THEN** the installer SHALL print `codex plugin marketplace add …` and `codex plugin install rembric`
+- **THEN** the installer SHALL print `codex plugin marketplace add …` and `codex plugin add rembric@rembric`
 - **AND** it SHALL NOT attempt to copy plugin files itself
 
 #### Scenario: Marketplace client run-through gated on binary presence
@@ -175,7 +177,7 @@ For each present client the installer SHALL offer Install, Update, and Uninstall
 
 - **WHEN** the installer runs headless as `--agent=claude --action=update --yes` (or `-y`) and the `claude` binary is on `PATH`
 - **THEN** it SHALL execute `claude plugin update rembric@rembric` directly without any prompt
-- **AND** the same SHALL hold for Codex (`codex plugin marketplace upgrade rembric`) and for the install/uninstall actions of both clients
+- **AND** the same SHALL hold for Codex (`codex plugin marketplace upgrade rembric && codex plugin add rembric@rembric`) and for the install/uninstall actions of both clients
 
 #### Scenario: --yes with an absent binary executes nothing
 


### PR DESCRIPTION
## Why

Installing the Codex plugin from the TUI failed: the installer ran `codex plugin install rembric`, but the Codex CLI (`codex-cli 0.141.0`) has **no `install` subcommand** under `codex plugin` — it aborts with `error: unrecognized subcommand 'install'` right after the marketplace is added, leaving the plugin half-wired.

The real `codex plugin` verbs are:
- `codex plugin add <PLUGIN[@MARKETPLACE]>` — install
- `codex plugin remove <PLUGIN[@MARKETPLACE]>` — uninstall
- `codex plugin marketplace upgrade <name>` — refresh the marketplace snapshot (does **not** re-install the cached plugin)

There is no per-plugin `update` verb, so updating = refresh-then-re-add.

## What changed

- **`apps/plugin/install.sh`** — Codex block now uses `add rembric@rembric` (install), `remove rembric@rembric` (uninstall), and `marketplace upgrade rembric && add rembric@rembric` (update).
- **Docs** — `docs/agents.md` (manual command, rewritten *Updating the plugin* section, Update table) and `apps/plugin/README.md` (manual-command table).
- **`install.test.ts`** — asserts the corrected verbs; keeps a `not.toContain('codex plugin install')` regression guard.
- **Specs** — `codex-distribution` + `tui-installer` scenarios updated.
- **OpenSpec** — change authored and archived: `openspec/changes/archive/2026-06-18-fix-codex-plugin-cli-verbs/`.

## Verification

- 42/42 installer tests green (`vitest run install.test.ts`).
- `sh -n apps/plugin/install.sh` clean.
- Live: `codex plugin marketplace add … && codex plugin add rembric@rembric` installs the plugin (cached under `~/.codex/plugins/cache/rembric/rembric/<version>/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)