### PR TITLE
feat(plugin): proactive save nudges across all four clients

### DIFF
--- a/apps/plugin/.hermes-plugin/__init__.py
+++ b/apps/plugin/.hermes-plugin/__init__.py
@@ -82,6 +82,9 @@ except ImportError:  # pragma: no cover - exercised only outside Hermes
         def sync_turn(self, user: str, assistant: str, **kwargs: Any) -> None:
             pass
 
+        def on_turn_start(self, turn_number: int, message: Any, **kwargs: Any) -> None:
+            pass
+
         def on_session_end(self, messages: list, **kwargs: Any) -> None:
             pass
 
@@ -106,7 +109,17 @@ _API_TIMEOUT_SEC = 3
 _HEALTHZ_TIMEOUT_SEC = 2
 _RECALL_LIMIT = 5
 _SYNC_TURN_HEARTBEAT_EVERY = 5
+_SAVE_HINT_EVERY = 3
+_COMPACTION_TOKEN_FLOOR = 20_000
 _NON_PRIMARY_AGENT_CONTEXTS = {"subagent", "cron", "flush"}
+_SAVE_HINT = (
+    "<memory-hint>If this turn produced a decision, fix, or discovery, "
+    "call memory.save now (title ≤100 + content).</memory-hint>"
+)
+_SAVE_HINT_URGENT = (
+    "<memory-hint>Context is about to compact — save anything important "
+    "with memory.save NOW before it is lost.</memory-hint>"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -271,6 +284,9 @@ class RembricMemoryProvider(MemoryProvider):
         # queue_prefetch warms this per-session; prefetch reads it back inline.
         self._prefetch_cache: dict[str, str] = {}
         self._sync_turn_count: int = 0
+        self._turn_number: int = 0
+        self._compaction_imminent: bool = False
+        self._compaction_warned: bool = False
 
     @property
     def name(self) -> str:
@@ -356,11 +372,34 @@ class RembricMemoryProvider(MemoryProvider):
             "Update Rembric itself: memory.about."
         )
 
+    def on_turn_start(self, turn_number: int, message: Any, **kwargs: Any) -> None:
+        del message
+        self._turn_number = turn_number
+        remaining = kwargs.get("remaining_tokens")
+        if (
+            isinstance(remaining, int)
+            and remaining < _COMPACTION_TOKEN_FLOOR
+            and not self._compaction_warned
+        ):
+            self._compaction_imminent = True
+        return None
+
     def prefetch(self, query: str, **kwargs: Any) -> str:
         # Inline on the turn path — read the cache only, never a network call.
         del query
         session_id = kwargs.get("session_id") or self._session_id
-        return self._prefetch_cache.get(session_id or "", "")
+        recalled = self._prefetch_cache.get(session_id or "", "")
+        if self._compaction_imminent:
+            self._compaction_imminent = False
+            self._compaction_warned = True
+            hint = _SAVE_HINT_URGENT
+        elif self._turn_number > 0 and self._turn_number % _SAVE_HINT_EVERY == 0:
+            hint = _SAVE_HINT
+        else:
+            hint = ""
+        if not hint:
+            return recalled
+        return f"{recalled}\n{hint}" if recalled else hint
 
     def queue_prefetch(self, query: str, **kwargs: Any) -> None:
         session_id = kwargs.get("session_id") or self._session_id
@@ -444,6 +483,12 @@ class RembricMemoryProvider(MemoryProvider):
             body,
         )
         self._prefetch_cache.pop(self._session_id, None)
+        self._reset_turn_state()
+
+    def _reset_turn_state(self) -> None:
+        self._turn_number = 0
+        self._compaction_imminent = False
+        self._compaction_warned = False
 
     def on_session_switch(
         self,
@@ -484,6 +529,7 @@ class RembricMemoryProvider(MemoryProvider):
             )
         if old_id and old_id != new_session_id:
             self._prefetch_cache.pop(old_id, None)
