### PR TITLE
fix(ci): prefetch + cache embedding model so the real-embedder test resolves offline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      REMBRIC_MODEL_CACHE: ${{ github.workspace }}/.model-cache
     steps:
       - uses: actions/checkout@v7
 
@@ -46,6 +48,23 @@ jobs:
       # defenses + blockExoticSubdeps cover the same threat model.)
       - name: Install
         run: pnpm install --frozen-lockfile
+
+      # The embedding model is fetched from the HF CDN at load time on
+      # bare-metal runners (the /app/models bake exists only in the Docker
+      # image). Prefetch it once into a cached local-model dir — keyed on the
+      # pinned revision — so the real-embedder suite resolves it OFFLINE and a
+      # transient CDN blip can no longer false-red the build.
+      - name: Cache embedding model
+        id: model-cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/.model-cache
+          key: embedder-${{ hashFiles('apps/server/scripts/fetch-model.mjs', 'apps/server/src/embeddings/embedder.ts') }}
+
+      - name: Prefetch embedding model (retried, offline-resolvable)
+        if: steps.model-cache.outputs.cache-hit != 'true'
+        working-directory: apps/server
+        run: node scripts/fetch-model.mjs "$REMBRIC_MODEL_CACHE"
 
       - name: Lint
         run: pnpm run lint

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ build/
 coverage/
 *.tsbuildinfo
 
+# CI prefetch of the embedding model (local-model layout; ephemeral on runners)
+.model-cache/
+
 # Python (Hermes plugin tests run via `python -m unittest`)
 __pycache__/
 *.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ Guidance for Claude Code working in this repo. Specs in `openspec/specs/` are th
 
 Conventional Commits required (commitlint). Pre-commit = lint-staged + `tsc --noEmit --incremental`. Pre-push = `pnpm test`. Never bypass git hooks with `--no-verify`.
 
+PR titles and descriptions are always written in English (regardless of the language used in chat).
+
 Operator surface = dashboard (`/dashboard/{tokens,projects,sessions,judgments,memories,consolidation,maintenance}`). No operator CLI; Docker image runs the server only.
 
 ## Architecture

--- a/apps/server/src/embeddings/embedder.ts
+++ b/apps/server/src/embeddings/embedder.ts
@@ -49,9 +49,12 @@ export async function loadEmbedder(): Promise<Embedder> {
   // Present → resolve locally, refuse network. Absent (dev machines) →
   // download at the pinned revision into the default cache; the first
   // bare-metal boot blocks on that download, once.
-  const baked = existsSync(IMAGE_MODEL_CACHE);
+  // REMBRIC_MODEL_CACHE overrides the dir (CI prefetches the same layout
+  // and points here so the suite resolves offline, never the HF CDN).
+  const localModelDir = process.env.REMBRIC_MODEL_CACHE ?? IMAGE_MODEL_CACHE;
+  const baked = existsSync(localModelDir);
   if (baked) {
-    env.localModelPath = IMAGE_MODEL_CACHE;
+    env.localModelPath = localModelDir;
     env.allowRemoteModels = false;
   }
   const pipe = (await pipeline('feature-extraction', EMBEDDING_MODEL_ID, {


### PR DESCRIPTION
## Problem
The CI `test` job runs on bare-metal (`actions/setup-node`), where the baked `/app/models` dir (Docker image only) does not exist. So `loadEmbedder()` (`apps/server/src/embeddings/embedder.ts`) **downloaded the model from the HuggingFace CDN on every run**, with transformers.js's 10s connect timeout and **no retry**. A transient network blip surfaced as a **false-red** in `hybrid-search.test.ts > hybrid search cross-lingual recall (real embedder)` — e.g. it blocked PR #177 (`ConnectTimeoutError` / `UND_ERR_CONNECT_TIMEOUT`), without being a code regression.

## Fix (root cause, no product-runtime behavior change)
- **`.github/workflows/ci.yml`** (`test` job): `actions/cache@v5` for the model (key = pinned revision via `hashFiles` of `fetch-model.mjs` + `embedder.ts`) + a **prefetch** step running `scripts/fetch-model.mjs` (which already has retry/backoff and offline validation), gated on cache-miss. Job-level `REMBRIC_MODEL_CACHE` env.
- **`apps/server/src/embeddings/embedder.ts`**: `loadEmbedder` honors `process.env.REMBRIC_MODEL_CACHE ?? '/app/models'` to resolve the model **offline** from the prefetched dir. **Production behavior is unchanged when the env is unset** (`/app/models` still wins).
- **`.gitignore`**: ignores `.model-cache/`.

From the 2nd run onward the model comes from cache and CI never touches the network for it.

## Validation
- Embedder test **offline** locally: 11/11 in 968ms (previously it downloaded the model every time).
- **`act pull_request -j test`** (full job in a container): `🏁 Job succeeded`, exit 0, **zero `ConnectTimeout`**. Lint ✅ · Typecheck ✅ · **Test ✅ (63 passed / 1 skipped; the real-embedder test ran offline)** · Installer e2e ✅ · Build ✅. The cache-miss correctly triggered the prefetch (`if: cache-hit != 'true'`).

No runtime behavior change → no OpenSpec needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)