### PR TITLE
fix(mcp): stabilize roots-discovery flake on slow CI

### DIFF
--- a/apps/server/src/mcp/roots-discovery.ts
+++ b/apps/server/src/mcp/roots-discovery.ts
@@ -32,11 +32,15 @@ import type { ProjectsService } from '../services/projects.js';
  * either of those happen.
  */
 
-// 1s is enough for any compliant client whose SSE channel is open by
-// the time the lazy path fires (first tool call from the agent).
-// Lower values cap the worst-case latency hit when a non-compliant
-// client advertises `roots` but never responds.
-const ROOTS_LIST_TIMEOUT_MS = 1000;
+// Budget for the `listRoots` SSE round trip on the first tool call. A
+// compliant client whose channel is open answers in well under this; the
+// budget only bites a client that advertises `roots` but never responds
+// (its first call waits this long before falling back to global). Bumped
+// from 1s: bearer auth now runs async (scrypt on the libuv threadpool) on
+// every message, including the client's `roots/list` RESPONSE, so the round
+// trip carries more latency under load — 1s occasionally lost the race on
+// slow/instrumented runners. 2.5s keeps the worst-case bound reasonable.
+const ROOTS_LIST_TIMEOUT_MS = 2500;
 
 /**
  * One slot per `(tokenId, mcpSessionId)` records whether discovery has

--- a/apps/server/src/test/mcp-integration.test.ts
+++ b/apps/server/src/test/mcp-integration.test.ts
@@ -1173,48 +1173,63 @@ describe('MCP protocol conformance', () => {
   // tool (not just save/search/get/confirm) now shares the async,
   // roots-discovery-aware resolver, so the FIRST call on a fresh transport
   // sees the same project scope a later call would.
-  it('memory.context as the FIRST call on an unscoped connection with a discoverable root returns project scope', async () => {
-    const projects = new ProjectsService(createRepositories(server.dbHandle.db));
-    const project = projects.create({ slug: 'integration-roots-ctx-proj' });
-    createRepositories(server.dbHandle.db).memory.insert({
-      id: '01TESTROOTSCTXMARKER00000A',
-      scope: 'project',
-      projectId: project.id,
-      type: 'project',
-      title: 'roots-discovered context marker',
-      content: 'roots-discovered context marker',
-      tags: [],
-      status: 'active',
-      replaces: [],
-      createdAt: new Date(),
-      lastSeenAt: new Date(),
-    });
+  //
+  // retry: discovery is an async `listRoots()` SSE round trip on a bounded
+  // budget; on a slow, coverage-instrumented CI runner it can occasionally
+  // exceed the budget and fall back to global. Correct behavior on a settled
+  // transport — each retry reconnects (fresh discovery) after startup
+  // contention (e.g. the boot-time embedding drain) has cleared.
+  it(
+    'memory.context as the FIRST call on an unscoped connection with a discoverable root returns project scope',
+    { retry: 3 },
+    async () => {
+      const projects = new ProjectsService(createRepositories(server.dbHandle.db));
+      const project = projects.create({ slug: 'integration-roots-ctx-proj' });
+      createRepositories(server.dbHandle.db).memory.insert({
+        id: '01TESTROOTSCTXMARKER00000A',
+        scope: 'project',
+        projectId: project.id,
+        type: 'project',
+        title: 'roots-discovered context marker',
+        content: 'roots-discovered context marker',
+        tags: [],
+        status: 'active',
+        replaces: [],
+        createdAt: new Date(),
+        lastSeenAt: new Date(),
+      });
 
-    const client = await connect({ rootUri: `file:///tmp/${project.slug}` });
-    const ctx = (await client.callTool({ name: 'memory.context', arguments: {} })) as ToolResult;
-    expect(ctx.isError).toBeFalsy();
-    const payload = readJson(ctx) as { scope: string; recentMemories: { snippet: string }[] };
-    expect(payload.scope).toBe(`project:${project.id}`);
-    expect(
-      payload.recentMemories.some((m) => m.snippet.includes('roots-discovered context marker')),
-    ).toBe(true);
+      const client = await connect({ rootUri: `file:///tmp/${project.slug}` });
+      const ctx = (await client.callTool({ name: 'memory.context', arguments: {} })) as ToolResult;
+      expect(ctx.isError).toBeFalsy();
+      const payload = readJson(ctx) as { scope: string; recentMemories: { snippet: string }[] };
+      expect(payload.scope).toBe(`project:${project.id}`);
+      expect(
+        payload.recentMemories.some((m) => m.snippet.includes('roots-discovered context marker')),
+      ).toBe(true);
 
-    await client.close();
-  });
+      await client.close();
+    },
+  );
 
-  it('memory.capture_passive rejects with project_suggestion_pending when roots surface an unminted slug', async () => {
-    const client = await connect({ rootUri: 'file:///tmp/integration-unminted-slug' });
-    const result = (await client.callTool({
-      name: 'memory.capture_passive',
-      arguments: { text: '## Key Learnings:\n- must not be saved silently to global\n' },
-    })) as ToolResult;
-    expect(result.isError).toBe(true);
-    const payload = readJson(result) as { code?: string; suggestedSlugs?: string[] };
-    expect(payload.code).toBe('project_suggestion_pending');
-    expect(payload.suggestedSlugs).toEqual(['integration-unminted-slug']);
+  // retry: same async roots-discovery round-trip dependency as the test above.
+  it(
+    'memory.capture_passive rejects with project_suggestion_pending when roots surface an unminted slug',
+    { retry: 3 },
+    async () => {
+      const client = await connect({ rootUri: 'file:///tmp/integration-unminted-slug' });
+      const result = (await client.callTool({
+        name: 'memory.capture_passive',
+        arguments: { text: '## Key Learnings:\n- must not be saved silently to global\n' },
+      })) as ToolResult;
+      expect(result.isError).toBe(true);
+      const payload = readJson(result) as { code?: string; suggestedSlugs?: string[] };
+      expect(payload.code).toBe('project_suggestion_pending');
+      expect(payload.suggestedSlugs).toEqual(['integration-unminted-slug']);
 
-    await client.close();
-  });
+      await client.close();
+    },
+  );
 });
 
 // Real-server coverage for the auth-surface hardening (change


### PR DESCRIPTION
Fixes the intermittent `mcp-integration` failure on main (`expected 'global' to be 'project:…'`).

**Cause:** the "FIRST call returns project scope" tests drive an async `listRoots()` SSE round trip on a 1s discovery budget. On the coverage-instrumented 2-core CI runner the round trip occasionally exceeds 1s and falls back to global. `fileParallelism: false` (already on main) removed cross-file starvation, but residual per-run jitter still tipped it over. Aggravated by #224 making `authenticate` async (scrypt on the threadpool now sits in front of every message, including the client's `roots/list` response).

**Fix (two honest layers):**
- Widen `ROOTS_LIST_TIMEOUT_MS` 1s → 2.5s — the message path legitimately carries more latency now that auth is async; only a client that advertises `roots` but never responds pays this bound.
- `retry: 3` on the two discovery tests as a CI-jitter backstop (each retry reconnects with fresh discovery).

No behavior change for compliant clients (they answer in well under 2.5s). Verified: `test:coverage` green 3× locally (the flake only reproduces on slower CI hardware).