+            self._reset_turn_state()
         self._session_id = new_session_id
         if self._slug and self._base and new_session_id:
             _api_post(

--- a/apps/plugin/.hermes-plugin/plugin.yaml
+++ b/apps/plugin/.hermes-plugin/plugin.yaml
@@ -7,6 +7,7 @@ hooks:
   - on_session_end
   - on_pre_compress
   - on_session_switch
+  - on_turn_start
   - prefetch
   - queue_prefetch
   - sync_turn

--- a/apps/plugin/.hermes-plugin/tests/test_proactive_save.py
+++ b/apps/plugin/.hermes-plugin/tests/test_proactive_save.py
@@ -1,0 +1,124 @@
+"""prefetch save-hint cadence + on_turn_start pre-compaction reminder."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from _loader import fresh_plugin
+
+
+class _FakeJsonResponse:
+    def __init__(self, body: dict, status: int = 200) -> None:
+        self.status = status
+        self._body = json.dumps(body).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_a):
+        return False
+
+    def read(self):
+        return self._body
+
+
+class ProactiveSaveTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = Path(self._tmp.name)
+        (self.tmp / "home").mkdir()
+        (self.tmp / "cwd").mkdir()
+        (self.tmp / "cwd" / ".rembric").write_text("PROJECT_SLUG=myproj\n")
+        self.mod = fresh_plugin(
+            env={
+                "REMBRIC_SERVER_URL": "http://server.example.com:8787",
+                "REMBRIC_API_TOKEN": "tok-XXXX",
+            },
+            home=str(self.tmp / "home"),
+        )
+
+    def _provider(self):
+        return self.mod.RembricMemoryProvider()
+
+    @patch("rembric_hermes_plugin.urlopen")
+    def test_prefetch_appends_save_hint_on_cadence_even_with_empty_cache(
+        self, mock_urlopen: MagicMock
+    ) -> None:
+        mock_urlopen.return_value = _FakeJsonResponse({"ok": True})
+        provider = self._provider()
+        provider.initialize("01XYZ", cwd=str(self.tmp / "cwd"))
+
+        provider.on_turn_start(3, None)
+        self.assertEqual(provider.prefetch("q", session_id="01XYZ"), self.mod._SAVE_HINT)
+
+    @patch("rembric_hermes_plugin.urlopen")
+    def test_prefetch_emits_nothing_off_cadence(self, mock_urlopen: MagicMock) -> None:
+        mock_urlopen.return_value = _FakeJsonResponse({"ok": True})
+        provider = self._provider()
+        provider.initialize("01XYZ", cwd=str(self.tmp / "cwd"))
+
+        provider.on_turn_start(1, None)
+        self.assertEqual(provider.prefetch("q", session_id="01XYZ"), "")
+
+    @patch("rembric_hermes_plugin.urlopen")
+    def test_prefetch_appends_hint_after_the_recalled_context(
+        self, mock_urlopen: MagicMock
+    ) -> None:
+        mock_urlopen.return_value = _FakeJsonResponse(
+            {"ok": True, "memories": [], "formatted": "<memory-context>\n- x: y\n</memory-context>"}
+        )
+        provider = self._provider()
+        provider.initialize("01XYZ", cwd=str(self.tmp / "cwd"))
+        provider.queue_prefetch("warm", session_id="01XYZ")
+
+        provider.on_turn_start(3, None)
+        out = provider.prefetch("q", session_id="01XYZ")
+        self.assertIn("<memory-context>", out)
+        self.assertTrue(out.endswith(self.mod._SAVE_HINT))
+
+    @patch("rembric_hermes_plugin.urlopen")
+    def test_on_turn_start_arms_urgent_only_below_the_floor(
+        self, mock_urlopen: MagicMock
+    ) -> None:
+        mock_urlopen.return_value = _FakeJsonResponse({"ok": True})
+        provider = self._provider()
+        provider.initialize("01XYZ", cwd=str(self.tmp / "cwd"))
+
+        provider.on_turn_start(1, None, remaining_tokens=self.mod._COMPACTION_TOKEN_FLOOR + 1)
+        self.assertFalse(provider._compaction_imminent)
+
+        provider.on_turn_start(2, None, remaining_tokens=self.mod._COMPACTION_TOKEN_FLOOR - 1)
+        self.assertTrue(provider._compaction_imminent)
+
+    @patch("rembric_hermes_plugin.urlopen")
+    def test_pre_compaction_reminder_fires_once(self, mock_urlopen: MagicMock) -> None:
+        mock_urlopen.return_value = _FakeJsonResponse({"ok": True})
+        provider = self._provider()
+        provider.initialize("01XYZ", cwd=str(self.tmp / "cwd"))
+
+        provider.on_turn_start(2, None, remaining_tokens=self.mod._COMPACTION_TOKEN_FLOOR - 1)
+        self.assertEqual(provider.prefetch("q", session_id="01XYZ"), self.mod._SAVE_HINT_URGENT)
+
+        provider.on_turn_start(4, None, remaining_tokens=self.mod._COMPACTION_TOKEN_FLOOR - 1)
+        self.assertNotIn(self.mod._SAVE_HINT_URGENT, provider.prefetch("q", session_id="01XYZ"))
+
+    @patch("rembric_hermes_plugin.urlopen")
+    def test_session_switch_resets_turn_state(self, mock_urlopen: MagicMock) -> None:
+        mock_urlopen.return_value = _FakeJsonResponse({"ok": True})
+        provider = self._provider()
+        provider.initialize("01XYZ", cwd=str(self.tmp / "cwd"))
+
+        provider.on_turn_start(2, None, remaining_tokens=self.mod._COMPACTION_TOKEN_FLOOR - 1)
+        provider.on_session_switch("01NEW")
+        self.assertEqual(provider._turn_number, 0)
+        self.assertFalse(provider._compaction_imminent)
+        self.assertFalse(provider._compaction_warned)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/plugin/.opencode-plugin/plugin.test.ts
+++ b/apps/plugin/.opencode-plugin/plugin.test.ts
@@ -174,12 +174,12 @@ describe('RembricPlugin handlers', () => {
       'What did we do with the JWT?',
       '¿qué hicimos con el login?',
     ];
-    for (const text of cases) {
+    for (const [i, text] of cases.entries()) {
       const output = {
         parts: [{ type: 'text', text }],
         message: {},
       };
-      await handlers['chat.message']!({ sessionID: 's-recall' } as never, output as never);
+      await handlers['chat.message']!({ sessionID: `s-recall-${i}` } as never, output as never);
       const lastPart = output.parts[output.parts.length - 1];
       expect(lastPart.text).toContain('rembric: User intent: recall');
       expect(lastPart.text).toContain('memory.search');
@@ -202,6 +202,47 @@ describe('RembricPlugin handlers', () => {
       // Only the original part remains; nudge was not appended.
       expect(output.parts).toHaveLength(1);
       expect(output.parts[0].text).toBe(text);
+    }
+  });
+
+  it('chat.message appends the save nudge every 5th user turn, not before', async () => {
+    const handlers = await RembricPlugin({ directory: dir } as never);
+    const pushed: number[] = [];
+    for (let turn = 1; turn <= 10; turn++) {
+      const output = { parts: [{ type: 'text', text: `edit number ${turn}` }], message: {} };
+      await handlers['chat.message']!({ sessionID: 's-save' } as never, output as never);
+      if (output.parts.some((p) => p.text?.includes('memory.save'))) pushed.push(turn);
+    }
+    expect(pushed).toEqual([5, 10]);
+  });
+
+  it('chat.message never nudges a sub-agent session', async () => {
+    const handlers = await RembricPlugin({ directory: dir } as never);
+    await handlers.event!({
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'sub-save', parentID: 'parent', title: 'sub work' } },
+      },
+    } as never);
+    for (let turn = 1; turn <= 6; turn++) {
+      const output = { parts: [{ type: 'text', text: `edit ${turn}` }], message: {} };
+      await handlers['chat.message']!({ sessionID: 'sub-save' } as never, output as never);
+      expect(output.parts).toHaveLength(1);
+    }
+  });
+
+  it('recall and save nudges can both fire on the same turn', async () => {
+    const handlers = await RembricPlugin({ directory: dir } as never);
+    for (let turn = 1; turn <= 5; turn++) {
+      const output = {
+        parts: [{ type: 'text', text: 'recall the auth fix' }],
+        message: {},
+      };
+      await handlers['chat.message']!({ sessionID: 's-both' } as never, output as never);
+      if (turn === 5) {
+        expect(output.parts.some((p) => p.text?.includes('memory.search'))).toBe(true);
+        expect(output.parts.some((p) => p.text?.includes('memory.save'))).toBe(true);
+      }
     }
   });
 

--- a/apps/plugin/.opencode-plugin/plugin.ts
+++ b/apps/plugin/.opencode-plugin/plugin.ts
@@ -48,6 +48,9 @@ const MAX_TITLE_CHARS = 100;
 const RECALL_REGEX = /remember|recall|acuérdate|qué hicimos|what did we do/i;
 const RECALL_NUDGE =
   'rembric: User intent: recall. Call memory.search with the user keywords before responding.';
+const SAVE_NUDGE_EVERY = 5;
+const SAVE_NUDGE =
+  'rembric: if recent work produced a decision, fix, or discovery, call memory.save now (title ≤100 + content).';
 
 type EventInput = {
   event: {
@@ -127,6 +130,7 @@ export const RembricPlugin: Plugin = async (ctx) => {
   const subAgentSessions = new Set<string>();
   const sessionMessages = new Map<string, TranscriptEntry[]>();
   const pendingFlush = new Map<string, ReturnType<typeof setTimeout>>();
+  const userTurnCounts = new Map<string, number>();
 
   const baseUrl = serverUrl ? serverUrl.replace(/\/$/, '') : '';
 
@@ -296,6 +300,7 @@ export const RembricPlugin: Plugin = async (ctx) => {
         knownSessions.delete(sessionId);
         subAgentSessions.delete(sessionId);
         sessionMessages.delete(sessionId);
+        userTurnCounts.delete(sessionId);
         const pending = pendingFlush.get(sessionId);
         if (pending) {
           clearTimeout(pending);
@@ -369,6 +374,12 @@ export const RembricPlugin: Plugin = async (ctx) => {
 
       if (RECALL_REGEX.test(content)) {
         output.parts.push({ type: 'text', text: RECALL_NUDGE });
+      }
+
+      const turn = (userTurnCounts.get(input.sessionID) ?? 0) + 1;
+      userTurnCounts.set(input.sessionID, turn);
+      if (turn % SAVE_NUDGE_EVERY === 0) {
+        output.parts.push({ type: 'text', text: SAVE_NUDGE });
       }
     },
 

--- a/apps/plugin/hooks/hooks.codex.json
+++ b/apps/plugin/hooks/hooks.codex.json
@@ -31,6 +31,16 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/post-tool.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/apps/plugin/hooks/hooks.json
+++ b/apps/plugin/hooks/hooks.json
@@ -31,6 +31,17 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/post-tool.sh"
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "hooks": [

--- a/apps/plugin/scripts/_api.sh
+++ b/apps/plugin/scripts/_api.sh
@@ -100,6 +100,19 @@ rembric_cwd_from_stdin_json() {
   printf '%s' "$input" | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1
 }
 
+# Extract the tool name from a PostToolUse hook stdin blob. Prefers Claude
+# Code's `tool_name`; falls back to Codex's `toolName`.
+rembric_tool_name_from_stdin_json() {
+  local input="${1:-}"
+  [ -z "$input" ] && return 0
+  local name
+  name="$(printf '%s' "$input" | sed -n 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+  if [ -z "$name" ]; then
+    name="$(printf '%s' "$input" | sed -n 's/.*"toolName"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+  fi
+  printf '%s' "$name"
+}
+
 # Extract `prompt` from UserPromptSubmit hook stdin JSON (jq, sed fallback).
 rembric_prompt_from_stdin_json() {
   local input="${1:-}"

--- a/apps/plugin/scripts/post-tool.sh
+++ b/apps/plugin/scripts/post-tool.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# PostToolUse hook — Claude Code + Codex CLI. After a write-shaped tool, remind
+# the model to persist salient work with memory.save, throttled to every Nth
+# such call. On PostToolUse only hookSpecificOutput.additionalContext reaches
+# the model (plain stdout is logged, not injected), so we emit that JSON shape.
+set -u
+trap 'exit 0' ERR
+
+NUDGE_EVERY=8
+NUDGE='rembric: if recent work produced a decision, fix, or discovery, call memory.save now (title ≤100 + content).'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_api.sh
+source "${SCRIPT_DIR}/_api.sh"
+
+INPUT=""
+if [ ! -t 0 ]; then
+  INPUT="$(cat)"
+fi
+
+TOOL="$(rembric_tool_name_from_stdin_json "$INPUT")"
+# Codex ignores the manifest matcher, so self-filter; unknown tool → no nudge.
+case "$TOOL" in
+  Edit | Write | MultiEdit | NotebookEdit) ;;
+  *) exit 0 ;;
+esac
+
+SESSION_ID="$(rembric_session_id_from_stdin_json "$INPUT")"
+[ -z "$SESSION_ID" ] && SESSION_ID="nosession"
+SAFE_ID="$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9_.-' '_')"
+
+DIR="${TMPDIR:-/tmp}/rembric-savenudge"
+mkdir -p "$DIR" 2>/dev/null || true
+FILE="${DIR}/${SAFE_ID}"
+COUNT=0
+[ -f "$FILE" ] && COUNT="$(cat "$FILE" 2>/dev/null || printf '0')"
+case "$COUNT" in
+  '' | *[!0-9]*) COUNT=0 ;;
+esac
+COUNT=$((COUNT + 1))
+printf '%s' "$COUNT" >"$FILE" 2>/dev/null || true
+
+[ $((COUNT % NUDGE_EVERY)) -ne 0 ] && exit 0
+
+printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"%s"}}\n' \
+  "$(rembric_json_escape "$NUDGE")"
+exit 0

--- a/apps/plugin/test/post-tool.test.ts
+++ b/apps/plugin/test/post-tool.test.ts
@@ -71,4 +71,20 @@ describe('post-tool.sh (throttled save nudge, self-filtering)', () => {
     expect(runPostTool(JSON.stringify({ session_id: 's3' })).trim()).toBe('');
     expect(runPostTool('').trim()).toBe('');
   });
+
+  it('never nudges after a memory/MCP tool call (no save→nudge→save loop)', () => {
+    const memoryTools = [
+      'memory.save',
+      'memory.search',
+      'mcp__plugin_rembric_rembric__memory_save',
+      'mcp__plugin_rembric_rembric__memory_search',
+    ];
+    for (const tool of memoryTools) {
+      for (let i = 1; i <= 10; i++) {
+        expect(
+          runPostTool(JSON.stringify({ tool_name: tool, session_id: `loop-${tool}` })).trim(),
+        ).toBe('');
+      }
+    }
+  });
 });

--- a/apps/plugin/test/post-tool.test.ts
+++ b/apps/plugin/test/post-tool.test.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const postToolSh = join(here, '..', 'scripts', 'post-tool.sh');
+
+let counterDir: string;
+
+function runPostTool(stdin: string): string {
+  return execFileSync('bash', [postToolSh], {
+    input: stdin,
+    encoding: 'utf8',
+    env: { ...process.env, TMPDIR: counterDir },
+  });
+}
+
+describe('post-tool.sh (throttled save nudge, self-filtering)', () => {
+  beforeEach(() => {
+    counterDir = mkdtempSync(join(tmpdir(), 'rembric-posttool-'));
+  });
+  afterEach(() => rmSync(counterDir, { recursive: true, force: true }));
+
+  it('stays silent for a read-only tool', () => {
+    const out = runPostTool(JSON.stringify({ tool_name: 'Read', session_id: 's1' }));
+    expect(out.trim()).toBe('');
+  });
+
+  it('stays silent for the first 7 write-shaped calls, then nudges on the 8th', () => {
+    let last = '';
+    for (let i = 1; i <= 8; i++) {
+      last = runPostTool(JSON.stringify({ tool_name: 'Write', session_id: 's-throttle' }));
+      if (i < 8) expect(last.trim()).toBe('');
+    }
+    const parsed = JSON.parse(last);
+    expect(parsed.hookSpecificOutput.hookEventName).toBe('PostToolUse');
+    expect(parsed.hookSpecificOutput.additionalContext).toContain('memory.save');
+  });
+
+  it('counts each write-shaped tool name toward the throttle', () => {
+    let last = '';
+    for (const tool of [
+      'Edit',
+      'Write',
+      'MultiEdit',
+      'NotebookEdit',
+      'Edit',
+      'Write',
+      'Edit',
+      'Edit',
+    ]) {
+      last = runPostTool(JSON.stringify({ tool_name: tool, session_id: 's-mixed' }));
+    }
+    expect(JSON.parse(last).hookSpecificOutput.additionalContext).toContain('memory.save');
+  });
+
+  it('recognizes Codex camelCase toolName', () => {
+    let last = '';
+    for (let i = 1; i <= 8; i++) {
+      last = runPostTool(JSON.stringify({ toolName: 'Edit', sessionId: 's-codex' }));
+    }
+    expect(JSON.parse(last).hookSpecificOutput.additionalContext).toContain('memory.save');
+  });
+
+  it('stays silent for an unknown or absent tool name', () => {
+    expect(runPostTool(JSON.stringify({ tool_name: 'Grep', session_id: 's2' })).trim()).toBe('');
+    expect(runPostTool(JSON.stringify({ session_id: 's3' })).trim()).toBe('');
+    expect(runPostTool('').trim()).toBe('');
+  });
+});

--- a/openspec/changes/proactive-save-nudges/.openspec.yaml
+++ b/openspec/changes/proactive-save-nudges/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/proactive-save-nudges/design.md
+++ b/openspec/changes/proactive-save-nudges/design.md
@@ -1,0 +1,50 @@
+# Design — proactive save nudges
+
+## Context
+
+Sessions end under-saved because the server's one-shot SAVE instruction gets buried and no client reinforces it per turn. Each client already has ONE proven, model-facing injection channel it uses for recall; this change adds a throttled SAVE reminder on that same channel. All mechanics are the provider's real hooks/APIs — no polling, no timers.
+
+## Decision 1 — Injection channel per client
+
+| Client      | Channel                                                     | Why                                                                                                                                                               |
+| ----------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Code | `PostToolUse` hook → `hookSpecificOutput.additionalContext` | Only structured `additionalContext` reaches the model on PostToolUse (verified against `code.claude.com/docs/en/hooks.md`); plain stdout is logged, not injected. |
+| Codex CLI   | `PostToolUse` hook → same `additionalContext` shape         | Codex injects `additionalContext` too. Note: Codex renders it as a visible developer message, so the nudge must stay terse.                                       |
+| opencode    | `chat.message` → `output.parts.push({type:'text'})`         | The exact channel already shipping for the recall nudge — stable, non-experimental.                                                                               |
+| Hermes      | `prefetch()` return + `on_turn_start` `remaining_tokens`    | `prefetch`'s return is injected as `<memory-context>` every turn; `on_turn_start` exposes `remaining_tokens` to detect imminent compaction.                       |
+
+### Rejected channels (confirmed dead ends)
+
+- **Codex `Stop`** — cannot inject context; its only outputs are `decision:"block"` (whose `reason` becomes a forced next user message) or `continue:false`. Using it to force a save loops the turn — high annoyance.
+- **opencode `experimental.chat.system.transform`** — mutations to `output.system` are silently discarded (upstream issue closed "not planned"). Non-operational.
+- **`tui.showToast` / `session.idle`** — user-facing / observation-only; neither reaches the model.
+- **Claude `Stop` hook** — deliberately not wired (the `claude-code-plugin` spec records the forced-continuation risk); PostToolUse is the safer per-turn channel.
+
+## Decision 2 — Throttle, because the failure mode has a mirror image
+
+The bug is _under_-saving; the naive fix (_over_-nudging) is just as bad. Each nudge is gated:
+
+- **Claude/Codex** — fire only after write-shaped tools (`Edit`/`Write`/`MultiEdit`/`NotebookEdit`), and only every **8th** such call per session (a counter file in `${TMPDIR}/rembric-savenudge/<session>`). Read-only tools never nudge.
+- **opencode** — every **5th** non-subagent user turn (in-memory `Map<sessionId, count>`).
+- **Hermes** — a terse hint every **3rd** turn (normal cadence) PLUS a one-shot urgent reminder when `remaining_tokens` first drops below the floor.
+
+Cadence constants live at the top of each file as named constants so they are trivially tunable after real-world observation.
+
+## Decision 3 — One shared `post-tool.sh` for both shell clients
+
+Per the plugin single-copy discipline, Claude and Codex share `apps/plugin/scripts/post-tool.sh`; the platform delta stays at the manifest level (Claude declares a tool-name `matcher`, Codex ignores matchers so the script self-filters on `tool_name`). The script emits nothing but the `additionalContext` JSON, needs no server URL/token, and fails safe: an unknown/absent tool name simply exits 0 (no nudge), so a Codex stdin-shape quirk causes silence, never noise. **The Codex path (its exact `tool_name` values + that `additionalContext` is actually injected) is e2e-gated** — the same operator-gated verification pattern used for opencode, since Codex is not installed in CI.
+
+## Decision 4 — Nudge copy: terse, English, imperative
+
+The copy matches `instructions.ts::BASE` and the existing recall nudge (English, `rembric:`-prefixed so Codex's `looks_like_json` heuristic doesn't flag it):
+
+- Normal: `rembric: if recent work produced a decision, fix, or discovery, call memory.save now (title ≤100 + content).`
+- Urgent (Hermes pre-compaction): `rembric: context is about to compact — save anything important with memory.save NOW before it's lost.`
+
+## Decision 5 — Hermes pre-compaction: heuristic floor, fire once
+
+`on_turn_start` reads `remaining_tokens` (when Hermes supplies it in kwargs). Below `_COMPACTION_TOKEN_FLOOR` (20 000, a conservative heuristic documented as tunable) it arms an urgent flag; the next `prefetch` emits the urgent reminder and marks itself warned so it fires **once** per session, not every turn thereafter. The flag resets on session end/switch. This is the single highest-value nudge — it fires exactly when un-saved context is about to be lost, and almost never otherwise.
+
+## Decision 6 — Pure-plugin, no server change
+
+Every nudge is a static client-local string. A server-side variant (appending a save-hint to the `/memory/recall` `formatted` field, which Hermes pipes through for free) was considered and deferred: it couples a write-side nudge to the recall endpoint and only benefits one client automatically. Keeping v1 pure-plugin keeps the blast radius inside `apps/plugin/` and each client independently tunable.

--- a/openspec/changes/proactive-save-nudges/proposal.md
+++ b/openspec/changes/proactive-save-nudges/proposal.md
@@ -1,0 +1,27 @@
+# Proactive save nudges across all four clients
+
+## Why
+
+Operators report long working sessions (30–40 min) ending with **zero memories saved**. The server ships a static SAVE/RECALL/SUMMARIZE instruction block once at session start (`instructions.ts::BASE`), but it gets buried as the conversation grows, and no client reinforces it afterward. Every client today nudges only **recall** (keyword-triggered) — none nudges **saving**. The write side of the memory contract has no per-turn reinforcement.
+
+An audit of each provider's plugin API found a proven, model-facing injection channel per client that can carry a throttled save reminder using **real provider hooks/APIs** — no polling, no timers:
+
+- **Claude Code / Codex CLI** — the `PostToolUse` hook injects `hookSpecificOutput.additionalContext` into the model's context after a tool runs.
+- **opencode** — the `chat.message` hook pushes a text part the model reads (the same channel already used for the recall nudge).
+- **Hermes** — `prefetch()`'s return value is injected as `<memory-context>` every turn; `on_turn_start`'s `remaining_tokens` signals imminent compaction.
+
+## What Changes
+
+- **Claude Code + Codex**: add a `PostToolUse` hook wired to one shared `post-tool.sh` that, after a write-shaped tool (Edit/Write/MultiEdit/NotebookEdit), emits a throttled `additionalContext` save reminder. Throttled to every Nth write-type call per session (counter file), so it nudges occasionally, not on every edit.
+- **opencode**: add a per-session user-turn counter to the existing `chat.message` handler; every Nth non-subagent user turn, push a save reminder text part (independent of the recall nudge).
+- **Hermes**: `prefetch()` appends a terse save-hint line on a turn cadence; `on_turn_start` sets an "urgent" flag when `remaining_tokens` falls below a threshold, so the next `prefetch` emits a **pre-compaction save reminder** — targeting the exact failure mode (a long session hitting compaction with nothing saved).
+
+Out of scope (dead ends confirmed by the audit): Codex `Stop` (cannot inject context, only forces continuation), opencode `experimental.chat.system.transform` (mutations silently discarded), `tui.showToast`/`session.idle` (user-facing, not model-facing), and a Claude `Stop` hook (deliberately not wired — forced-continuation risk, per the `claude-code-plugin` spec).
+
+## Impact
+
+- Affected specs: `claude-code-plugin`, `codex-distribution`, `opencode-plugin`, `hermes-agent-plugin` (each gains one save-nudge requirement).
+- Affected code: `apps/plugin/scripts/post-tool.sh` (new, shared), `apps/plugin/hooks/hooks.json` + `hooks/hooks.codex.json` (new `PostToolUse` entry), `apps/plugin/.opencode-plugin/plugin.ts`, `apps/plugin/.hermes-plugin/__init__.py` + `plugin.yaml`.
+- No server change. All nudges are static client-local strings; no new endpoint.
+- Single-copy discipline preserved: one `post-tool.sh` for both shell clients (the platform delta stays at the manifest env-prefix/matcher level).
+- Plugin version bumps (touches `apps/plugin/`), so Claude Code re-fetches the hook.

--- a/openspec/changes/proactive-save-nudges/specs/claude-code-plugin/spec.md
+++ b/openspec/changes/proactive-save-nudges/specs/claude-code-plugin/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: The plugin SHALL ship a `PostToolUse` save-nudge hook
+
+The plugin's hook catalog (`apps/plugin/hooks/hooks.json`) SHALL declare a `PostToolUse` entry that invokes a shared `${CLAUDE_PLUGIN_ROOT}/scripts/post-tool.sh`, reminding the model to persist salient work with `memory.save` after write-shaped tool calls, throttled to avoid noise.
+
+- Matcher: `Edit|Write|MultiEdit|NotebookEdit` (write-shaped tools only; read-only tools never trigger it).
+- The script SHALL read `tool_name` and `session_id` from hook stdin.
+- The script SHALL maintain a per-session counter of matched calls and emit the nudge only every 8th matched call.
+- When it emits, it SHALL write a single JSON object to stdout of the shape `{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"<nudge>"}}` — the only channel that injects into the model's context on `PostToolUse` (plain stdout is not injected).
+- The nudge text SHALL be terse, `rembric:`-prefixed, and imperative (call `memory.save` with title ≤100 + content).
+- The script SHALL fail safe: an absent/unknown tool name, unreadable stdin, or any error SHALL exit 0 with no output.
+- The script needs no `REMBRIC_SERVER_URL`/`REMBRIC_API_TOKEN` (the nudge is a static local string; no network call).
+
+#### Scenario: Save nudge fires on the throttle boundary after write-shaped tools
+
+- **GIVEN** the plugin is installed and a Claude Code session has issued 7 prior `Edit`/`Write` tool calls
+- **WHEN** Claude Code fires `PostToolUse` for the 8th write-shaped tool with stdin `{"tool_name":"Write","session_id":"claude-sess-abc"}`
+- **THEN** `post-tool.sh` SHALL write `{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"rembric: …memory.save…"}}` to stdout
+- **AND** the next model turn SHALL see that reminder in its context
+
+#### Scenario: No nudge for read-only tools or below the throttle
+
+- **WHEN** `PostToolUse` fires with `tool_name` not in the write-shape set (e.g. `Read`, `Grep`), or on any of the first 7 matched calls of a session
+- **THEN** `post-tool.sh` SHALL emit no stdout and exit 0

--- a/openspec/changes/proactive-save-nudges/specs/codex-distribution/spec.md
+++ b/openspec/changes/proactive-save-nudges/specs/codex-distribution/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: The Codex hook catalog SHALL ship the shared `PostToolUse` save-nudge hook
+
+`apps/plugin/hooks/hooks.codex.json` SHALL declare a `PostToolUse` entry invoking the SAME `${CLAUDE_PLUGIN_ROOT}/scripts/post-tool.sh` used by Claude Code (single-copy discipline — no Codex-specific variant). Because Codex's dispatcher ignores hook matchers, the script self-filters on `tool_name`; the manifest matcher (if any) is advisory.
+
+- The script emits the same throttled `additionalContext` JSON as for Claude Code (every 8th write-shaped tool call).
+- Codex renders `additionalContext` as a visible developer message, so the nudge text stays terse.
+- Fail-safe behaviour is identical: an unknown/absent `tool_name` exits 0 with no output, so a Codex stdin-shape difference causes silence, never repeated noise.
+
+#### Scenario: Codex reuses the shared script and self-filters
+
+- **GIVEN** the Codex plugin is installed and its `PostToolUse` hook type is trusted in `/hooks`
+- **WHEN** Codex fires `PostToolUse` after a write-shaped tool
+- **THEN** `post-tool.sh` SHALL apply its own `tool_name` filter and per-session throttle (not relying on the manifest matcher)
+- **AND** on the throttle boundary SHALL emit the `additionalContext` save nudge, else nothing
+
+#### Scenario: Single-copy discipline preserved
+
+- **WHEN** the repo is inspected for hook-script duplication
+- **THEN** `apps/plugin/scripts/post-tool.sh` SHALL exist exactly once and be referenced by both `hooks.json` and `hooks.codex.json`; no `post-tool.codex.sh` variant SHALL exist

--- a/openspec/changes/proactive-save-nudges/specs/hermes-agent-plugin/spec.md
+++ b/openspec/changes/proactive-save-nudges/specs/hermes-agent-plugin/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: The Hermes provider SHALL emit per-turn and pre-compaction save reminders
+
+The Hermes `MemoryProvider` (`apps/plugin/.hermes-plugin/__init__.py`) SHALL reinforce saving through `prefetch()` (whose return is injected as `<memory-context>` every turn) and `on_turn_start()` (which observes `remaining_tokens`). This is the only per-turn save reinforcement Hermes has, since it does not consume the server's `initialize.instructions`.
+
+- `on_turn_start(turn_number, message, **kwargs)` SHALL be added AND listed in `plugin.yaml`'s `hooks:` array (the array gates override invocation). It SHALL record the turn number and, when `remaining_tokens` is an int below `_COMPACTION_TOKEN_FLOOR` and no urgent reminder has yet fired this session, arm an urgent flag.
+- `prefetch()` SHALL continue to return the cached recall context and SHALL additionally:
+  - when the urgent flag is armed, emit a pre-compaction save reminder instead of the normal hint, then mark itself warned (fires at most once per session);
+  - otherwise, append a terse save-hint line every 3rd turn.
+- `prefetch()` SHALL remain inline (no network call), and SHALL return a non-empty hint even when the recall cache is empty.
+- The urgent/warned flags and the turn counter SHALL reset on session end and session switch.
+
+#### Scenario: prefetch appends the normal save hint on cadence
+
+- **GIVEN** an initialized Hermes provider with an empty recall cache
+- **WHEN** `prefetch` is called on the 3rd turn with no low-token signal
+- **THEN** it SHALL return a string containing the terse save-hint even though the recall cache is empty
+
+#### Scenario: on_turn_start arms the urgent reminder only below the floor
+
+- **WHEN** `on_turn_start` is called with `remaining_tokens` above `_COMPACTION_TOKEN_FLOOR`
+- **THEN** no urgent flag SHALL be armed
+- **WHEN** it is later called with `remaining_tokens` below the floor
+- **THEN** the urgent flag SHALL be armed
+
+#### Scenario: The pre-compaction reminder fires once
+
+- **GIVEN** the urgent flag is armed
+- **WHEN** `prefetch` is next called
+- **THEN** it SHALL return the urgent pre-compaction save reminder and clear the armed flag
+- **AND** a subsequent `prefetch` on a later low-token turn SHALL NOT repeat the urgent reminder (warned once per session)

--- a/openspec/changes/proactive-save-nudges/specs/opencode-plugin/spec.md
+++ b/openspec/changes/proactive-save-nudges/specs/opencode-plugin/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: The opencode plugin SHALL emit a periodic save nudge on `chat.message`
+
+`apps/plugin/.opencode-plugin/plugin.ts` SHALL push a save-reminder text part into `chat.message`'s `output.parts` on a per-session turn cadence, using the same model-facing channel already used for the recall nudge.
+
+- A per-session user-turn counter (in-memory `Map<sessionId, number>`) SHALL increment on each non-subagent user message the handler already processes.
+- Every 5th such turn, the handler SHALL push `{type:'text', text:'<terse save nudge>'}`.
+- The save nudge SHALL be independent of the recall nudge — both MAY fire on the same turn.
+- Subagent sessions SHALL NOT be nudged (the handler's existing subagent guard covers this).
+- The counter entry SHALL be evicted in the existing `session.deleted` cleanup.
+
+#### Scenario: Save nudge fires every 5th user turn
+
+- **GIVEN** a non-subagent opencode session
+- **WHEN** the user submits their 5th message of the session
+- **THEN** `chat.message` SHALL push the save-reminder text part into `output.parts`
+- **AND** SHALL NOT push it on turns 1–4
+
+#### Scenario: Recall and save nudges coexist
+
+- **WHEN** the 5th user message also matches the recall keyword regex
+- **THEN** both the recall nudge and the save nudge SHALL be pushed as separate parts
+
+#### Scenario: Subagent sessions are never nudged
+
+- **WHEN** the message belongs to a sub-agent session
+- **THEN** neither the counter nor the nudge SHALL run (early return, as today)

--- a/openspec/changes/proactive-save-nudges/tasks.md
+++ b/openspec/changes/proactive-save-nudges/tasks.md
@@ -1,0 +1,29 @@
+## 1. Shared PostToolUse script (Claude + Codex)
+
+- [x] 1.1 Add a `rembric_tool_name_from_stdin_json` helper to `apps/plugin/scripts/_api.sh` extracting `tool_name` (Claude) with a `toolName` fallback (Codex/camelCase), mirroring the existing `session_id`/`sessionId` extractor.
+- [x] 1.2 Add `apps/plugin/scripts/post-tool.sh`: read stdin, self-filter to write-shaped tools (`Edit|Write|MultiEdit|NotebookEdit`), maintain a per-session write counter file under `${TMPDIR}/rembric-savenudge/`, and every 8th write emit `{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"<terse save nudge>"}}` on stdout. Fail safe (unknown/absent tool → exit 0, no nudge). No server URL/token needed.
+- [x] 1.3 Wire a `PostToolUse` entry (matcher `Edit|Write|MultiEdit|NotebookEdit`) invoking `post-tool.sh` into `apps/plugin/hooks/hooks.json`.
+- [x] 1.4 Wire a `PostToolUse` entry invoking `post-tool.sh` into `apps/plugin/hooks/hooks.codex.json` (no meaningful matcher — Codex ignores it; the script self-filters).
+- [x] 1.5 Add a test (co-located with the existing `apps/plugin/test/prompt-search.test.ts` harness) asserting: no nudge for a read-only tool; no nudge for the first 7 write calls; a well-formed `additionalContext` JSON on the 8th; unknown/empty tool → no output.
+
+## 2. opencode periodic save nudge
+
+- [x] 2.1 Add a `SAVE_NUDGE` constant and a per-session `Map<string, number>` turn counter to `apps/plugin/.opencode-plugin/plugin.ts`; in the existing `chat.message` handler (after `appendUserMessage`, skipping subagents as it already does), push the save nudge on every 5th user turn. Independent of the recall nudge (both may fire).
+- [x] 2.2 Evict the counter entry in the existing `session.deleted` cleanup.
+- [x] 2.3 Add unit tests to `plugin.test.ts`: the nudge fires on the 5th user message and not before; it does not fire for a subagent session; recall + save nudges can both fire on the same turn.
+
+## 3. Hermes per-turn + pre-compaction save reminder
+
+- [x] 3.1 Add `on_turn_start(self, turn_number, message, **kwargs)` to `apps/plugin/.hermes-plugin/__init__.py`: store the turn number; when `remaining_tokens` (from kwargs) is an int below `_COMPACTION_TOKEN_FLOOR` and not already warned, arm `_compaction_imminent`.
+- [x] 3.2 Extend `prefetch` to append a terse save-hint to the cached recall string every 3rd turn, and — when `_compaction_imminent` is armed — emit the urgent pre-compaction reminder instead, then mark warned (fires once). Still returns `""`-plus-hint semantics without a network call.
+- [x] 3.3 Reset `_compaction_imminent`/`_compaction_warned` (and the turn counter) in the existing session-end and session-switch cleanup paths.
+- [x] 3.4 Add `on_turn_start` to `apps/plugin/.hermes-plugin/plugin.yaml`'s `hooks:` array (the array gates override invocation).
+- [x] 3.5 Add Python tests: `on_turn_start` arms the flag only below the floor; `prefetch` emits the urgent reminder once then reverts; the normal hint appends on cadence; the recall cache still flows through.
+
+## 4. Validation
+
+- [x] 4.1 `pnpm run typecheck` and `pnpm run lint` clean.
+- [x] 4.2 `pnpm test` clean (TS + Python), including all new tests.
+- [x] 4.3 `openspec validate --strict proactive-save-nudges` clean.
+- [ ] 4.4 Claude Code live check: drive ≥8 file edits in one session, confirm the save nudge appears in the model's context (not just the transcript) on the throttle boundary and nowhere else.
+- [ ] 4.5 **Operator-gated (Codex + opencode not installed in this environment):** verify Codex `PostToolUse` fires, its `tool_name` values match the write-shape filter, and `additionalContext` is injected; verify the opencode 5th-turn nudge against a live session. Same gating pattern as the opencode e2e in `improve-recall-and-plugin-parity`.


### PR DESCRIPTION
## Summary

Implements OpenSpec change `proactive-save-nudges`. Targets `main` (rebased after #228 merged; supersedes #229, which was stacked on the pre-merge #228 branch).

Addresses the report that long sessions (30–40 min) end with **zero memories saved**: the server's one-shot SAVE instruction gets buried and no client reinforced it. Every client already nudges *recall*; none nudged *saving*. This adds a throttled, model-facing save reminder on each client's real per-turn/per-event hook — no polling, no timers.

## What changes (per client, real provider hooks)

- **Claude Code + Codex** — new shared `scripts/post-tool.sh` on the `PostToolUse` hook. After a write-shaped tool (Edit/Write/MultiEdit/NotebookEdit), every 8th such call per session, it emits `hookSpecificOutput.additionalContext` (the only channel that reaches the model on PostToolUse; plain stdout is not injected). One script for both clients (single-copy discipline); Claude filters via the manifest `matcher`, Codex self-filters on `tool_name`. Fails safe — unknown/absent tool ⇒ no output.
- **opencode** — a per-session turn counter in the existing `chat.message` handler pushes a save reminder every 5th non-subagent user turn. Independent of the recall nudge.
- **Hermes** — `prefetch()` appends a terse save-hint on a turn cadence (every 3rd); `on_turn_start` arms a **one-shot pre-compaction reminder** when `remaining_tokens` drops below a floor — the highest-value nudge, firing exactly when un-saved context is about to be lost. Adds `on_turn_start` to `plugin.yaml`'s `hooks:` array.

## No recursion (verified)

Every emitter is a *leaf* — it only prints/returns text and mutates local state; none calls a tool, emits an event, or makes a network call. The one nudge→action→trigger path (Claude/Codex `PostToolUse` → model may call a tool) is cut because our `memory.*`/MCP tools are not write-shaped, so calling `memory.save` never re-nudges. Even a file-edit loop is bounded 1-in-8, and saving doesn't advance the counter. A regression test (`post-tool.test.ts`) locks in "memory/MCP tool ⇒ never nudge".

## Why these mechanisms

Each channel is the one already proven model-facing for that client. Confirmed dead ends, avoided: Codex `Stop` (can't inject context), opencode `experimental.chat.system.transform` (mutations silently discarded), `tui.showToast`/`session.idle` (user-facing), and a Claude `Stop` hook (forced-continuation risk). Over-nudging is as bad as under-saving, so every nudge is throttled; cadences are named constants at the top of each file.

## Validation

- `typecheck`, `lint`, full suite (1051 TS + 53 Python), `openspec validate --strict` — all green.
- New tests: `post-tool.sh` throttle/filter/JSON-shape + no-recursion; opencode 5th-turn nudge + subagent exclusion + recall/save coexistence; Hermes cadence + pre-compaction fire-once + session-switch reset.
- **Operator-gated (not run here):** Claude live check (≥8 edits → nudge on boundary only); Codex `PostToolUse` firing + `tool_name` values + `additionalContext` injection; opencode live 5th-turn nudge (Codex/opencode not installed in this environment).
