### PR TITLE
test(mcp): make the roots-discovery context test retry-safe

### DIFF
--- a/apps/server/src/test/mcp-integration.test.ts
+++ b/apps/server/src/test/mcp-integration.test.ts
@@ -1210,21 +1210,27 @@ describe('MCP protocol conformance', () => {
     'memory.context as the FIRST call on an unscoped connection with a discoverable root returns project scope',
     { retry: 3 },
     async () => {
-      const projects = new ProjectsService(createRepositories(server.dbHandle.db));
-      const project = projects.create({ slug: 'integration-roots-ctx-proj' });
-      createRepositories(server.dbHandle.db).memory.insert({
-        id: '01TESTROOTSCTXMARKER00000A',
-        scope: 'project',
-        projectId: project.id,
-        type: 'project',
-        title: 'roots-discovered context marker',
-        content: 'roots-discovered context marker',
-        tags: [],
-        status: 'active',
-        replaces: [],
-        createdAt: new Date(),
-        lastSeenAt: new Date(),
-      });
+      // Fixtures created once: `retry` re-runs this body, so a re-`create`
+      // would hit UNIQUE(slug)/PK and mask the real (timing) retry.
+      const repos = createRepositories(server.dbHandle.db);
+      const projectsSvc = new ProjectsService(repos);
+      let project = projectsSvc.findBySlug('integration-roots-ctx-proj');
+      if (!project) {
+        project = projectsSvc.create({ slug: 'integration-roots-ctx-proj' });
+        repos.memory.insert({
+          id: '01TESTROOTSCTXMARKER00000A',
+          scope: 'project',
+          projectId: project.id,
+          type: 'project',
+          title: 'roots-discovered context marker',
+          content: 'roots-discovered context marker',
+          tags: [],
+          status: 'active',
+          replaces: [],
+          createdAt: new Date(),
+          lastSeenAt: new Date(),
+        });
+      }
 
       const client = await connect({ rootUri: `file:///tmp/${project.slug}` });
       const ctx = (await client.callTool({ name: 'memory.context', arguments: {} })) as ToolResult;


### PR DESCRIPTION
## Problem

CI on unrelated PRs (e.g. #232, plugin-only) intermittently fails in `mcp-integration.test.ts` with:

```
AssertionError: expected 'global' to be 'project:…'      # attempt 1 (discovery timing)
SqliteError: UNIQUE constraint failed: projects.slug     # retries 1–3
```

The `{ retry: 3 }` added in #226 is **defeated by fixtures created inside the retried body**. The `memory.context as the FIRST call…` test creates a fixed-slug project and a fixed-id memory at the top of the `it`. When the real flake fires (roots-discovery exceeds its budget on a slow/coverage CI runner and falls back to `global`), vitest re-runs the whole body — which re-`create`s the same slug and re-inserts the same memory id, hitting `UNIQUE`/PK on every retry. So the retry can never recover; it just converts the timing flake into a constraint error.

## Fix

Guard the fixture setup on `ProjectsService.findBySlug` so it runs **once**; retries then re-run only the flaky part (the async `listRoots()` SSE round-trip). Test-only change — no src, no release impact.

The sibling `capture_passive` test needs no change (it creates no fixtures, so its retry was already effective).