### PR TITLE
chore(deps): bump @eslint/js to 10.0.1 + fix no-useless-assignment

### DIFF
--- a/apps/server/src/consolidation/runner.ts
+++ b/apps/server/src/consolidation/runner.ts
@@ -144,7 +144,7 @@ export class ConsolidationRunner {
       const a = this.opts.repos.memory.findScopeTupleById(row.sourceId);
       const b = this.opts.repos.memory.findScopeTupleById(row.targetId);
 
-      let reason: string | null = null;
+      let reason: string | null;
       if (!a || !b) {
         reason = 'source or target memory missing';
       } else if (

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^21.0.2",
-    "@eslint/js": "^9.13.0",
+    "@eslint/js": "^10.0.1",
     "eslint": "^9.13.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^21.0.2
         version: 21.0.2
       '@eslint/js':
-        specifier: ^9.13.0
-        version: 9.39.4
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@9.39.4(jiti@2.6.1))
       eslint:
         specifier: ^9.13.0
         version: 9.39.4(jiti@2.6.1)
@@ -811,6 +811,15 @@ packages:
   '@eslint/eslintrc@3.3.5':
     resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
 
   '@eslint/js@9.39.4':
     resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
@@ -4024,6 +4033,10 @@ snapshots:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@eslint/js@10.0.1(eslint@9.39.4(jiti@2.6.1))':
+    optionalDependencies:
+      eslint: 9.39.4(jiti@2.6.1)
 
   '@eslint/js@9.39.4': {}
 


### PR DESCRIPTION
Reemplaza a #180. Combina el bump de dependabot con el fix de lint que la v10 requiere, para que `main` nunca quede en rojo.

## Qué incluye
- **`chore(deps)`**: bump `@eslint/js` 9.39.4 → 10.0.1 (cherry-pick del commit de dependabot de #180).
- **`fix(server)`**: elimina la inicialización `= null` inútil en `apps/server/src/consolidation/runner.ts:147`, que la nueva regla `no-useless-assignment` de eslint v10 marcaba como error. Todas las ramas reescriben `reason` antes de usarlo, así que el inicializador era redundante.

## Por qué una rama nueva y no commitear en #180
Empujar a la rama de dependabot es frágil: dependabot hace force-push/rebase de sus ramas y puede sobrescribir el commit del fix. Esta rama es nuestra y no la pisa nadie.

## Validación local (sobre `main` actual)
- `pnpm run lint` ✅ (eslint v10, exit 0)
- `pnpm run typecheck` ✅
- `pnpm test` ✅ server 830 passed / 1 skipped · Hermes 35 passed

Al mergear esto, cerrar #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)