### PR TITLE
docs: update maintainer contact email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -20,7 +20,7 @@ the project) and to all participants.
 ## Enforcement contact
 
 Reports of conduct concerns may be sent to the maintainer at
-**jesusmejias.jm@gmail.com** with the subject line
+**rembric@susomejias.dev** with the subject line
 `[rembric-coc] <short description>`.
 
 - Reports are confidential.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,7 +29,7 @@ click **Report a vulnerability**. This opens a private channel between you and
 the maintainer; do not file a public issue.
 
 **Email fallback:** if you cannot use Security Advisories for any reason
-(corporate firewall, anonymous report, …), email **jesusmejias.jm@gmail.com**
+(corporate firewall, anonymous report, …), email **rembric@susomejias.dev**
 with subject line `[rembric-security] <short description>`.
 
 When you report, please include:

--- a/openspec/changes/archive/2026-05-18-prepare-public-release/design.md
+++ b/openspec/changes/archive/2026-05-18-prepare-public-release/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-The repo has been a single-owner private project on GitHub since 2026-05-13. Current state is `main @ 959c38a`, 188 commits, 28 tags (`v0.1.0` … `v0.14.2`), 24 GitHub Releases, 32 PRs (1 open: release-please pending 0.15.0; 29 merged; 2 closed). The committer set is `jesusmejias.jm@gmail.com` (personal Gmail) + `github-actions[bot]` — zero corporate-identity leak. LICENSE is MIT with copyright neutralized to "Rembric contributors". `.gitignore` excludes `.env`, `*.local.*`, `data/`, `data-dev/`, `AGENTS.md`, `.claude/`.
+The repo has been a single-owner private project on GitHub since 2026-05-13. Current state is `main @ 959c38a`, 188 commits, 28 tags (`v0.1.0` … `v0.14.2`), 24 GitHub Releases, 32 PRs (1 open: release-please pending 0.15.0; 29 merged; 2 closed). The committer set is the maintainer's previous personal Gmail + `github-actions[bot]` — zero corporate-identity leak. LICENSE is MIT with copyright neutralized to "Rembric contributors". `.gitignore` excludes `.env`, `*.local.*`, `data/`, `data-dev/`, `AGENTS.md`, `.claude/`.
 
 The OWNER has explicitly chosen Ruta B (orphan-swap in the same repo) over Ruta A (rename current to `rembric-private`, create new public from scratch). The motivation: the URL `github.com/susomejias/rembric` carries SEO / backlink value and the project's documentation already hard-codes that URL across README, `docs/`, and `openspec/`. A two-repo split would either redirect (transient) or force a documentation-wide URL update; Ruta B preserves the URL.
 


### PR DESCRIPTION
## Summary
- Update security and code of conduct contact emails to rembric@susomejias.dev
- Remove the literal old Gmail address from the archived public-release design note

## Validation
- rg check for the old Gmail address and @gmail.com returns no matches
- git diff --check
- pre-commit: prettier --write, apps/server typecheck
- pre-push: pnpm -r run test and pnpm run test:hermes-plugin