### PR TITLE
fix: dashboard, mcp, and consolidation correctness quick wins

### DIFF
--- a/apps/server/src/consolidation/runner.ts
+++ b/apps/server/src/consolidation/runner.ts
@@ -107,17 +107,13 @@ export class ConsolidationRunner {
     });
 
     // 1. Decay.
-    const decayIds = findDecayCandidates(
-      this.opts.repos,
-      scope,
-      this.opts.decay ?? DEFAULT_DECAY,
-      now,
-    );
+    const decay = this.opts.decay ?? DEFAULT_DECAY;
+    const decayIds = findDecayCandidates(this.opts.repos, scope, decay, now);
     if (decayIds.length > 0) {
       applyDecay(this.opts.repos, this.opts.tx, {
         runId,
         ids: decayIds,
-        reasoning: `last_seen_at older than ${(this.opts.decay ?? DEFAULT_DECAY).thresholdMs}ms with low confidence`,
+        reasoning: `last_seen_at older than ${formatDurationMs(decay.thresholdMs)} with confidence ≤ ${decay.confidenceFloor}`,
       });
       ops.archives = decayIds.length;
     }
@@ -179,4 +175,11 @@ export class ConsolidationRunner {
 
 function scopeString(scope: ScopeKey): string {
   return scope.scope === 'global' ? 'global' : `project:${scope.projectId ?? ''}`;
+}
+
+function formatDurationMs(ms: number): string {
+  const days = Math.round(ms / 86_400_000);
+  if (days >= 365 && days % 365 === 0) return `${days / 365}y`;
+  if (days >= 30 && days % 30 === 0) return `${days / 30}mo`;
+  return `${days}d`;
 }

--- a/apps/server/src/dashboard/memories.ts
+++ b/apps/server/src/dashboard/memories.ts
@@ -70,7 +70,7 @@ export function createMemoriesRouter(deps: MemoriesDeps): Hono {
     let rows: Memory[];
     if (query) {
       rows = deps.repos.memory
-        .adminSearchFts(query, PAGE_SIZE, offset)
+        .adminSearchFts(query, PAGE_SIZE + 1, offset)
         .filter((m) => clientSideFilter(m, projectBySlug, projectFilter, statusFilter, typeFilter));
     } else if (wantNeedsReview) {
       // needs_review implies active; the SQL path filters + paginates correctly.

--- a/apps/server/src/mcp/memory-tools.test.ts
+++ b/apps/server/src/mcp/memory-tools.test.ts
@@ -122,6 +122,23 @@ describe('memory.save — strict path scoping', () => {
     expect(persisted?.projectId).toBe(projectA.id);
   });
 
+  it("rejects a save into an archived project with code 'project_archived'", async () => {
+    const guarded = buildMemoryHandlers({ memory, projects });
+    projects.archive(projectA.id);
+    const r = await runWithContext(fakeContext(projectA), () =>
+      Promise.resolve(
+        guarded.save({
+          scope: 'project',
+          type: 'user',
+          title: 'should be rejected',
+          content: 'write into an archived project',
+        }),
+      ),
+    );
+    expect(isErrorResponse(r)).toBe(true);
+    expect(parseText<{ code: string }>(r).code).toBe('project_archived');
+  });
+
   it('on unscoped connections still saves globals normally', async () => {
     const r = await runWithContext(fakeContext(null), () =>
       Promise.resolve(

--- a/apps/server/src/mcp/memory-tools.ts
+++ b/apps/server/src/mcp/memory-tools.ts
@@ -470,6 +470,11 @@ async function handleSave(
   };
 
   try {
+    // Archived projects reject new writes (projects spec, "Archiving a
+    // project"). Enforced here rather than in resolveEffectiveProject so the
+    // read paths (search/get) keep returning an archived project's memories.
+    if (activeProject) deps.projects?.assertWritable(activeProject.id);
+
     const { memory: m, supersededByTopicKey } = deps.memory.saveWithTopicKey(input, scope);
 
     // If the topic_key upsert path fired, record the auto-judged


### PR DESCRIPTION
## What

Three small, spec-aligned correctness fixes surfaced by a repo-wide opportunity scan. No behavioural contract changes, no migration.

### 1. `fix(dashboard)` — memories FTS search now paginates
`adminSearchFts` was called with `PAGE_SIZE` while its sibling branches request `PAGE_SIZE + 1`, so `hasMore = rows.length > PAGE_SIZE` was structurally impossible on the search branch — **results past page 1 were unreachable**. Now fetches one extra row like the other branches.
`apps/server/src/dashboard/memories.ts`

### 2. `fix(mcp)` — `memory.save` rejects archived projects
The projects spec mandates that archiving a project rejects subsequent `memory.save` (while `search`/`get` keep working). `ProjectsService.assertWritable` existed but was **never wired into the write path** — archived projects still accepted writes. Now `handleSave` asserts writability before persisting; reads are deliberately left untouched (the guard lives in `handleSave`, not in `resolveEffectiveProject`, which is shared with the read paths). Covered by a new test.
`apps/server/src/mcp/memory-tools.ts`, `apps/server/src/mcp/memory-tools.test.ts`

### 3. `fix(consolidation)` — human-readable decay audit string
The journaled archival reasoning interpolated raw milliseconds (`last_seen_at older than 7776000000ms with low confidence`) into the dashboard ops table that exists for auditability. Now reads `last_seen_at older than 3mo with confidence ≤ 1` (config-only, still deterministic — no run-time-varying values).
`apps/server/src/consolidation/runner.ts`

## Verification
`pnpm run typecheck` · `pnpm run lint` · `pnpm test` all green (pre-push ran the full suite).

## Deferred follow-up
A fourth candidate from the scan — running `PRAGMA quick_check` at boot — turned out **not** to be spec-free: it is a new boot-time integrity guard (sibling of the spec'd data-loss guard), so it needs its own OpenSpec change rather than a silent code fix. Tracked separately.

---
_Part of a verified opportunity-scan backlog; companion OpenSpec proposals opened as separate draft PRs._
