### PR TITLE
fix(mcp): require write authorization for project.use autocreate

### DIFF
--- a/apps/server/src/mcp/authorization.test.ts
+++ b/apps/server/src/mcp/authorization.test.ts
@@ -312,3 +312,54 @@ describe('project.list is filtered by token scope', () => {
     expect(slugs).toEqual([projectB.slug]);
   });
 });
+
+describe('project.use({autocreate: true}) requires write authorization', () => {
+  it('a `read:*` token cannot autocreate a new project', async () => {
+    const r = await runWithContext(ctxFor('read:*'), () =>
+      Promise.resolve(projectHandlers.use({ slug: 'brand-new-slug', autocreate: true })),
+    );
+    const { isError, payload } = decode(r);
+    expect(isError).toBe(true);
+    expect(payload.code).toBe('forbidden');
+    expect(projects.findBySlug('brand-new-slug')).toBeUndefined();
+  });
+
+  it('a `read:project:<id>` token cannot autocreate a new project', async () => {
+    const r = await runWithContext(ctxFor(`read:project:${projectA.id}`), () =>
+      Promise.resolve(projectHandlers.use({ slug: 'another-new-slug', autocreate: true })),
+    );
+    const { isError, payload } = decode(r);
+    expect(isError).toBe(true);
+    expect(payload.code).toBe('forbidden');
+    expect(projects.findBySlug('another-new-slug')).toBeUndefined();
+  });
+
+  it('a `project:<id>` token cannot autocreate a new project', async () => {
+    const r = await runWithContext(ctxFor(`project:${projectA.id}`), () =>
+      Promise.resolve(projectHandlers.use({ slug: 'yet-another-slug', autocreate: true })),
+    );
+    const { isError, payload } = decode(r);
+    expect(isError).toBe(true);
+    expect(payload.code).toBe('forbidden');
+    expect(projects.findBySlug('yet-another-slug')).toBeUndefined();
+  });
+
+  it('a `*` token can still autocreate a new project', async () => {
+    const r = await runWithContext(ctxFor('*'), () =>
+      Promise.resolve(projectHandlers.use({ slug: 'admin-created-slug', autocreate: true })),
+    );
+    const { isError, payload } = decode(r);
+    expect(isError).toBeFalsy();
+    expect(payload.created).toBe(true);
+    expect(projects.findBySlug('admin-created-slug')).toBeDefined();
+  });
+
+  it('autocreate against an already-existing slug is unaffected by the write check', async () => {
+    const r = await runWithContext(ctxFor(`read:project:${projectA.id}`), () =>
+      Promise.resolve(projectHandlers.use({ slug: projectA.slug, autocreate: true })),
+    );
+    const { isError, payload } = decode(r);
+    expect(isError).toBeFalsy();
+    expect(payload.created).toBe(false);
+  });
+});

