### PR TITLE
fix(mcp): surface write verdict on session_summary/session_end

### DIFF
--- a/apps/server/src/mcp/server.ts
+++ b/apps/server/src/mcp/server.ts
@@ -312,7 +312,7 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
     'memory.session_end',
     {
       description:
-        'End the active session without writing a summary. Prefer memory.session_summary unless the session is being abandoned. Optional: sessionId (pass it if you know your current one — never invent one — to guarantee correct attachment when multiple sessions could be active).',
+        'End the active session without writing a summary. Prefer memory.session_summary unless the session is being abandoned. Optional: sessionId (pass it if you know your current one — never invent one — to guarantee correct attachment when multiple sessions could be active). Returns: { ok: true, sessionId, endedAt, applied: true } on an active row or { ok: true, sessionId, endedAt, applied: false } if the row was already terminal and the call was a no-op.',
       inputSchema: sessionEndSchema,
       outputSchema: sessionEndOutput,
       annotations: IDEMPOTENT_WRITE_ANNOTATIONS('End session'),

--- a/apps/server/src/mcp/session-tools.test.ts
+++ b/apps/server/src/mcp/session-tools.test.ts
@@ -219,6 +219,85 @@ describe('memory.session_summary on a session the sweep already abandoned', () =
     expect(out.code).toBe('session_not_found');
     expect(agentSessions.getById(s.id)?.summary).toBeNull();
   });