--- a/apps/server/src/mcp/project-tools.ts
+++ b/apps/server/src/mcp/project-tools.ts
@@ -100,12 +100,14 @@ function handleUse(
   let created = false;
   if (!project) {
     if (args.autocreate === true) {
-      // A project minted here can never match a project-pinned token id, so
-      // gate on an anonymous project target BEFORE creating the row.
-      if (!isAuthorized(ctx.scope, 'read', { scope: 'project', projectId: null })) {
+      // Minting a project row is a write, even though project.use is
+      // otherwise a read action. A project minted here can never match a
+      // project-pinned token id, so gate on an anonymous project target
+      // BEFORE creating the row.
+      if (!isAuthorized(ctx.scope, 'write', { scope: 'project', projectId: null })) {
         return mcpError(
           'forbidden',
-          `token scope '${ctx.scope}' does not authorize read on project '${args.slug}'`,
+          `token scope '${ctx.scope}' does not authorize creating project '${args.slug}'`,
         );
       }
       try {

--- a/openspec/specs/mcp-api/spec.md
+++ b/openspec/specs/mcp-api/spec.md
@@ -1101,11 +1101,25 @@ Every registered MCP tool except `memory.about` SHALL be classified as `read` or
 
 Write classification: `memory.save`, `memory.save_prompt`, `memory.capture_passive`, `memory.confirm`, `memory.judge`, `memory.session_start`, `memory.session_summary`, `memory.session_end`. Read classification: `memory.search`, `memory.get`, `memory.context`, `memory.timeline`, `memory.stats`, `memory.doctor`, `memory.search_prompts`, `memory.suggest_topic_key`, `memory.session_get`, `memory.compare`, `project.use` (against the requested project), `project.current`. `project.list` SHALL filter its result to the projects the token is authorized to read: `*` and `read:*` tokens see all projects; `project:<id>` and `read:project:<id>` tokens see only that project.
 
+`project.use({autocreate: true})` on a slug that does not yet exist is a WRITE (it mints a new project row), even though `project.use` is otherwise read-classified: the server SHALL check `isAuthorized(tokenScope, 'write', {scope: 'project', projectId: null})` before creating the row. `autocreate: true` against an ALREADY-existing slug is unaffected (no row is created, so the normal read check against the resolved project applies).
+
 #### Scenario: Read-restricted token attempts a formerly-ungated write
 
 - **GIVEN** a token with scope `read:*` or `read:project:<id>`
 - **WHEN** the token invokes `memory.capture_passive`, `memory.save_prompt`, `memory.session_start`, or `memory.judge`
 - **THEN** the call SHALL be rejected with code `forbidden` and no row SHALL be written
+
+#### Scenario: A read-only token cannot autocreate a project
+
+- **GIVEN** a token with scope `read:*` or `read:project:<id>`
+- **WHEN** the token calls `project.use({slug: 'brand-new-slug', autocreate: true})` for a slug that does not yet exist
+- **THEN** the call SHALL be rejected with code `forbidden` and no project row SHALL be created
+
+#### Scenario: A full-access token can still autocreate a project
+
+- **GIVEN** a token with scope `*`
+- **WHEN** the token calls `project.use({slug: 'brand-new-slug', autocreate: true})` for a slug that does not yet exist
+- **THEN** the project SHALL be created and the call SHALL succeed
 
 #### Scenario: Project-restricted token reads another project's context
 


### PR DESCRIPTION
## Summary

Closes the residual gap flagged when #215 (`enforce-mcp-authorization`) shipped: `project.use` is read-classified for authorization purposes, but `{autocreate: true}` on a non-existent slug mints a new project row — a write. The pre-create gate checked `isAuthorized(scope, 'read', ...)`, so a `read:*` token (meant to be read-only) could still autocreate projects.

- `apps/server/src/mcp/project-tools.ts` — the pre-create check now asserts `write`, not `read`.
- `*` is unaffected (always authorized). `project:<id>`/`read:project:<id>` were already rejected (their id can never match the anonymous pre-create target `projectId: null`) and remain rejected — no behavior change for them.
- Autocreate against an **already-existing** slug is unaffected: no row is created, so the normal read check against the resolved project still applies (a `read:project:A` token can still no-op `project.use({slug: A, autocreate:true})`).
- Updates the `mcp-api` spec's authorization requirement directly (no new OpenSpec proposal — small, surgical fix to an already-shipped requirement) with the write-classification nuance and two new scenarios.

Small enough that this skips the full propose/design/tasks OpenSpec flow per the repo's own guidance (spec-level behavior change, but a one-line tightening of an already-merged requirement, not a new capability).

## Test plan

- [x] New `apps/server/src/mcp/authorization.test.ts` cases: `read:*`, `read:project:<id>`, and `project:<id>` tokens all rejected with `forbidden` on autocreate (no row created); `*` token still succeeds; autocreate against an existing slug is unaffected
- [x] `pnpm run typecheck && pnpm run lint && pnpm test` — 967 passed / 1 skipped (74 files)
- [x] `openspec validate --specs --strict` — 21/21 green