+
+  it('applied is false and discardReason is terminal_final on a terminal row with a prior curated summary', async () => {
+    const s = startSession();
+    // Write the first curated summary
+    await runWithContext(makeContext(), () =>
+      handlers.sessionSummary({
+        sessionId: s.id,
+        summary: '## Goal\nfirst curated',
+      }),
+    );
+    // Mark as abandoned (terminal)
+    agentSessions.markAbandoned(s.id, { adminBypass: true });
+
+    // Second write on terminal row with summaryFinal=true should be discarded
+    const r = await runWithContext(makeContext(), () =>
+      handlers.sessionSummary({
+        sessionId: s.id,
+        summary: '## Goal\nsecond curated',
+      }),
+    );
+    const out = parseText<{
+      ok: boolean;
+      summary: string;
+      applied: boolean;
+      discardReason?: string;
+    }>(r);
+    expect(out.ok).toBe(true);
+    expect(out.summary).toBe('## Goal\nfirst curated');
+    expect(out.applied).toBe(false);
+    expect(out.discardReason).toBe('terminal_final');
+  });
+
+  it('applied is true on a terminal row without a prior curated summary', async () => {
+    const s = startSession();
+    agentSessions.markAbandoned(s.id, { adminBypass: true });
+    // No prior summary write — summaryFinal is false, write should land
+    const r = await runWithContext(makeContext(), () =>
+      handlers.sessionSummary({
+        sessionId: s.id,
+        summary: '## Goal\nlate handoff',
+      }),
+    );
+    const out = parseText<{ ok: boolean; summary: string; applied: boolean }>(r);
+    expect(out.ok).toBe(true);
+    expect(out.summary).toBe('## Goal\nlate handoff');
+    expect(out.applied).toBe(true);
+  });
+
+  it('applied is true and discardReason is absent on an active row', async () => {
+    const s = startSession();
+    const r = await runWithContext(makeContext(), () =>
+      handlers.sessionSummary({
+        sessionId: s.id,
+        summary: '## Goal\nactive write',
+      }),
+    );
+    const out = parseText<{ ok: boolean; applied: boolean; discardReason?: string }>(r);
+    expect(out.ok).toBe(true);
+    expect(out.applied).toBe(true);
+    expect(out.discardReason).toBeUndefined();
+  });
+
+  it('session_end applied is true on an active row', async () => {
+    const s = startSession();
+    const r = await runWithContext(makeContext(), () => handlers.sessionEnd({ sessionId: s.id }));
+    const out = parseText<{ ok: boolean; applied: boolean }>(r);
+    expect(out.ok).toBe(true);
+    expect(out.applied).toBe(true);
+  });
+
+  it('session_end applied is false on an already-terminal row', async () => {
+    const s = startSession();
+    agentSessions.end(s.id, { tokenId: adminToken.id });
+    // Already terminal — should be no-op
+    const r = await runWithContext(makeContext(), () => handlers.sessionEnd({ sessionId: s.id }));
+    const out = parseText<{ ok: boolean; applied: boolean }>(r);
+    expect(out.ok).toBe(true);
+    expect(out.applied).toBe(false);
+  });
 });
 
 describe('memory.session_resume', () => {
@@ -236,7 +315,7 @@ describe('memory.session_resume', () => {
 
   it('returns an ended session to active and reports what it discarded', async () => {
     const s = startSession();
-    const ended = agentSessions.end(s.id, { tokenId: adminToken.id });
+    const { row: ended } = agentSessions.end(s.id, { tokenId: adminToken.id });
 
     const r = await runWithContext(makeContext(), () =>
       handlers.sessionResume({ sessionId: s.id }),
@@ -422,7 +501,7 @@ describe('session tools acting on a resumed session', () => {
 
     const s = sessions.start({ tokenId: adminToken.id, projectId: defaultProjectId, agent: 'a' });
     tick = 1;
-    const firstEnd = sessions.end(s.id, { tokenId: adminToken.id });
+    const { row: firstEnd } = sessions.end(s.id, { tokenId: adminToken.id });
     expect(firstEnd.endedAt?.getTime()).toBe(ticks[1]!.getTime());
     tick = 2;
     await runWithContext(ctx, () => clocked.sessionResume({ sessionId: s.id }));

--- a/apps/server/src/mcp/session-tools.ts
+++ b/apps/server/src/mcp/session-tools.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { getRequestContext } from '../server/request-context.js';
 import type { ProjectResolutionSource, SessionRouter } from '../server/session-router.js';
 import { SUMMARY_MAX_CHARS, type AgentSessionsService } from '../services/agent-sessions.js';
-import { type ProjectsService } from '../services/projects.js';
+import type { ProjectsService } from '../services/projects.js';
 import { projectScope, type Scope } from '../services/scope.js';
 
 import {
@@ -78,6 +78,7 @@ export const sessionEndOutput = {
   ok: z.literal(true),
   sessionId: z.string(),
   endedAt: z.string().nullable(),
+  applied: z.boolean(),
 };
 
 export const sessionSummaryOutput = {
@@ -87,6 +88,8 @@ export const sessionSummaryOutput = {
   title: z.string().nullable(),
   summaryFinal: z.boolean(),
   titleFinal: z.boolean(),
+  applied: z.boolean(),
+  discardReason: z.string().optional(),
 };
 
 export const sessionResumeOutput = {
@@ -139,7 +142,13 @@ async function handleSessionStart(
   // project), awaiting roots discovery on a path-less connection.
   let scope: Scope;
   let source: ProjectResolutionSource;
-  if (args.project !== undefined) {
+  if (args.project === undefined) {
+    try {
+      ({ scope, source } = await resolveEffectiveScope(deps));
+    } catch (err) {
+      return errToMcp(err);
+    }
+  } else {
     if (ctx.requestedSlug && ctx.requestedSlug !== args.project) {
       return mcpError(
         'scope_locked',
@@ -157,12 +166,6 @@ async function handleSessionStart(
     }
     scope = projectScope(found.id);
     source = 'tool-explicit';
-  } else {
-    try {
-      ({ scope, source } = await resolveEffectiveScope(deps));
-    } catch (err) {
-      return errToMcp(err);
-    }
   }
   const projectId = scope.projectId;
 
@@ -197,7 +200,7 @@ async function handleSessionStart(
         projectId,
         agent: args.agent ?? 'unknown',
         description: args.description ?? null,
-        cwd: typeof process !== 'undefined' ? process.cwd() : null,
+        cwd: typeof process === 'undefined' ? null : process.cwd(),
       });
     } catch (err) {
       return errToMcp(err);
@@ -250,14 +253,16 @@ async function handleSessionEnd(deps: SessionToolDeps, args: { sessionId?: strin
   const blocked = rejectIfDeleted(deps, sessionId, ctx.token.id, scope.projectId);
   if (blocked) return blocked;
   try {
-    const ended = deps.agentSessions.end(sessionId, { tokenId: ctx.token.id });
+    const { row: ended, applied } = deps.agentSessions.end(sessionId, {
+      tokenId: ctx.token.id,
+    });
     const key = routerKey();
     // Not on an abandoned row: `end()` used to throw there, so the binding
     // survived. Clearing it now would drop auto-attach to `session_id = NULL`.
     if (key && ended.status !== 'abandoned') {
       deps.router.clearSession(key.tokenId, key.mcpSessionId);
     }
-    return ok({ ok: true, sessionId: ended.id, endedAt: ended.endedAt });
+    return ok({ ok: true, sessionId: ended.id, endedAt: ended.endedAt, applied });
   } catch (err) {
     return errToMcp(err);
   }
@@ -286,7 +291,7 @@ async function handleSessionSummary(
   const blocked = rejectIfDeleted(deps, sessionId, ctx.token.id, scope.projectId);
   if (blocked) return blocked;
   try {
-    const updated = deps.agentSessions.writeSummary(sessionId, {
+    const { row: updated, applied } = deps.agentSessions.writeSummary(sessionId, {
       tokenId: ctx.token.id,
       summary: args.summary,
       title: args.title,
@@ -299,6 +304,8 @@ async function handleSessionSummary(
       title: updated.title,
       summaryFinal: updated.summaryFinal,
       titleFinal: updated.titleFinal,
+      applied,
+      ...(applied === false && { discardReason: 'terminal_final' }),
     });
   } catch (err) {
     return errToMcp(err);

--- a/apps/server/src/server/api-router.ts
+++ b/apps/server/src/server/api-router.ts
@@ -172,10 +172,10 @@ export function createApiRouter(deps: ApiRouterDeps): Hono<ApiEnv> {
       // HTTP path truncates server-side: bash / Python / opencode writers
       // cannot react to invalid_input. The MCP path rejects (agent retries).
       // See apps/server/src/services/agent-sessions.ts:SUMMARY_MAX_CHARS.
-      const updated = deps.agentSessions.writeSummary(sessionId, {
+      const { row: updated } = deps.agentSessions.writeSummary(sessionId, {
         tokenId: ctx.token.id,
         summary: truncateSummary(parsed.data.summary),
-        title: parsed.data.title !== undefined ? truncateTitle(parsed.data.title) : undefined,
+        title: parsed.data.title === undefined ? undefined : truncateTitle(parsed.data.title),
         final: parsed.data.final,
       });
       return c.json({
@@ -214,11 +214,11 @@ export function createApiRouter(deps: ApiRouterDeps): Hono<ApiEnv> {
     }
     try {
       // HTTP path truncates server-side (see /summary handler above).
-      const updated = deps.agentSessions.end(sessionId, {
+      const { row: updated } = deps.agentSessions.end(sessionId, {
         tokenId: ctx.token.id,
         summary:
-          parsed.data.summary !== undefined ? truncateSummary(parsed.data.summary) : undefined,
-        title: parsed.data.title !== undefined ? truncateTitle(parsed.data.title) : undefined,
+          parsed.data.summary === undefined ? undefined : truncateSummary(parsed.data.summary),
+        title: parsed.data.title === undefined ? undefined : truncateTitle(parsed.data.title),
         final: parsed.data.final,
       });
       return c.json({
@@ -303,7 +303,7 @@ export function createApiRouter(deps: ApiRouterDeps): Hono<ApiEnv> {
       const result = deps.agentSessions.reportTurn(sessionId, {
         tokenId: ctx.token.id,
         usedTools: parsed.data.usedTools,
-        title: parsed.data.title !== undefined ? truncateTitle(parsed.data.title) : undefined,
+        title: parsed.data.title === undefined ? undefined : truncateTitle(parsed.data.title),
       });
       // `lines` MUST stay the last key: the hooks' no-jq fallback
       // (`apps/plugin/scripts/_api.sh::rembric_turn_report`) reads it with a

--- a/apps/server/src/services/agent-sessions.test.ts
+++ b/apps/server/src/services/agent-sessions.test.ts
@@ -59,7 +59,7 @@ describe('AgentSessionsService', () => {
 
   it('end transitions to ended without writing summary', () => {
     const s = sessions.start({ tokenId, projectId, agent: 'claude' });
-    const ended = sessions.end(s.id, { tokenId });
+    const { row: ended } = sessions.end(s.id, { tokenId });
     expect(ended.status).toBe('ended');
     expect(ended.endedAt).not.toBeNull();
     expect(ended.summary).toBeNull();
@@ -67,7 +67,7 @@ describe('AgentSessionsService', () => {
 
   it('end with a summary transitions and persists it', () => {
     const s = sessions.start({ tokenId, projectId, agent: 'claude' });
-    const updated = sessions.end(s.id, {
+    const { row: updated } = sessions.end(s.id, {
       tokenId,
       summary: '## Goal\nwrap it up',
       final: true,
@@ -84,12 +84,12 @@ describe('AgentSessionsService', () => {
 
   it('double-end is idempotent on already-ended sessions', () => {
     const s = sessions.start({ tokenId, projectId, agent: 'claude' });
-    const first = sessions.end(s.id, { tokenId });
+    const { row: first } = sessions.end(s.id, { tokenId });
     expect(first.status).toBe('ended');
     const firstEndedAt = first.endedAt?.getTime();
     // Second end returns the existing row unchanged — no throw, no
     // re-write of ended_at.
-    const second = sessions.end(s.id, { tokenId });
+    const { row: second } = sessions.end(s.id, { tokenId });
     expect(second.status).toBe('ended');
     expect(second.endedAt?.getTime()).toBe(firstEndedAt);
   });
@@ -121,7 +121,7 @@ describe('AgentSessionsService', () => {
 
     it('writeSummary accepts a summary of exactly the cap', () => {
       const s = sessions.start({ tokenId, projectId, agent: 'claude' });
-      const updated = sessions.writeSummary(s.id, {
+      const { row: updated } = sessions.writeSummary(s.id, {
         tokenId,
         summary: 'a'.repeat(SUMMARY_MAX_CHARS),
         final: true,
@@ -490,7 +490,10 @@ describe('AgentSessionsService', () => {
       }
       const row =
         status === 'ended'
-          ? svc.end(s.id, { tokenId })
+          ? (() => {
+              const { row: r } = svc.end(s.id, { tokenId });
+              return r;
+            })()
           : svc.markAbandoned(s.id, { tokenId, adminBypass: true });
       clock = LATE;
       return row;
@@ -499,7 +502,7 @@ describe('AgentSessionsService', () => {
     for (const status of ['abandoned', 'ended'] as const) {
       it(`writeSummary on a ${status} row writes summary and title, leaving lifecycle columns untouched`, () => {
         const before = terminalSession(status);
-        const updated = svc.writeSummary(before.id, {
+        const { row: updated } = svc.writeSummary(before.id, {
           tokenId,
           summary: 'late but curated',
           title: 'Fix the reaper',
@@ -522,7 +525,7 @@ describe('AgentSessionsService', () => {
 
       it(`writeSummary on a ${status} row applies per-field precedence: the curated summary survives a final:false sync, the title still lands`, () => {
         const before = terminalSession(status, { curatedSummary: true });
-        const updated = svc.writeSummary(before.id, {
+        const { row: updated } = svc.writeSummary(before.id, {
           tokenId,
           summary: 'raw transcript dump',
           title: 'hook fallback title',
@@ -540,7 +543,7 @@ describe('AgentSessionsService', () => {
       it(`writeSummary on a ${status} row emits no UPDATE when precedence blocks every field`, () => {
         const before = terminalSession(status, { curatedSummary: true });
         const spy = vi.spyOn(repos.agentSessions, 'updateById');
-        const updated = svc.writeSummary(before.id, {
+        const { row: updated } = svc.writeSummary(before.id, {
           tokenId,
           summary: 'raw transcript dump',
           final: false,
@@ -553,7 +556,11 @@ describe('AgentSessionsService', () => {
 
     it('end on an abandoned row writes the summary without promoting the status', () => {
       const before = terminalSession('abandoned');
-      const updated = svc.end(before.id, { tokenId, summary: 'closing notes', final: true });
+      const { row: updated } = svc.end(before.id, {
+        tokenId,
+        summary: 'closing notes',
+        final: true,
+      });
       expect(updated.summary).toBe('closing notes');
       expect(updated.summaryFinal).toBe(true);
       expect(updated.status).toBe('abandoned');
@@ -995,7 +1002,10 @@ describe('AgentSessionsService', () => {
         final: true,
       });
       return status === 'ended'
-        ? svc.end(s.id, { tokenId })
+        ? (() => {
+            const { row: r } = svc.end(s.id, { tokenId });
+            return r;
+          })()
         : svc.markAbandoned(s.id, { adminBypass: true });
     }
 
@@ -1134,7 +1144,10 @@ describe('AgentSessionsService', () => {
           final: true,
         });
         return status === 'ended'
-          ? svc.end(s.id, { tokenId })
+          ? (() => {
+              const { row: r } = svc.end(s.id, { tokenId });
+              return r;
+            })()
           : svc.markAbandoned(s.id, { adminBypass: true });
       }
 
@@ -1276,7 +1289,7 @@ describe('AgentSessionsService', () => {
 
     it('markAbandoned still refuses an ended row that was never resumed', () => {
       const s = svc.start({ tokenId, projectId, agent: 'ended-not-resumed' });
-      const before = svc.end(s.id, { tokenId });
+      const { row: before } = svc.end(s.id, { tokenId });
       clock = LATER;
 
       let code = 'no-throw';
@@ -1309,7 +1322,7 @@ describe('AgentSessionsService', () => {
 
     it('a partial write updates one section and preserves the others', () => {
       const s = curated('## Goal\nShip X\n## Files\nsrc/a.ts');
-      const updated = svc.writeSummary(s.id, {
+      const { row: updated } = svc.writeSummary(s.id, {
         tokenId,
         summary: '## Files\nsrc/a.ts, src/b.ts',
         final: true,
@@ -1319,14 +1332,18 @@ describe('AgentSessionsService', () => {
 
     it('a section the write carries is replaced outright, not appended to', () => {
       const s = curated('## Goal\nShip X');
-      const updated = svc.writeSummary(s.id, { tokenId, summary: '## Goal\nShip Y', final: true });
+      const { row: updated } = svc.writeSummary(s.id, {
+        tokenId,
+        summary: '## Goal\nShip Y',
+        final: true,
+      });
       expect(updated.summary).toBe('## Goal\nShip Y');
       expect(updated.summary).not.toContain('Ship X');
     });
 
     it('a heading only the write carries is appended after the stored sections', () => {
       const s = curated('## Goal\nShip X\n## Files\nsrc/a.ts');
-      const updated = svc.writeSummary(s.id, {
+      const { row: updated } = svc.writeSummary(s.id, {
         tokenId,
         summary: '## Risks\nflaky test',
         final: true,
@@ -1336,7 +1353,7 @@ describe('AgentSessionsService', () => {
 
     it('shared headings keep the stored order even when the write reorders them', () => {
       const s = curated('## Goal\nA\n## Files\nB');
-      const updated = svc.writeSummary(s.id, {
+      const { row: updated } = svc.writeSummary(s.id, {
         tokenId,
         summary: '## Files\nB2\n## Goal\nA2',
         final: true,
@@ -1346,7 +1363,7 @@ describe('AgentSessionsService', () => {
 
     it('heading matching ignores case and surrounding whitespace', () => {
       const s = curated('## Files\nsrc/a.ts');
-      const updated = svc.writeSummary(s.id, {
+      const { row: updated } = svc.writeSummary(s.id, {
         tokenId,
         summary: '##   files  \nsrc/b.ts',
         final: true,
@@ -1357,14 +1374,18 @@ describe('AgentSessionsService', () => {
 
     it('a `##` line inside a fenced code block is not a section boundary', () => {
       const s = curated('## Files\n```\n## Goal\n```\nsrc/a.ts');
-      const updated = svc.writeSummary(s.id, { tokenId, summary: '## Goal\nShip X', final: true });
+      const { row: updated } = svc.writeSummary(s.id, {
+        tokenId,
+        summary: '## Goal\nShip X',
+        final: true,
+      });
       expect(updated.summary).toContain('```\n## Goal\n```');
       expect(updated.summary).toContain('## Goal\nShip X');
     });
 
     it('a section carried with an empty body is stored empty rather than removed', () => {
       const s = curated('## Goal\nA\n## Unfinished+why\nblocked on Y');
-      const updated = svc.writeSummary(s.id, {
+      const { row: updated } = svc.writeSummary(s.id, {
         tokenId,
         summary: '## Unfinished+why\n',
         final: true,
@@ -1379,7 +1400,7 @@ describe('AgentSessionsService', () => {
         '## Goal\nA\n## Accomplished\nB\n## Decisions+why\nC\n## Verified+how\nD\n## Unfinished+why\nE\n## Files\nF',
       );
       const before = svc.getById(s.id)?.summary;
-      const updated = svc.writeSummary(s.id, {
+      const { row: updated } = svc.writeSummary(s.id, {
         tokenId,
         summary: '<raw transcript>',
         final: false,
@@ -1394,7 +1415,11 @@ describe('AgentSessionsService', () => {
         summary: 'raw transcript containing a ## line',
         final: false,
       });
-      const updated = svc.writeSummary(s.id, { tokenId, summary: '## Goal\nShip X', final: true });
+      const { row: updated } = svc.writeSummary(s.id, {
+        tokenId,
+        summary: '## Goal\nShip X',
+        final: true,
+      });
       expect(updated.summary).toBe('## Goal\nShip X');
       expect(updated.summary).not.toContain('raw transcript');
     });
@@ -1402,7 +1427,7 @@ describe('AgentSessionsService', () => {
     it('a late curated write to a terminal row is still a silent no-op', () => {
       const s = curated('## Goal\nA\n## Files\nB');
       svc.end(s.id, { tokenId });
-      const updated = svc.writeSummary(s.id, {
+      const { row: updated } = svc.writeSummary(s.id, {
         tokenId,
         summary: 'a flat paragraph',
         final: true,
@@ -1413,7 +1438,7 @@ describe('AgentSessionsService', () => {
     it('a late over-cap curated write to a terminal row is still a silent no-op, not invalid_input', () => {
       const s = curated('## Goal\nA\n## Files\nB');
       svc.end(s.id, { tokenId });
-      const updated = svc.writeSummary(s.id, {
+      const { row: updated } = svc.writeSummary(s.id, {
         tokenId,
         summary: 'a'.repeat(SUMMARY_MAX_CHARS),
         final: true,
@@ -1423,14 +1448,18 @@ describe('AgentSessionsService', () => {
 
     it('a merge that changes nothing stores the same bytes', () => {
       const s = curated('## Goal\nA\n## Files\nB');
-      const updated = svc.writeSummary(s.id, { tokenId, summary: '## Files\nB', final: true });
+      const { row: updated } = svc.writeSummary(s.id, {
+        tokenId,
+        summary: '## Files\nB',
+        final: true,
+      });
       expect(updated.summary).toBe('## Goal\nA\n## Files\nB');
     });
 
     it('merging a document with itself is the identity', () => {
       const doc = '## Goal\nA\n\n### Sub-decision\ndetail\n## Files\n```\ncode\n```\nsrc/a.ts';
       const s = curated(doc);
-      const updated = svc.writeSummary(s.id, { tokenId, summary: doc, final: true });
+      const { row: updated } = svc.writeSummary(s.id, { tokenId, summary: doc, final: true });
       expect(updated.summary).toBe(doc);
     });
 
@@ -1451,7 +1480,7 @@ describe('AgentSessionsService', () => {
 
       it('is accepted against a stored summary with no headings (the control)', () => {
         const s = curated('Goal: A. Files: B.');
-        const updated = svc.writeSummary(s.id, {
+        const { row: updated } = svc.writeSummary(s.id, {
           tokenId,
           summary: 'Fixed the CI formatting job.',
           final: true,
@@ -1461,7 +1490,7 @@ describe('AgentSessionsService', () => {
 
       it('a first curated write on an empty session may be free-form', () => {
         const s = svc.start({ tokenId, projectId, agent: 'claude' });
-        const updated = svc.writeSummary(s.id, {
+        const { row: updated } = svc.writeSummary(s.id, {
           tokenId,
           summary: 'no headings here',
           final: true,
@@ -1473,7 +1502,7 @@ describe('AgentSessionsService', () => {
         const s = curated(
           '## Goal\nA\n## Accomplished\nB\n## Decisions+why\nC\n## Verified+how\nD\n## Unfinished+why\nE\n## Files\nF',
         );
-        const updated = svc.writeSummary(s.id, {
+        const { row: updated } = svc.writeSummary(s.id, {
           tokenId,
           summary: '## Accomplished\nDid it',
           final: true,
@@ -1501,7 +1530,11 @@ describe('AgentSessionsService', () => {
         const stored = `## Goal\n${'a'.repeat(SUMMARY_MAX_CHARS - 20)}`;
         const s = curated(stored);
         const condensed = '## Goal\ncondensed';
-        const updated = svc.writeSummary(s.id, { tokenId, summary: condensed, final: true });
+        const { row: updated } = svc.writeSummary(s.id, {
+          tokenId,
+          summary: condensed,
+          final: true,
+        });
         expect(updated.summary).toBe(condensed);
       });
     });
@@ -1513,7 +1546,7 @@ describe('AgentSessionsService', () => {
         summary: '## Goal\nShip X\n## Files\nsrc/a.ts',
         final: true,
       });
-      const updated = svc.end(s.id, {
+      const { row: updated } = svc.end(s.id, {
         tokenId,
         summary: '## Files\nsrc/a.ts, src/b.ts',
         final: true,

--- a/apps/server/src/services/agent-sessions.ts
+++ b/apps/server/src/services/agent-sessions.ts
@@ -317,10 +317,10 @@ export class AgentSessionsService {
     return updated;
   }
 
-  /**
-   * The one late-write path for a row that is already `ended` or
-   * `abandoned`. */
-  private writeTerminalFields(existing: AgentSession, input: PrecedenceInput): AgentSession {
+  private writeTerminalFields(
+    existing: AgentSession,
+    input: PrecedenceInput,
+  ): { row: AgentSession; applied: boolean } {
     // No lastActivityAt stamp, unlike the active path: it only drives
     // stale-active retirement and transport resolution, both status='active'.
     // `{ terminal: true }` is the deviation from the active path's
@@ -337,10 +337,13 @@ export class AgentSessionsService {
       delete set.titleFinal;
     }
     if (Object.keys(set).length === 0) {
-      return existing;
+      return { row: existing, applied: false };
     }
     const updated = this.repos.agentSessions.updateById(existing.id, set, { requireActive: false });
-    return updated ?? existing;
+    if (!updated) {
+      return { row: existing, applied: false };
+    }
+    return { row: updated, applied: true };
   }
 
   /**
@@ -354,7 +357,10 @@ export class AgentSessionsService {
    * `_final` flag is already true ignores incoming `final:false` writes
    * and is replaced by incoming `final:true` writes (last-final-wins).
    */
-  writeSummary(sessionId: string, input: WriteSummaryInput): AgentSession {
+  writeSummary(
+    sessionId: string,
+    input: WriteSummaryInput,
+  ): { row: AgentSession; applied: boolean } {
     if (input.summary !== undefined && input.summary.trim().length === 0) {
       throw new DomainError('invalid_input', 'sessions.writeSummary: summary must be non-empty');
     }
@@ -384,10 +390,10 @@ export class AgentSessionsService {
       lastActivityAt: ts,
       ...precedenceSet(existing, input, ts),
     };
-    return this.updateActiveOrThrow(sessionId, set);
+    return { row: this.updateActiveOrThrow(sessionId, set), applied: true };
   }
 
-  end(sessionId: string, input: EndSessionInput): AgentSession {
+  end(sessionId: string, input: EndSessionInput): { row: AgentSession; applied: boolean } {
     if (input.summary !== undefined && input.summary.trim().length === 0) {
       throw new DomainError('invalid_input', 'sessions.end: summary must be non-empty');
     }
@@ -420,7 +426,7 @@ export class AgentSessionsService {
       lastActivityAt: ts,
       ...precedenceSet(existing, input, ts),
     };
-    return this.updateActiveOrThrow(sessionId, set);
+    return { row: this.updateActiveOrThrow(sessionId, set), applied: true };
   }
 
   /**

--- a/apps/server/src/test/mcp-integration.test.ts
+++ b/apps/server/src/test/mcp-integration.test.ts
@@ -21,7 +21,7 @@ import {
 import { DESCRIPTION_MAX_LENGTH } from '../mcp/server.js';
 import { SUMMARY_MERGE_RULE, SUMMARY_SECTIONS } from '../mcp/summary-rubric.js';
 import { type BootstrappedServer, createServer } from '../server/index.js';
-import { SUMMARY_MAX_CHARS } from '../services/agent-sessions.js';
+import { AgentSessionsService, SUMMARY_MAX_CHARS } from '../services/agent-sessions.js';
 import { ABSTENTION_FLOOR, EMPTY_POOL_REASON } from '../services/hybrid-search.js';
 import { MemoryService } from '../services/memory.js';
 import { ProjectsService } from '../services/projects.js';
@@ -939,6 +939,77 @@ describe('MCP protocol conformance', () => {
     expect(rows.map((r) => r.id)).toEqual([a.sessionId]);
 
     await client.callTool({ name: 'memory.session_end', arguments: {} });
+    await client.close();
+  });
+
+  it('session_summary on an abandoned terminal row returns applied:false and discardReason', async () => {
+    const projects = new ProjectsService(createRepositories(server.dbHandle.db));
+    const project =
+      projects.findBySlug('integration-verdict-terminal') ??
+      projects.create({ slug: 'integration-verdict-terminal' });
+    const client = await connect({ projectSlug: project.slug });
+    const agentSessions = new AgentSessionsService(
+      createRepositories(server.dbHandle.db),
+      server.dbHandle.db,
+    );
+
+    // Start and write a summary to create a terminal row with summaryFinal:true
+    const start = (await client.callTool({
+      name: 'memory.session_start',
+      arguments: { agent: 'rembric-test' },
+    })) as ToolResult;
+    const sessionId = (readJson(start) as { sessionId: string }).sessionId;
+
+    await client.callTool({
+      name: 'memory.session_summary',
+      arguments: { sessionId, summary: '## Goal\nfirst curated summary' },
+    });
+    // Mark as abandoned (terminal) — bypass token check since integration test
+    // uses a single token
+    agentSessions.markAbandoned(sessionId, { adminBypass: true });
+
+    // Second summary on terminal row with summaryFinal=true should be discarded
+    const second = (await client.callTool({
+      name: 'memory.session_summary',
+      arguments: { sessionId, summary: '## Goal\nsecond curated' },
+    })) as ToolResult;
+    const body = readJson(second) as { applied: boolean; discardReason?: string };
+    expect(body.applied).toBe(false);
+    expect(body.discardReason).toBe('terminal_final');
+
+    await client.close();
+  });
+
+  it('session_end on an already-terminal row returns applied:false', async () => {
+    const projects = new ProjectsService(createRepositories(server.dbHandle.db));
+    const project =
+      projects.findBySlug('integration-verdict-end') ??
+      projects.create({ slug: 'integration-verdict-end' });
+    const client = await connect({ projectSlug: project.slug });
+
+    // Start the session and capture the session ID
+    const start = (await client.callTool({
+      name: 'memory.session_start',
+      arguments: { agent: 'rembric-test' },
+    })) as ToolResult;
+    const sessionId = (readJson(start) as { sessionId: string }).sessionId;
+
+    // End the session to make it terminal
+    const firstEnd = (await client.callTool({
+      name: 'memory.session_end',
+      arguments: { sessionId },
+    })) as ToolResult;
+    const body1 = readJson(firstEnd) as { applied: boolean };
+    expect(body1.applied).toBe(true);
+
+    // Second end on already-terminal row should return applied:false
+    const secondEnd = (await client.callTool({
+      name: 'memory.session_end',
+      arguments: { sessionId },
+    })) as ToolResult;
+    const body2 = readJson(secondEnd) as { applied: boolean };
+    expect(body2.applied).toBe(false);
+
     await client.close();
   });
 

--- a/openspec/changes/expose-session-write-verdict/.openspec.yaml
+++ b/openspec/changes/expose-session-write-verdict/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/expose-session-write-verdict/design.md
+++ b/openspec/changes/expose-session-write-verdict/design.md
@@ -1,0 +1,64 @@
+## Context
+
+`memory.session_summary` writes summary and title onto a session row. On an `active` row the write always lands (last-final-wins among `final:true` writes). On a terminal row (`ended` or `abandoned`), the write enters `writeTerminalFields`, which calls `precedenceSet` with `{ terminal: true }`. That flag locks summary once `existing.summaryFinal` is already `true` — "first curated value stands" — because on a closed row the owning process is dead and losing a curated handoff is unrecoverable (`openspec/specs/plugin-session-protocol`, "Write precedence for summary and title MUST be expressed via a `final:boolean` flag"). The result: a second curated write on a terminal row is a silent no-op, but the handler returns `ok:true` with the stored summary, which is byte-identical to the caller's input when the summary text happens to match, and byte-different but equally `ok:true` when it does not. The caller cannot tell.
+
+The same pattern exists on `memory.session_end`: `end()` on a terminal row returns the existing row, the handler reports `ok:true` with the existing `endedAt`. This is the explicit idempotent contract (the spec says `session_end` on an already-ended row returns `{ ok: true, endedAt }`), so it is not a bug — but it is the same class of "outcome not legible" and fixing both tools in one change keeps the surface consistent.
+
+The precedent for this fix class: issue #337 fixed `memory.session_start`'s silent agent discard by echoing the effective outcome (`reused` + effective `agent`). The in-flight change `expose-session-start-agent` is the structural template.
+
+Service layer anchoring:
+
+- `writeSummary` (`agent-sessions.ts:375`) calls `writeTerminalFields` when `existing.status !== 'active'`.
+- `writeTerminalFields` (`:322`) calls `precedenceSet` with `{ terminal: true }`, gets back a `set`. If `set` is empty (nothing changed), returns `existing`. Otherwise writes `set` via `updateById` and returns the updated row.
+- `end` (`:390`) has the same terminal path: calls `writeTerminalFields` when `existing.status !== 'active'`.
+- The handler (`session-tools.ts:266`) reads `updated.summary`, `updated.summaryFinal`, etc. from the returned row and emits them. When the terminal write was a no-op, these are the OLD stored values, identical to what the caller sent.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A caller of `memory.session_summary` can tell, from the response alone, whether the write landed or was discarded by the terminal precedence rule.
+- A caller of `memory.session_end` can tell, from the response alone, whether the call transitioned an `active` row or was a no-op on an already-terminal row.
+- The `mcp-api` spec states the new fields, what they mean, and why the terminal discard cannot be an error.
+- The reproduction probe's assertions are folded into proper regression tests and the probe file is deleted.
+
+**Non-Goals:**
+
+- Changing the first-curated-stands precedence rule on terminal rows (the spec's `plugin-session-protocol` requires it, and there is no `replaces` chain for sessions to recover from).
+- Changing `session_already_ended` error semantics (the spec already says this SHALL NOT be an error code).
+- Surfacing a verdict on `memory.session_resume` (it already reports `previousStatus` / `previousEndedAt`, which is the verdict).
+- Extending the HTTP API surface (the `POST /api/<slug>/sessions/<id>/summary` path is out of scope, same as in the precedent change's D5).
+- Adding operator-facing advice to the tool description (it belongs in `docs/`, not in the model-facing channel).
+
+## Decisions
+
+**D1 — `applied` is a required boolean, not an enum or union.** A boolean answers the one question the caller needs: "did my write land?". Rejected: an enum like `applied | terminal_final | active_noop` — more expressive, but the only case that needs a distinguishing name is the terminal-final discard, and that is the case `discardReason` covers. The boolean keeps the common path cheap and the rare path descriptive. The MCP SDK validates output against the registered schema, so adding an optional `discardReason` is additive and backward-safe: existing callers that do not read it are unaffected.
+
+**D2 — `discardReason` is optional, not required, and only present when `applied: false`.** When `applied: true`, the caller does not need a reason — the write landed. When `applied: false`, the `discardReason` string names why. Today the only value is `'terminal_final'` (the write was skipped because the terminal row already carries a curated summary). Keeping it optional means the output shape is smaller in the common case and extensible for future discard reasons without a schema-breaking change. The zod shape is `z.string().optional()` — present in the `outputSchema` so clients can discover it, but not required.
+
+**D3 — Surface `applied` on `session_end` for consistency, even though the no-op is the documented contract.** The spec already says `session_end` on a terminal row is a no-op returning the existing `ended_at`. Adding `applied` makes the two session-lifecycle write tools consistent: both report whether the call achieved a state change. This matters because `session_end` is called from the same nudge path as `session_summary` — a model that receives `applied: false` on both can reason uniformly about "nothing changed" without special-casing the two tools. Rejected: not adding it (asymmetric surface), adding it only to `session_summary` (then `session_end` has the same class of omission that motivated this change).
+
+**D4 — The service layer must signal "no-op" rather than the handler inferring it.** The handler currently reads the returned row and cannot tell whether `writeTerminalFields` was a no-op (returned `existing`) or a real write (returned `updated`). Two implementation options: (a) change the return type to include a flag (`{ row, applied }`), or (b) the handler compares the returned summary against what it sent and infers. Option (a) is chosen because: inference from the returned row fails when the caller's summary matches the stored one (the same text was written, so the comparison is a false positive), and it introduces a coupling between the handler and the service's storage details. Option (b) is rejected. The same `{ row, applied }` shape applies to `writeTerminalFields` and to `end`, keeping the boundary clean.
+
+**D5 — The spec scenario "last-final-wins among final writes" is scoped to active rows.** The current spec says: "GIVEN a session whose `summary_final = true` … WHEN the agent calls `memory.session_summary({summary: "B"})` again — THEN `summary` SHALL be replaced with 'B' (last-final-wins among final writes)". This is true on active rows and false on terminal rows. The scenario SHALL be updated to scope the claim to active rows, and a new scenario SHALL cover the terminal-final-discard case. This is a spec clarification, not a behaviour change — the code already implements terminal-first-curated-stands — and the scenario was the source of the issue author's expectation that the second write would land.
+
+**D6 — `memory.session_summary`'s tool description SHALL state the terminal-summary rule.** A model that receives `applied: false` with `discardReason: 'terminal_final'` needs to know what to do next: use `memory.session_resume` to reopen the session and write again. The description SHALL add a clause explaining that a terminal row keeps its first curated summary and that `memory.session_resume` is the way to resume the session for further writes. This clause replaces no existing text — it is additive within the `DESCRIPTION_MAX_LENGTH` budget, and the new length shall be measured from a real `tools/list` response.
+
+**D7 — No comment on the schema or handler edits.** The "why" is in the spec and design doc, per house policy.
+
+## Risks / Trade-offs
+
+- [Trade-off] One more REQUIRED field on two tools every model sees → Accepted: the field answers a question the caller cannot answer any other way, and the precedent (#337) established that output-schema fields for observable state are the right remedy class. Budget: two boolean fields cost negligible description space.
+- [Trade-off] `session_end` gains `applied` even though its no-op is documented → Accepted: consistency across the two write tools, and the cost is one more boolean. The alternative (leaving `session_end` asymmetric) is the same class of omission this change exists to close.
+- [Risk] A test that asserts `applied: false` on a terminal-final discard passes without the terminal row actually being final — the shape of failure the repo has been bitten by before → Mitigation: the distinguishing test creates a terminal row with `summaryFinal: false` and asserts `applied: true` (the write lands on a terminal row that has no curated summary), paired with the control that creates a terminal row with `summaryFinal: true` and asserts `applied: false`. Both arms are required; the `applied: false` arm alone cannot be told from a broken flag.
+- [Risk] `discardReason` could be emitted on an active row by accident → Mitigation: the service layer only sets `applied: false` when `writeTerminalFields` returns the existing row; the active path always calls `updateActiveOrThrow`, which either returns the updated row or throws `session_already_ended`. A test asserting `discardReason` is undefined on an active-row write guards this.
+- [Trade-off] The HTTP `POST /api/<slug>/sessions/<id>/summary` path keeps its silent discard → Accepted, same reachability argument as in `expose-session-start-agent` D5. The MCP surface is the one the model uses; the HTTP surface is plugin-only and each client already handles its own retry.
+- [Risk] Existing terminal-final discards will now return `applied: false`, which is a response-shape change → Mitigation: additive field, not a breaking change; existing callers that do not read `applied` are unaffected. The MCP SDK validates `structuredContent` against the schema published at registration, so schema and payload move together.
+
+## Migration Plan
+
+No migration. No schema change, no new column, no index, no backfill, no derived-data invalidation. Deploy is a `server`-track version bump only. First boot after upgrade: `memory.session_summary` and `memory.session_end` return one additional field each; nothing persisted depends on it. Rollback removes the fields and restores the silent discard; safe in both directions.
+
+## Open Questions
+
+None. The decisions above settle every design choice identified during analysis. The terminal-first-curated-stands rule is correct and not on the table. The `discardReason` shape is extensible for future reasons without a schema change.

--- a/openspec/changes/expose-session-write-verdict/proposal.md
+++ b/openspec/changes/expose-session-write-verdict/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+`memory.session_summary` on a terminal (ended/abandoned) row that already carries a curated summary silently discards the write while returning `ok:true`. The handler echoes the stored row — `summary`, `summaryFinal`, `title`, `titleFinal` — and the caller cannot distinguish "your write landed" from "your write was silently discarded by the first-curated-stands precedence rule". Verified today by a vitest probe at the real MCP handler boundary:
+
+- Second curated write on an abandoned, already-final row → response `ok:true`, `summaryFinal:true`, echoes the STORED (old) summary; row unchanged.
+- Same second write on an active row → lands (last-final-wins).
+- A terminal row WITHOUT a prior summary → accepts the late curated write.
+
+The caller has no way to tell applied from terminal-final discard. This matters because `memory.session_summary` is the only tool whose write outcome on a terminal row is ambiguous: `memory.session_end` is explicitly a no-op there (returning existing `ended_at`), and `memory.session_start` already reports `reused` to distinguish adoption from fresh-mint.
+
+## What Changes
+
+- **Report the write verdict on `memory.session_summary`.** Add a REQUIRED `applied: z.boolean()` to `sessionSummaryOutput` and a conditional `discardReason: z.string().optional()` carrying `'terminal_final'` when the write was skipped by the terminal first-curated-stands rule. The service layer (`writeSummary` → `writeTerminalFields` → `precedenceSet`) must signal whether the write landed — the handler cannot infer it from the returned row, because the same stored row is returned in both cases. Rejected: (a) returning an error on discard — the current contract says terminal writes SHALL NOT be rejected, and the plugin nudge instructs agents to call this tool on every terminal path; (b) changing the precedence rule itself — first-curated-stands on terminal rows is correct by design (no `replaces` chain for sessions, so losing a curated handoff is unrecoverable).
+- **Surface the same verdict on `memory.session_end`.** The same silent no-op pattern exists: `end()` on a terminal row returns the existing row with `endedAt`, and the handler reports `ok:true`. Adding `applied: z.boolean()` to `sessionEndOutput` makes both session-lifecycle write tools consistent. The precedent: `memory.session_start` already surfaces an outcome legible in `reused`.
+- **Update the session_summary tool description** to state that a terminal row keeps its first curated summary and that `memory.session_resume` is the way back.
+- **Delta-spec the `mcp-api` capability** with updated `sessionSummaryOutput` and `sessionEndOutput` schema requirements, updated scenarios, and a new scenario covering the terminal-final-discard case.
+- **Fold the temporary reproduction probe** (apps/server/src/mcp/session-371-probe.test.ts) into proper regression tests in the co-located test file and delete the probe.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `mcp-api`: MODIFIED requirement "The MCP server MUST expose four session-lifecycle tools" — `sessionSummaryOutput` gains `applied: z.boolean()` and optional `discardReason`; `sessionEndOutput` gains `applied: z.boolean()`; the description requirement is updated; new scenarios cover the terminal-final-discard case and the end no-op case; the existing "last-final-wins" scenario is clarified to scope the claim to active rows.
+
+## Impact
+
+- MCP surface: `apps/server/src/mcp/session-tools.ts` — `sessionSummaryOutput` gains `applied: z.boolean()`, `discardReason: z.string().optional()`; `sessionEndOutput` gains `applied: z.boolean()`; `handleSessionSummary` and `handleSessionEnd` must populate them from the service return.
+- Service: `apps/server/src/services/agent-sessions.ts` — `writeSummary` and `end` must signal whether the write landed (via a return shape change or a side-channel flag on the returned row). The `writeTerminalFields` method currently returns the existing row on no-op; it must distinguish this case.
+- Tests: `apps/server/src/mcp/session-tools.test.ts`, `apps/server/src/test/mcp-integration.test.ts` (required-field pins and description-length pins), plus deleting `apps/server/src/mcp/session-371-probe.test.ts`.
+- Tool description: `apps/server/src/mcp/server.ts` — `memory.session_summary` and `memory.session_end` descriptions gain the `applied` field in their `Returns:` list and the terminal-summary clause.
+- Specs merged at archive time: `openspec/specs/mcp-api/spec.md`.
+- Deliberately untouched: the precedence rule in `precedenceSet`, the `plugin-session-protocol` capability, `apps/plugin/` (no plugin code changes), the dashboard.
+- Existing installations: no migration, no schema change, no derived-data invalidation. First boot after upgrade returns one more field on two tools; nothing persisted depends on it. Rollback removes the fields and restores the silent discard.

--- a/openspec/changes/expose-session-write-verdict/specs/mcp-api/spec.md
+++ b/openspec/changes/expose-session-write-verdict/specs/mcp-api/spec.md
@@ -1,0 +1,206 @@
+## MODIFIED Requirements
+
+### Requirement: The MCP server MUST expose four session-lifecycle tools
+
+The `/mcp` and `/mcp/<slug>` endpoints SHALL register the tools `memory.session_start`, `memory.session_end`, `memory.session_summary` and `memory.session_resume` with the following contracts. The tools are split by responsibility: `memory.session_start` opens a session, `memory.session_summary` writes summary/title without transitioning, `memory.session_end` is the state transition out of `active`, and `memory.session_resume` is the sole transition back into it.
+
+`memory.session_start` SHALL NOT always insert a row. When an `active` session already exists for the caller's `(tokenId, projectId)` on this transport — the ordinary case, because every supported host registers the session over HTTP before the agent runs — the call SHALL adopt that row instead of minting a second one, and SHALL report which of the two happened in a REQUIRED `reused` field: `true` when an existing row was adopted, `false` when a row was inserted. `reused` is the only signal distinguishing "you are now attached to the host's session" from "you just created a parallel session", which is the question a defensive `memory.session_start` call is asking. Its `outputSchema` SHALL mark it required, and the tool's description SHALL name it and state what `true` means (see "A tool's description and its response MUST agree, and neither may promise an unreachable state"): a required field the description omits from a closed-form `Returns: { … }` list is undocumented surface on the one channel the model reads.
+
+`memory.session_summary` SHALL validate `summary` against the single canonical cap exported from `apps/server/src/services/agent-sessions.ts` (`SUMMARY_MAX_CHARS`, currently `10000`). The MCP zod schema SHALL be `summary: z.string().min(1).max(SUMMARY_MAX_CHARS)` so overflow is rejected at the transport boundary with `invalid_input` before the tool body runs. The rejected agent SHALL receive an error whose message contains the decimal string of `SUMMARY_MAX_CHARS` so it can retry with a tighter body on the first attempt.
+
+`memory.session_summary` and `memory.session_end` SHALL NOT reject a call because the resolved row is in a terminal state. `memory.session_summary` SHALL apply its summary/title write subject to the `final` precedence rules regardless of `status`; `memory.session_end` takes no summary/title arguments, so on a terminal row it SHALL be a pure no-op returning the existing `ended_at`. Neither SHALL mutate `status`, `ended_at` or `last_activity_at` on a terminal row — see the `sessions` capability, "Terminal session rows MUST accept late summary and title writes, and MUST NOT change status except through `resume`". `session_already_ended` SHALL NOT be a possible error code for either tool. This matters because the plugin's `PreCompact`, `SessionStart:compact` and `Stop` nudges instruct the agent to call `memory.session_summary`, and the stale-active retirement sweep can have flipped the row to `abandoned` (the documented steady state for two of the clients) before the agent gets there.
+
+`memory.session_summary`'s response SHALL carry a REQUIRED `applied: boolean` field. `applied` is `true` when the summary/title write landed on the row (whether the row was `active` or terminal without a prior curated summary). `applied` is `false` when the terminal first-curated-stands precedence rule blocked the write: the row is terminal (`ended` or `abandoned`), `summary_final` was already `true`, and the incoming curated summary was discarded. When `applied` is `false`, the response SHALL additionally carry `discardReason: 'terminal_final'` — the only discard reason today — to name the specific rule that blocked the write. When `applied` is `true`, `discardReason` SHALL be omitted from the response. The `outputSchema` SHALL declare `applied` as required (`z.boolean()`) and `discardReason` as optional (`z.string().optional()`). This field is the entire remedy available on the MCP surface: the row cannot be repaired, the first-curated-stands rule cannot be changed (there is no `replaces` chain for sessions, so losing a curated handoff is unrecoverable), and returning an error would violate the "SHALL NOT reject a call because the resolved row is in a terminal state" clause above.
+
+`memory.session_end`'s response SHALL carry a REQUIRED `applied: boolean` field. `applied` is `true` when the call transitioned an `active` row to `ended`. `applied` is `false` when the row was already terminal (`ended` or `abandoned`) and the call was a no-op. The `outputSchema` SHALL declare `applied` as required (`z.boolean()`). This makes the two session-lifecycle write tools consistent: both report whether the call achieved a state change.
+
+`memory.session_resume` SHALL accept `{ sessionId: string }` with `sessionId` REQUIRED, and SHALL call `AgentSessionsService.resume` (specified in the `sessions` capability) with the request's token id. Its response SHALL be `{ ok: true, sessionId, status: 'active', startedAt, resumedAt, previousStatus, previousEndedAt, title }`, where `previousStatus` is the row's `status` immediately before the call and `previousEndedAt` is the `ended_at` the call discarded (`null` when the row was already `active`). Those two fields are the ONLY report of a value the server does not retain, so the tool's `outputSchema` SHALL mark them required and the description SHALL name them. `resumedAt` SHALL be the row's effective last activity after the call — the instant of the resume on the transition path, and the row's PRIOR activity on the already-`active` no-op path, since that path writes nothing by design. `resumedAt` SHALL NOT be read as "the instant this call ran": `previousStatus` is what distinguishes a transition from a no-op, and the tool description SHALL say so.
+
+`sessionId` SHALL have no fallback resolution on `memory.session_resume`. Unlike the other three tools it SHALL NOT consult the `SessionRouter` entry, and SHALL NOT consult the sole-active-session lookup. Both fallbacks are structurally unavailable — `memory.session_end` cleared the router binding on its way out, and the active-session lookup filters `status = 'active'`, which the resume target by definition is not — so any fallback would have to select a terminal row by recency, precisely the heuristic the `sessions` capability's "`findActiveForTransport` MUST NOT guess under concurrent ambiguity" refuses. A call omitting `sessionId` SHALL be rejected at the zod boundary with `invalid_input`, never resolved to a guess.
+
+`memory.session_end` clears the `SessionRouter` transport binding for `(tokenId, mcpSessionId)` ONLY when the row it resolved is not `abandoned`. Before terminal writes were admitted, `end()` threw on an `abandoned` row and the clear was unreachable, so the binding survived; clearing it now would drop every later `memory.save` on that transport to `session_id = NULL`. That prior behaviour SHALL be preserved: ending an `abandoned` row SHALL leave the binding intact, ending an `active` or `ended` row SHALL clear it.
+
+`memory.session_resume` SHALL set that binding, and this is load-bearing rather than incidental. On success it SHALL call the same `SessionRouter.setActiveSession(tokenId, mcpSessionId, sessionId)` that `memory.session_start` calls, so the resuming transport resolves its session by an explicit pin rather than by the ambiguous-resolution fallback. Without the pin a resumed row is only reachable through the sole-active-session lookup, which returns nothing whenever a second session is concurrently live under the same `(token, project)`. It SHALL set the binding on the already-`active` no-op path too, since re-pinning is the useful half of a defensive call. It SHALL NOT set `setActiveProject`: resume names a session, not a project, and the project is whatever the connection already resolved.
+
+Session resolution is unchanged for the other three tools and SHALL remain status-aware where it already is: `memory.session_summary` resolves its target from an explicit `sessionId`, else the transport's `SessionRouter` entry, else the unambiguous `active` session for the caller's `(token_id, project_id)`. The third source SHALL continue to consider only `active` rows, so an agent that supplies neither an explicit id nor a router-mapped session SHALL receive `session_not_found` rather than having its write attached to a closed session picked by recency.
+
+#### Scenario: `memory.session_start` opens a new session
+
+- **WHEN** an MCP client calls `memory.session_start` with `{ agent?: string, description?: string }`
+- **THEN** the server SHALL insert a `sessions` row with `status = 'active'`, `started_at = now`, the provided `agent` (or `'unknown'`), `token_id` from the request context, `project_id` from the request scope, and a placeholder `title` of the form `basename(cwd) · HH:MM UTC` with `title_final = false`; **AND** the response SHALL be `{ sessionId, scope, projectId, startedAt, title, reused }`
+
+#### Scenario: `memory.session_end` ends a session without summary
+
+- **WHEN** an MCP client calls `memory.session_end` with `{ sessionId: string }` for an active session
+- **THEN** the server SHALL set `status = 'ended'` and `ended_at = now` on that row, leave `summary` and `title` unchanged, and SHALL return `{ ok: true, sessionId, endedAt, applied: true }`
+
+#### Scenario: `memory.session_end` is idempotent on already-ended sessions
+
+- **WHEN** an MCP client calls `memory.session_end` on a row whose `status` is already `'ended'`
+- **THEN** the server SHALL return `{ ok: true, sessionId, endedAt, applied: false }` with the existing `ended_at` and SHALL NOT mutate the row
+
+#### Scenario: `memory.session_end` is idempotent on abandoned sessions
+
+- **WHEN** an MCP client calls `memory.session_end` on a row whose `status` is `'abandoned'` with `ended_at = E`
+- **THEN** the server SHALL return `{ ok: true, sessionId, endedAt: E, applied: false }`, SHALL leave `status = 'abandoned'` and `ended_at = E` untouched, and SHALL NOT return `session_already_ended`
+- **AND** the `SessionRouter` binding for the calling transport SHALL remain pointing at that session, so a subsequent `memory.save` on the same transport still auto-attaches its `session_id`
+
+#### Scenario: `memory.session_end` on an active session clears the transport binding
+
+- **WHEN** an MCP client calls `memory.session_end` on an `active` row and the call transitions it to `ended`
+- **THEN** the `SessionRouter` entry for `(tokenId, mcpSessionId)` SHALL be cleared, as before this requirement's revision
+
+#### Scenario: `memory.session_summary` writes summary and title without ending the session
+
+- **WHEN** an MCP client calls `memory.session_summary` with `{ sessionId?: string, summary: string, title?: string }` and `summary.length <= SUMMARY_MAX_CHARS`
+- **THEN** the server SHALL resolve `sessionId` from the active MCP transport mapping when omitted, write `summary` with `summary_final = true`, write `title` (when provided, after validating length ≤100) with `title_final = true`, leave `status`/`ended_at` unchanged, and return `{ ok: true, sessionId, summary, title, summaryFinal: true, titleFinal: <true|false>, applied: true }`
+
+#### Scenario: `memory.session_summary` succeeds on a session the sweep already abandoned
+
+- **GIVEN** the agent's session was flipped to `status = 'abandoned'` with `ended_at = E` and `last_activity_at = L` by stale-active retirement while the conversation was still open, and the agent knows its `sessionId` (the plugin's nudge injects it)
+- **WHEN** the agent calls `memory.session_summary({ sessionId, summary, title })`
+- **THEN** the call SHALL succeed and return `{ ok: true, sessionId, summary, title, summaryFinal: true, applied: true }`
+- **AND** the row SHALL retain `status = 'abandoned'`, `ended_at = E` and `last_activity_at = L`
+- **AND** the call SHALL NOT return `session_already_ended`
+
+#### Scenario: `memory.session_summary` succeeds on an ended session
+
+- **GIVEN** a row whose `status = 'ended'` with `ended_at = E` and `summary_final = false` (no curated summary written yet)
+- **WHEN** the agent calls `memory.session_summary({ sessionId, summary })`
+- **THEN** the call SHALL succeed with `summaryFinal: true` and `applied: true`, and `status`/`ended_at` SHALL be unchanged
+
+#### Scenario: `memory.session_summary` with no resolvable session still reports `session_not_found`
+
+- **GIVEN** the agent passes no explicit `sessionId`, the transport has no `SessionRouter` entry, and the only candidate row for its `(token_id, project_id)` is `abandoned`
+- **WHEN** the agent calls `memory.session_summary({ summary })`
+- **THEN** the call SHALL be rejected with code `session_not_found` (NOT `session_already_ended`, and NOT silently attached to the abandoned row)
+
+#### Scenario: `memory.session_summary` may be called multiple times; the latest call wins
+
+- **GIVEN** an `active` session whose `summary_final = true` from a prior `memory.session_summary({summary: "A"})` call
+- **WHEN** the agent calls `memory.session_summary({summary: "B"})` again
+- **THEN** `summary` SHALL be replaced with "B" (last-final-wins among final writes on active rows) and `applied` SHALL be `true`
+
+#### Scenario: `memory.session_summary` discards a second curated write on a terminal row
+
+- **GIVEN** a terminal session (`status = 'ended'` or `'abandoned'`) whose `summary_final = true` from a prior curated write with summary "A"
+- **WHEN** the agent calls `memory.session_summary({ sessionId, summary: "B" })`
+- **THEN** the response SHALL carry `ok: true`, `summary: "A"` (the stored value, unchanged), `summaryFinal: true`, `applied: false`, and `discardReason: 'terminal_final'`
+- **AND** the session row SHALL be unchanged in every column
+
+#### Scenario: `memory.session_summary` discards a second curated title on a terminal row
+
+- **GIVEN** a terminal session whose `title_final = true` from a prior curated write with title "First"
+- **WHEN** the agent calls `memory.session_summary({ sessionId, summary: "new summary", title: "Second" })`
+- **THEN** the response SHALL carry `title: "First"` (the stored value, unchanged), `titleFinal: true`, `applied: false`, and `discardReason: 'terminal_final'`
+- **AND** the session row SHALL be unchanged in every column
+
+#### Scenario: `memory.session_summary` discards summary but applies title on a terminal row
+
+- **GIVEN** a terminal session whose `summary_final = true` and `title_final = false`
+- **WHEN** the agent calls `memory.session_summary({ sessionId, summary: "B", title: "New Title" })`
+- **THEN** the response SHALL carry `summary: "A"` (unchanged), `summaryFinal: true`, `title: "New Title"` (applied), `titleFinal: true`, `applied: false`, and `discardReason: 'terminal_final'`
+- **AND** the summary column SHALL be unchanged but the title column SHALL reflect the new value
+
+#### Scenario: `memory.session_summary` rejects empty summary
+
+- **WHEN** the agent submits `summary: ""` or whitespace-only
+- **THEN** the call SHALL be rejected with code `invalid_input`
+
+#### Scenario: `memory.session_summary` rejects title over 100 chars
+
+- **WHEN** the agent submits `title: "A".repeat(101)`
+- **THEN** the call SHALL be rejected with code `invalid_input`
+
+#### Scenario: `memory.session_summary` rejects summary over `SUMMARY_MAX_CHARS`
+
+- **WHEN** the agent submits `summary: "A".repeat(SUMMARY_MAX_CHARS + 1)` (one char over the cap)
+- **THEN** the call SHALL be rejected at the zod boundary with code `invalid_input`
+- **AND** the error message SHALL contain the decimal string of `SUMMARY_MAX_CHARS` so the agent can deduce the cap and retry with a tighter body on the first attempt
+- **AND** the session row SHALL NOT be mutated (no partial write, `summary_final` unchanged)
+
+#### Scenario: `memory.session_summary` accepts summary of exactly `SUMMARY_MAX_CHARS`
+
+- **WHEN** the agent submits `summary: "A".repeat(SUMMARY_MAX_CHARS)`
+- **THEN** the call SHALL succeed and the row SHALL have `summary` of length `SUMMARY_MAX_CHARS` with `summary_final = true` and `applied: true`
+
+#### Scenario: A session-lifecycle tool targets a session owned by a different token
+
+- **WHEN** any of the four tools is called with a `sessionId` whose `token_id` does not match the caller's token
+- **THEN** the call SHALL be rejected with code `session_not_found` (never `forbidden`, to avoid information disclosure)
+
+#### Scenario: A second `memory.session_start` adopts the first session and says so
+
+- **GIVEN** a connection with no active session for its `(tokenId, projectId)`
+- **WHEN** an MCP client calls `memory.session_start` twice in a row on that connection
+- **THEN** the first response SHALL carry `reused: false` and the second SHALL carry `reused: true`
+- **AND** both responses SHALL carry the SAME `sessionId` — the second call SHALL NOT insert a second `sessions` row
+- **AND** the `sessions` row count for that `(tokenId, projectId)` SHALL be 1 after both calls, which is the control that `reused: true` describes adoption rather than a coincidence of ids
+
+#### Scenario: `memory.session_start`'s description names every required output field
+
+- **WHEN** an MCP client retrieves the tool description for `memory.session_start` via `tools/list`
+- **THEN** the description's `Returns:` enumeration SHALL name every field its `outputSchema` marks required, including `title` and `reused`
+- **AND** the description SHALL state that `reused: true` means the call adopted the host's already-active session rather than starting one
+- **AND** a CI test SHALL compare the description against the `outputSchema`'s required list, so a field added to the schema without a description update fails the build
+
+#### Scenario: `memory.session_resume` returns an ended session to active
+
+- **GIVEN** session `<S>` owned by the calling token, `status='ended'` with `ended_at = E`, in the connection's project
+- **WHEN** an MCP client calls `memory.session_resume` with `{ sessionId: <S> }`
+- **THEN** the response SHALL be `{ ok: true, sessionId: <S>, status: 'active', startedAt, resumedAt, previousStatus: 'ended', previousEndedAt: E, title }`
+- **AND** the row SHALL have `status='active'` and `ended_at IS NULL`
+
+#### Scenario: `memory.session_resume` returns an abandoned session to active identically
+
+- **GIVEN** session `<S>` owned by the calling token, `status='abandoned'` with `ended_at = E`
+- **WHEN** an MCP client calls `memory.session_resume` with `{ sessionId: <S> }`
+- **THEN** the response SHALL carry `previousStatus: 'abandoned'`, `previousEndedAt: E` and `status: 'active'`
+- **AND** the row SHALL be indistinguishable in every column from the same row resumed out of `ended`
+
+#### Scenario: `memory.session_resume` pins the transport binding
+
+- **GIVEN** an MCP transport whose `SessionRouter` entry carries no session (the state `memory.session_end` leaves behind)
+- **WHEN** the client calls `memory.session_resume` with `{ sessionId: <S> }` and it succeeds
+- **THEN** the `SessionRouter` entry for `(tokenId, mcpSessionId)` SHALL point at `<S>`
+- **AND** a subsequent `memory.save` on that transport, with no explicit `sessionId`, SHALL persist `session_id = <S>`
+- **AND** that SHALL hold even when a second `active` session exists for the same `(token_id, project_id)`, which is the case the sole-active-session fallback refuses to resolve
+
+#### Scenario: `memory.session_resume` refuses a call with no `sessionId`
+
+- **WHEN** an MCP client calls `memory.session_resume` with `{}`
+- **THEN** the call SHALL be rejected at the zod boundary with code `invalid_input`
+- **AND** no session SHALL be resolved from the `SessionRouter` entry or by recency, and no row SHALL be mutated
+
+#### Scenario: `memory.session_resume` refuses an unknown property
+
+- **WHEN** an MCP client calls `memory.session_resume` with `{ sessionId: <S>, epoch: 3 }`
+- **THEN** the call SHALL be rejected with `invalid_input` rather than having the unknown property silently stripped, because every tool's input schema is registered strict
+
+#### Scenario: `memory.session_resume` targets a session in another project
+
+- **GIVEN** session `<S>` owned by the calling token but belonging to a project other than the one this connection resolved
+- **WHEN** the client calls `memory.session_resume` with `{ sessionId: <S> }`
+- **THEN** the call SHALL be rejected with `session_not_found` and the row SHALL NOT be mutated
+
+#### Scenario: `memory.session_resume` on an already-active session succeeds and re-pins
+
+- **GIVEN** session `<S>` with `status='active'` and `last_activity_at = L`
+- **WHEN** the client calls `memory.session_resume` with `{ sessionId: <S> }`
+- **THEN** the call SHALL succeed with `previousStatus: 'active'` and `previousEndedAt: null`
+- **AND** the row SHALL NOT be mutated, so `last_activity_at` SHALL still be `L`
+- **AND** the `SessionRouter` entry SHALL nonetheless point at `<S>`
+
+#### Scenario: `memory.session_start` adopts a resumed session rather than minting a second row
+
+- **GIVEN** session `<S>` was resumed and is the only `active` row for the caller's `(token_id, project_id)`
+- **WHEN** the agent calls `memory.session_start`
+- **THEN** the response SHALL carry `sessionId = <S>` and `reused: true`
+- **AND** the `sessions` row count for that `(token_id, project_id)` SHALL be unchanged, which is the control that adoption happened rather than a coincidence of ids
+
+#### Scenario: `memory.session_resume`'s description names every required output field
+
+- **WHEN** an MCP client retrieves the tool description for `memory.session_resume` via `tools/list`
+- **THEN** the description's `Returns:` enumeration SHALL name every field its `outputSchema` marks required, including `previousStatus` and `previousEndedAt`
+- **AND** the description SHALL state that `previousEndedAt` is not retained on the row after the call
+- **AND** the CI test that compares each description against its `outputSchema`'s required list SHALL cover this tool

--- a/openspec/changes/expose-session-write-verdict/tasks.md
+++ b/openspec/changes/expose-session-write-verdict/tasks.md
@@ -1,0 +1,62 @@
+## 1. Read the contract and record the baseline
+
+- [x] 1.1 Read `specs/mcp-api/spec.md` in this change folder before touching code — it is a MODIFIED block that replaces the whole "The MCP server MUST expose four session-lifecycle tools" requirement, and the code must satisfy it rather than the other way round. The key additions: the `applied` paragraph for `memory.session_summary`, the `applied` paragraph for `memory.session_end`, and the new scenarios covering terminal-final-discard.
+- [x] 1.2 Read `design.md` D1–D7. D4 (service layer signals no-op, handler does not infer) and D5 (the spec scenario is scoped to active rows) are the two that a plausible-looking implementation gets wrong.
+- [x] 1.3 Record the baseline, so every later number has something to be compared against: `cd apps/server && pnpm vitest run src/mcp/session-tools.test.ts` and `pnpm vitest run src/test/mcp-integration.test.ts` both green, with their test counts written down. Baseline: `session-tools.test.ts` 20 tests passing; `mcp-integration.test.ts` 119 tests passing.
+
+## 2. Service layer
+
+- [x] 2.1 Change the return type of `writeTerminalFields` (`apps/server/src/services/agent-sessions.ts:322`) from `AgentSession` to `{ row: AgentSession; applied: boolean }`. When `Object.keys(set).length === 0`, return `{ row: existing, applied: false }`. When a real write occurs, return `{ row: updated, applied: true }`. The calling methods `writeSummary` and `end` must propagate this shape.
+- [x] 2.2 Update `writeSummary` (`:375`) to handle the new return type from `writeTerminalFields`: when the terminal path returns `{ row, applied }`, return `{ row, applied }` to the caller. The active path (`updateActiveOrThrow`) always applies, so it returns `{ row: result, applied: true }`.
+- [x] 2.3 Update `end` (`:390`) identically: propagate the `{ row, applied }` shape from `writeTerminalFields` on the terminal path, and return `{ row: result, applied: true }` from the active path.
+- [x] 2.4 Confirm no other callers of `writeSummary` or `end` exist that would break on the shape change. Check `apps/server/src/server/api-router.ts` (the HTTP endpoint calls `agentSessions.end` directly or through a wrapper — verify the shape change is handled there too, or that the HTTP path delegates through a method that absorbs it). The HTTP `POST /sessions/<id>/summary` and `POST /sessions/<id>/end` paths are out of scope for the verdict surface, but they must not break on the return-type change.
+- [x] 2.5 No comment on any edit. The "why" is in the spec and design doc, per house policy.
+
+## 3. Handler and output schema
+
+- [x] 3.1 Add `applied: z.boolean()` and `discardReason: z.string().optional()` to `sessionSummaryOutput` in `apps/server/src/mcp/session-tools.ts:83-89`. Both are declared in the `outputSchema` so clients can discover them; `applied` is required, `discardReason` is optional.
+- [x] 3.2 Add `applied: z.boolean()` to `sessionEndOutput` in `apps/server/src/mcp/session-tools.ts:77-81`. Required.
+- [x] 3.3 Update `handleSessionSummary` (`:266`) to destructure the `{ row, applied }` return from `writeSummary` and populate `applied` and `discardReason` (set to `'terminal_final'` when `applied === false`) in the `ok({ … })` payload.
+- [x] 3.4 Update `handleSessionEnd` (`:253`) to destructure `{ row, applied }` from `end()` and populate `applied` in the `ok({ … })` payload.
+- [x] 3.5 Confirm the HTTP API path in `apps/server/src/server/api-router.ts` does not break. `POST /api/<slug>/sessions/<id>/summary` calls `agentSessions.writeSummary` directly; if the router destructures the old `AgentSession` return, it must be updated to destructure `{ row, applied }` and use `row`. The verdict fields (`applied`, `discardReason`) SHALL NOT be added to the HTTP response — they are MCP-only, same as the precedent in `expose-session-start-agent` D5.
+
+## 4. Tool description
+
+- [x] 4.1 Update the `memory.session_summary` description at `apps/server/src/mcp/server.ts:323`: add `applied` to the `Returns:` list (when present in the description — if the current description does not have a `Returns:` list, add one or add a clause explaining `applied`). Add a clause stating that a terminal row keeps its first curated summary (`applied: false`, `discardReason: 'terminal_final'`) and that `memory.session_resume` is the way to resume the session for further writes.
+- [x] 4.2 Update the `memory.session_end` description at `apps/server/src/mcp/server.ts:315`: add `applied` to the description, explaining that `applied: false` means the session was already terminal and the call was a no-op.
+- [x] 4.3 Measure the new description lengths from a REAL `tools/list` response (not from the source constant) — the `descriptions` map in `apps/server/src/test/mcp-integration.test.ts` is the instrument. Confirm both remain below `DESCRIPTION_MAX_LENGTH`. Record the measured length and headroom for each. If either exceeds the cap, name the clause reclaimed rather than silently trimming.
+- [x] 4.4 No operator advice ("use memory.session_resume") in the description beyond the one sentence stating the path — it is the model's remedy, not the operator's, and the operator-facing guidance is in `docs/`.
+
+## 5. Tests — unit, integration, and probe cleanup
+
+- [x] 5.1 In `apps/server/src/mcp/session-tools.test.ts`, add the **distinguishing test** in the `memory.session_summary on a session the sweep already abandoned` block: create a terminal row with `summaryFinal: true`, call `sessionSummary`, and assert `applied: false` and `discardReason: 'terminal_final'`. The two candidate implementations (always-true flag vs. service-signal) disagree only here.
+- [x] 5.2 Add the **control**: create a terminal row with `summaryFinal: false` (no prior curated summary), call `sessionSummary`, and assert `applied: true`. Without this, a green 5.1 cannot be told from a test that never exercises the terminal-without-summary path.
+- [x] 5.3 Add the **active-row control**: call `sessionSummary` on an `active` session and assert `applied: true` and `discardReason` is `undefined` (not present in the response). This guards against `discardReason` leaking onto active-row writes.
+- [x] 5.4 Add a test for `memory.session_end` on an active row: assert `applied: true`. Add a test for `session_end` on a terminal row: assert `applied: false`. Both in the `memory.session_summary on a session the sweep already abandoned` block or a new adjacent block.
+- [x] 5.5 Fold the assertions from the temporary reproduction probe (`apps/server/src/mcp/session-371-probe.test.ts`) into proper regression tests in `apps/server/src/mcp/session-tools.test.ts` (or the appropriate co-located test file). The probe's three tests (REPRO, CONTROL, secondary terminal-without-summary) map to 5.1, 5.2, and the existing test at `:198` ("still writes when the terminal session belongs to the scoped project").
+- [x] 5.6 Delete `apps/server/src/mcp/session-371-probe.test.ts`.
+- [x] 5.7 Update the integration test's required-field pins if `sessionSummaryOutput` or `sessionEndOutput` required-field lists changed (the CI test at `apps/server/src/test/mcp-integration.test.ts` that compares `outputSchema` required fields against the `Returns:` list in the description).
+- [x] 5.8 Mutation gate — the `applied` field is not covered until this reddens: `node scripts/mutate.mjs --file apps/server/src/mcp/session-tools.ts --spec src/mcp/session-tools.test.ts --mutation 'applied: row.applied,' --with "applied: true,"`. It MUST report red. A green run means the tests prove nothing and the tests are what gets fixed.
+- [x] 5.9 Second mutation, against the integration boundary: same find/replace with `--spec src/test/mcp-integration.test.ts`. It MUST redden the terminal-discard scenario. Record which named tests each mutation caught, and confirm `scripts/mutate.mjs` restored both files byte-identically.
+
+## 6. Verification
+
+- [x] 6.1 `pnpm run typecheck` and `pnpm run lint` clean.
+- [x] 6.2 `pnpm test` green from the repo root, with the new counts recorded. `apps/server/src/test/invariants.test.ts` must stay green — nothing here emits SQL outside `db/` and nothing mutates an immutable session column.
+- [ ] 6.3 `pnpm run eval` is NOT required and SHALL NOT be run as evidence for this change: no retrieval, ranking, embedding or search path is touched.
+- [x] 6.4 `pnpm run check:spec-provenance` locally (it inspects only `origin/main...HEAD`; CI is the actual gate) and `node scripts/check-delta-freshness.mjs` clean.
+
+## 7. Real Docker smoke against pre-existing seeded data (operator-assisted — `/opsx:apply` must pause here)
+
+- [x] 7.1 Bring up the dev stack: `pnpm run dev:docker:up` (if it dies with `SQLITE_CANTOPEN`, `chown -R 10001:10001 data-dev` first). Note that the boot seeds and reseeds, so "pre-existing data" here means the seeded corpus present before the probe, not an empty database — capture the session row count before probing so the after-count is comparable.
+- [x] 7.2 Over the REAL `/mcp/<slug>` transport with a real token from the boot banner (never the handler directly — that path bypasses the registered schema), call `memory.session_summary` on a terminal row with a prior curated summary. Confirm `applied: false` and `discardReason: 'terminal_final'` in the response.
+- [x] 7.3 The control: call `memory.session_summary` on a terminal row WITHOUT a prior curated summary. Confirm `applied: true`.
+- [x] 7.4 Call `memory.session_end` on an already-terminal row. Confirm `applied: false`.
+- [x] 7.5 Tear the stack down and record in the PR which client and transport the probe used, alongside the response payloads.
+
+## 8. Deferred and explicitly rejected — do not silently drop
+
+- [ ] 8.1 The first-curated-stands precedence rule is deliberately NOT changed (design D1, D5). Do not change it inside this change; the `plugin-session-protocol` capability requires it, and there is no `replaces` chain for sessions.
+- [ ] 8.2 The HTTP `POST /api/<slug>/sessions/<id>/summary` path is deliberately NOT given the verdict surface (design D5 analogy, same as `expose-session-start-agent`). Its adopt path keys on the host session id, not on `(token, project)`, and each client already handles its own retry. Tracked as a follow-up if the MCP surface proves insufficient.
+- [ ] 8.3 `session_already_ended` SHALL NOT become an error code (the spec says so and the plugin nudge path depends on it). Confirmed: not added.
+- [ ] 8.4 PR title and description in English, Conventional Commits (`fix(mcp): …`), hooks never bypassed. Reference issue #371, and state plainly that this change makes the discard observable and does NOT change the precedence rule.


### PR DESCRIPTION
## Summary

`memory.session_summary` on a terminal (`ended`/`abandoned`) row that already carries a curated summary silently discarded the write while returning `ok:true` (#371). The service now signals whether the write landed, the MCP outputs carry the verdict (`applied`, plus `discardReason: 'terminal_final'`), and the tool descriptions state the terminal rule and point at `memory.session_resume`. The first-curated-stands precedence rule is unchanged.

## OpenSpec change

- Change name: `expose-session-write-verdict`

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm run typecheck` clean
- [x] `pnpm test` green (full suite, no `-t` narrowing) — 2935 passed (apps/server, 150 files) + 96 installer
- [x] `pnpm run build` clean
- [x] `openspec validate expose-session-write-verdict --strict` clean
- [x] Manual smoke against `pnpm run dev:docker:up`: real `/mcp/<slug>` transport (SSE JSON-RPC), 5 arms each paired with a control in the same run — terminal+final write → `applied:false, discardReason:'terminal_final'` echoing the stored summary; terminal row without prior summary → `applied:true`; double `session_end` → `applied:false`; active-row controls → `applied:true`. `scripts/mutate.mjs` gates against both the unit and integration specs redden the named verdict tests and restore files byte-identically.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:` / `fix:` / `docs:` / ...).
- [x] Changes are scoped: one conceptual change per PR.
- [x] New tests cover new behaviour; coverage gates still pass (≥90% stmts / ≥85% rest).
- [x] No new dependency added without consulting [`.agents/skills/npm-security-best-practices/SKILL.md`](../.agents/skills/npm-security-best-practices/SKILL.md).
- [x] Changes touching `apps/plugin/` carry **no** hand-edited version bump: release-please owns every version carrier and moves them in lock-step from the conventional-commit type.
- [x] No tokens, API keys, private hostnames, LAN IPs, or maintainer home-directory paths committed (see `openspec/config.yaml::rules.tasks`).
- [x] If this PR closes an issue, the body includes `Closes #<n>`.

Closes #371
